### PR TITLE
feat: on-the-fly HTML rendering in published worker with mobile UI fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -82,6 +82,8 @@
       "name": "@veecontext/worker",
       "version": "0.1.0",
       "dependencies": {
+        "@veecontext/core": "workspace:*",
+        "@veecontext/crawlers": "workspace:*",
         "hono": "^4.0.0",
       },
       "devDependencies": {

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -202,7 +202,7 @@ export const publishCommand = new Command("publish")
     schemaSql.push("DROP TABLE IF EXISTS entities;");
     schemaSql.push("DROP TABLE IF EXISTS collections_meta;");
     schemaSql.push("");
-    schemaSql.push("CREATE TABLE collections_meta (name TEXT PRIMARY KEY, title TEXT);");
+    schemaSql.push("CREATE TABLE collections_meta (name TEXT PRIMARY KEY, title TEXT, crawler_type TEXT);");
     schemaSql.push(`CREATE TABLE entities (
   id INTEGER PRIMARY KEY, collection_name TEXT NOT NULL,
   external_id TEXT NOT NULL, entity_type TEXT NOT NULL,
@@ -241,7 +241,7 @@ export const publishCommand = new Command("publish")
       const colDb = getCollectionDb(dbPath);
       const title = col.title || colName;
 
-      schemaSql.push(`INSERT INTO collections_meta (name, title) VALUES ('${escapeSQL(colName)}', '${escapeSQL(title)}');`);
+      schemaSql.push(`INSERT INTO collections_meta (name, title, crawler_type) VALUES ('${escapeSQL(colName)}', '${escapeSQL(title)}', '${escapeSQL(col.crawler)}');`);
 
       const allEntities = colDb.select().from(entities).all();
       const entityIdMap = new Map<number, number>();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./theme": "./src/theme/index.ts"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit"
   },

--- a/packages/crawlers/package.json
+++ b/packages/crawlers/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./themes": "./src/themes.ts"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit"
   },

--- a/packages/crawlers/src/git/theme.ts
+++ b/packages/crawlers/src/git/theme.ts
@@ -1,5 +1,5 @@
-import type { Theme, ThemeRenderContext } from "@veecontext/core";
-import { frontmatter, wikilink, callout } from "@veecontext/core";
+import type { Theme, ThemeRenderContext } from "@veecontext/core/theme";
+import { frontmatter, wikilink, callout } from "@veecontext/core/theme";
 
 function slugify(text: string): string {
   return text

--- a/packages/crawlers/src/github/theme.ts
+++ b/packages/crawlers/src/github/theme.ts
@@ -1,5 +1,5 @@
-import type { Theme, ThemeRenderContext } from "@veecontext/core";
-import { frontmatter, wikilink, callout } from "@veecontext/core";
+import type { Theme, ThemeRenderContext } from "@veecontext/core/theme";
+import { frontmatter, wikilink, callout } from "@veecontext/core/theme";
 import { gemoji } from "gemoji";
 
 // Build emoji shortcode lookup map once

--- a/packages/crawlers/src/mantisbt/theme.ts
+++ b/packages/crawlers/src/mantisbt/theme.ts
@@ -1,5 +1,5 @@
-import type { Theme, ThemeRenderContext } from "@veecontext/core";
-import { frontmatter, wikilink } from "@veecontext/core";
+import type { Theme, ThemeRenderContext } from "@veecontext/core/theme";
+import { frontmatter, wikilink } from "@veecontext/core/theme";
 
 function slugify(text: string): string {
   return text

--- a/packages/crawlers/src/obsidian/theme.ts
+++ b/packages/crawlers/src/obsidian/theme.ts
@@ -1,4 +1,4 @@
-import type { Theme, ThemeRenderContext } from "@veecontext/core";
+import type { Theme, ThemeRenderContext } from "@veecontext/core/theme";
 
 export class ObsidianTheme implements Theme {
   crawlerType = "obsidian";

--- a/packages/crawlers/src/themes.ts
+++ b/packages/crawlers/src/themes.ts
@@ -1,0 +1,5 @@
+// Theme-only exports — no crawler code, safe to import in Cloudflare Workers
+export { GitHubTheme } from "./github/theme";
+export { ObsidianTheme } from "./obsidian/theme";
+export { GitTheme } from "./git/theme";
+export { MantisBTTheme } from "./mantisbt/theme";

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -1891,17 +1891,18 @@ body {
 }
 
 /* ===== Mobile bottom action bar ===== */
-.mobile-bottom-bar {
+.mobile-top-bar {
   display: flex;
   align-items: center;
   justify-content: space-around;
   height: 48px;
   min-height: 48px;
   background: var(--bg-secondary);
-  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
   padding: 0 4px;
-  padding-bottom: env(safe-area-inset-bottom, 0px);
+  padding-top: env(safe-area-inset-top, 0px);
   flex-shrink: 0;
+  order: -1;
 }
 
 .mobile-bar-btn {
@@ -2019,6 +2020,42 @@ body {
     max-width: 140px;
     padding: 0 8px 0 10px;
     font-size: 11px;
+  }
+
+  /* HTML view: compact padding and font sizes on mobile */
+  .gh-issue-view {
+    padding: 12px 14px 24px;
+  }
+
+  .gh-title {
+    font-size: 20px;
+  }
+
+  .gh-header-meta {
+    font-size: 13px;
+    gap: 6px;
+  }
+
+  .gh-comment-body {
+    font-size: 14px;
+  }
+
+  /* Code blocks scroll horizontally instead of overflowing */
+  .gh-code-block,
+  .gh-diff-hunk {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .gh-code-block pre,
+  .gh-diff-hunk {
+    white-space: pre;
+    word-break: normal;
+  }
+
+  /* Diff comments: remove extra indentation */
+  .gh-diff-comment {
+    margin-left: 0;
   }
 
   /* Toolbar adjustments */

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -127,6 +127,7 @@ export default function App() {
   const [backlinksOpen, setBacklinksOpen] = useState(!isMobile);
   const [viewMode, setViewMode] = useState<ViewMode>("markdown");
   const [htmlContent, setHtmlContent] = useState<string | null>(null);
+  const [htmlLoading, setHtmlLoading] = useState(false);
   const [htmlAvailable, setHtmlAvailable] = useState(false);
 
   // Tabs
@@ -366,9 +367,11 @@ export default function App() {
   useEffect(() => {
     if (!htmlAvailable || !selectedCollection || !selectedFile) {
       setHtmlContent(null);
+      setHtmlLoading(false);
       return;
     }
-    setHtmlContent(null); // clear while loading
+    setHtmlContent(null);
+    setHtmlLoading(true);
     fetch(
       `/api/collections/${encodeURIComponent(selectedCollection)}/html/${selectedFile}`,
     )
@@ -376,9 +379,13 @@ export default function App() {
         if (!r.ok) throw new Error("HTML not available");
         return r.text();
       })
-      .then(setHtmlContent)
+      .then((html) => {
+        setHtmlContent(html);
+        setHtmlLoading(false);
+      })
       .catch(() => {
         setHtmlContent(null);
+        setHtmlLoading(false);
       });
   }, [htmlAvailable, selectedCollection, selectedFile]);
 
@@ -705,11 +712,11 @@ export default function App() {
       </div>
       <div className="main-body">
         <div className="main-inner">
-          {loading && <div className="loading">Loading...</div>}
+          {(loading || (viewMode === "html" && htmlLoading)) && <div className="loading">Loading...</div>}
           {!loading && selectedFile && viewMode === "html" && htmlContent !== null && (
             <HtmlView html={htmlContent} onWikilinkClick={handleWikilinkNavigate} />
           )}
-          {!loading && selectedFile && fileContent !== null && !(viewMode === "html" && htmlContent !== null) && (
+          {!loading && selectedFile && viewMode === "markdown" && fileContent !== null && (
             <MarkdownView
               content={fileContent}
               collection={selectedCollection || ""}
@@ -750,9 +757,9 @@ export default function App() {
           </div>
         </div>
       )}
-      {/* Mobile bottom action bar */}
+      {/* Mobile top action bar */}
       {isMobile && (
-        <div className="mobile-bottom-bar">
+        <div className="mobile-top-bar">
           <button
             className={`mobile-bar-btn${sidebarOpen ? " active" : ""}`}
             onClick={() => setSidebarOpen((o) => !o)}

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -10,7 +10,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "hono": "^4.0.0"
+    "hono": "^4.0.0",
+    "@veecontext/core": "workspace:*",
+    "@veecontext/crawlers": "workspace:*"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.0.0",

--- a/packages/worker/src/db/client.ts
+++ b/packages/worker/src/db/client.ts
@@ -3,6 +3,7 @@ import type { Env } from "../types";
 export interface CollectionMeta {
   name: string;
   title: string;
+  crawler_type: string | null;
 }
 
 export interface Entity {
@@ -43,8 +44,50 @@ export interface Attachment {
 }
 
 export async function getCollections(db: D1Database): Promise<CollectionMeta[]> {
-  const { results } = await db.prepare("SELECT name, title FROM collections_meta").all<CollectionMeta>();
+  const { results } = await db.prepare("SELECT name, title, crawler_type FROM collections_meta").all<CollectionMeta>();
   return results ?? [];
+}
+
+export async function getCollection(db: D1Database, name: string): Promise<CollectionMeta | null> {
+  const result = await db
+    .prepare("SELECT name, title, crawler_type FROM collections_meta WHERE name = ?")
+    .bind(name)
+    .first<CollectionMeta>();
+  return result ?? null;
+}
+
+export async function getEntityByMarkdownPath(
+  db: D1Database,
+  collectionName: string,
+  markdownPath: string,
+): Promise<Entity | null> {
+  // Try with and without "markdown/" prefix
+  const variants = [`markdown/${markdownPath}`, markdownPath];
+  for (const variant of variants) {
+    const result = await db
+      .prepare("SELECT * FROM entities WHERE collection_name = ? AND markdown_path = ?")
+      .bind(collectionName, variant)
+      .first<Entity>();
+    if (result) return result;
+  }
+  return null;
+}
+
+export async function getEntityMarkdownPathByExternalId(
+  db: D1Database,
+  collectionName: string,
+  externalId: string,
+): Promise<string | null> {
+  const result = await db
+    .prepare("SELECT markdown_path FROM entities WHERE collection_name = ? AND external_id = ?")
+    .bind(collectionName, externalId)
+    .first<{ markdown_path: string | null }>();
+  if (!result?.markdown_path) return null;
+  const prefix = "markdown/";
+  const rel = result.markdown_path.startsWith(prefix)
+    ? result.markdown_path.slice(prefix.length)
+    : result.markdown_path;
+  return rel.endsWith(".md") ? rel.slice(0, -3) : rel;
 }
 
 export async function getEntities(

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -2,8 +2,11 @@ import { Hono } from "hono";
 import type { Env } from "../types";
 import {
   getCollections,
+  getCollection,
   getEntities,
   getEntityByExternalId,
+  getEntityByMarkdownPath,
+  getEntityMarkdownPathByExternalId,
   getEntityTags,
   getEntityCount,
   getBacklinks,
@@ -11,6 +14,14 @@ import {
 } from "../db/client";
 import { searchEntities } from "../db/search";
 import { getR2Object, getMimeType } from "../storage/r2";
+import { ThemeEngine } from "@veecontext/core/theme";
+import { GitHubTheme, ObsidianTheme, GitTheme, MantisBTTheme } from "@veecontext/crawlers/themes";
+
+const themeEngine = new ThemeEngine();
+themeEngine.register(new GitHubTheme());
+themeEngine.register(new ObsidianTheme());
+themeEngine.register(new GitTheme());
+themeEngine.register(new MantisBTTheme());
 
 const api = new Hono<{ Bindings: Env }>();
 
@@ -25,6 +36,65 @@ api.get("/api/collections", async (c) => {
     })),
   );
   return c.json(result);
+});
+
+// GET /api/collections/:name/html-support
+api.get("/api/collections/:name/html-support", async (c) => {
+  const name = c.req.param("name");
+  const col = await getCollection(c.env.DB, name);
+  if (!col?.crawler_type) return c.json({ supported: false });
+  return c.json({ supported: themeEngine.hasHtmlRenderer(col.crawler_type) });
+});
+
+// GET /api/collections/:name/html/*
+api.get("/api/collections/:name/html/*", async (c) => {
+  const name = c.req.param("name");
+  const col = await getCollection(c.env.DB, name);
+  if (!col?.crawler_type || !themeEngine.hasHtmlRenderer(col.crawler_type)) {
+    return c.text("HTML not supported for this collection", 404);
+  }
+
+  const filePath = c.req.path.replace(`/api/collections/${encodeURIComponent(name)}/html/`, "");
+  const decoded = decodeURIComponent(filePath);
+
+  const entity = await getEntityByMarkdownPath(c.env.DB, name, decoded);
+  if (!entity) return c.text("Entity not found", 404);
+
+  const [tags, allEntities] = await Promise.all([
+    getEntityTags(c.env.DB, name, entity.id),
+    c.env.DB.prepare("SELECT external_id, markdown_path FROM entities WHERE collection_name = ?")
+      .bind(name)
+      .all<{ external_id: string; markdown_path: string | null }>()
+      .then((r) => r.results ?? []),
+  ]);
+
+  // Build synchronous externalId → relative path map for cross-reference resolution
+  const entityPathMap = new Map<string, string>();
+  for (const row of allEntities) {
+    if (!row.markdown_path) continue;
+    const prefix = "markdown/";
+    const rel = row.markdown_path.startsWith(prefix) ? row.markdown_path.slice(prefix.length) : row.markdown_path;
+    entityPathMap.set(row.external_id, rel.endsWith(".md") ? rel.slice(0, -3) : rel);
+  }
+
+  const data = typeof entity.data === "string" ? JSON.parse(entity.data) : entity.data;
+
+  const html = themeEngine.renderHtml({
+    entity: {
+      externalId: entity.external_id,
+      entityType: entity.entity_type,
+      title: entity.title,
+      data,
+      url: entity.url ?? undefined,
+      tags,
+    },
+    collectionName: name,
+    crawlerType: col.crawler_type,
+    lookupEntityPath: (externalId) => entityPathMap.get(externalId),
+  });
+  if (!html) return c.text("HTML rendering failed", 500);
+
+  return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });
 });
 
 // GET /api/collections/:name/tree


### PR DESCRIPTION
## Summary

- **Worker HTML rendering**: published Cloudflare worker now renders GitHub issues/PRs/users as styled HTML on the fly via new `/api/collections/:name/html-support` and `/api/collections/:name/html/*` routes — no pre-generated files stored in R2
- **D1 schema**: stores `crawler_type` in `collections_meta` so the worker knows which theme renderer to use
- **Theme subpath exports**: added `@veecontext/core/theme` and `@veecontext/crawlers/themes` subpath exports so the worker bundles only pure theme code (no Bun/Node built-ins like `bun:sqlite`, `fs`, `child_process`)
- **UI race condition fix**: markdown was showing instead of HTML while HTML content was loading; added `htmlLoading` state so a spinner shows instead; `MarkdownView` only renders when `viewMode === "markdown"`
- **Mobile nav bar**: moved from bottom to top; uses `safe-area-inset-top` for iPhone notch
- **Mobile HTML CSS**: compact padding, horizontal scroll on code/diff blocks, smaller title font size

## Test plan

- [ ] Publish a GitHub collection and verify HTML view loads by default (no markdown flash)
- [ ] Verify `/api/collections/:name/html-support` returns `{"supported":true}` for GitHub collections
- [ ] Verify `/api/collections/:name/html/:file` renders HTML on the worker
- [ ] Check mobile layout: nav bar appears at top, HTML view is readable
- [ ] Run CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)