### PR TITLE
feat: MantisBT user/project entities, HTML renderer, and UI polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,34 @@ Re-running `vctx publish --name <existing>` **updates** an existing deployment:
 
 The worker implements MCP via direct JSON-RPC (not the SDK's StreamableHTTPServerTransport, which requires Node.js APIs unavailable in Workers).
 
+#### When to do a full publish vs. worker-only
+
+| Scenario | Command |
+|----------|---------|
+| Changed crawler data, synced new entities | Full publish: `vctx publish <collections...> --name <name>` |
+| Changed `packages/worker/src/**` (server logic, HTML rendering, routes) | Worker-only (after rebuild): see below |
+| Changed `packages/ui/src/**` (React components, CSS) | Worker-only (after rebuild): see below |
+| Changed `packages/crawlers/src/mantisbt/theme.ts` (HTML renderer) | Worker-only — HTML is rendered on-the-fly by the worker at request time, not pre-stored |
+
+#### Build steps required before publishing
+
+**Always build before publishing** — the CLI uploads pre-built artifacts, not source files:
+
+```bash
+# After changing packages/ui/src/** (React, CSS):
+cd packages/ui && bun run build          # outputs to packages/ui/dist/
+
+# After changing packages/worker/src/** (server, routes, renderers):
+cd packages/worker && bun run build      # outputs to packages/worker/dist/worker.js
+
+# Then deploy (worker + UI assets only, no D1/R2 data change):
+bun run packages/cli/src/index.ts publish --worker-only --name <deployment-name>
+```
+
+Skipping the build means the old compiled bundle is deployed — source changes have no effect.
+
+**Note:** `wrangler` is not globally installed; invoke it via `bunx wrangler` or use the CLI which calls it as a subprocess automatically.
+
 ### Build & Test Commands
 
 ```bash

--- a/packages/crawlers/src/mantisbt/__tests__/crawler.test.ts
+++ b/packages/crawlers/src/mantisbt/__tests__/crawler.test.ts
@@ -58,13 +58,29 @@ describe("MantisBTCrawler", () => {
       });
     });
 
+    // Issues phase: syncs 1 issue, then transitions to users phase.
     const first = await crawler.sync(null);
     expect(first.entities).toHaveLength(1);
-    expect(first.nextCursor).toEqual({ updatedSince: "2024-01-02T00:00:00Z" });
+    expect(first.entities[0].externalId).toBe("issue:1");
+    expect((first.nextCursor as any).phase).toBe("users");
+    expect((first.nextCursor as any).updatedSince).toBe("2024-01-02T00:00:00Z");
 
-    const second = await crawler.sync(first.nextCursor);
-    expect(second.entities.map((e) => e.externalId)).toEqual(["issue:2", "issue:1"]);
-    expect(second.nextCursor).toEqual({ updatedSince: "2024-01-03T00:00:00Z" });
+    // Users+projects phase: emits project entity, no users (sample issue has no reporter/handler).
+    const usersPhase = await crawler.sync(first.nextCursor);
+    expect(usersPhase.hasMore).toBe(false);
+    expect(usersPhase.nextCursor).toEqual({ updatedSince: "2024-01-02T00:00:00Z" });
+
+    // Incremental issues phase: filters by updatedSince, returns issues 2 and 1.
+    const incr = await crawler.sync(usersPhase.nextCursor);
+    expect(incr.entities.filter((e) => e.entityType === "issue").map((e) => e.externalId))
+      .toEqual(["issue:2", "issue:1"]);
+    expect((incr.nextCursor as any).phase).toBe("users");
+    expect((incr.nextCursor as any).updatedSince).toBe("2024-01-03T00:00:00Z");
+
+    // Incremental users+projects phase.
+    const incrUsers = await crawler.sync(incr.nextCursor);
+    expect(incrUsers.hasMore).toBe(false);
+    expect(incrUsers.nextCursor).toEqual({ updatedSince: "2024-01-03T00:00:00Z" });
   });
 
   it("includes entities with updated_at equal to updatedSince", async () => {
@@ -104,10 +120,16 @@ describe("MantisBTCrawler", () => {
     expect(first.hasMore).toBe(true);
     expect(first.nextCursor).toBeTruthy();
 
+    // Second call detects repeated page signature and transitions to users phase.
     const second = await crawler.sync(first.nextCursor);
-    expect(second.hasMore).toBe(false);
+    expect(second.hasMore).toBe(true);
+    expect((second.nextCursor as any).phase).toBe("users");
     expect(second.entities).toHaveLength(0);
-    expect(second.nextCursor).toEqual({ updatedSince: "2024-02-01T00:00:00Z" });
+
+    // Users+projects phase: emits 1 project entity (no users in sample issues).
+    const third = await crawler.sync(second.nextCursor);
+    expect(third.hasMore).toBe(false);
+    expect(third.nextCursor).toEqual({ updatedSince: "2024-02-01T00:00:00Z" });
   });
 
   it("advances to page 2 with in-run cursor state", async () => {

--- a/packages/crawlers/src/mantisbt/crawler.ts
+++ b/packages/crawlers/src/mantisbt/crawler.ts
@@ -9,6 +9,7 @@ import type {
   MantisBTConfig,
   MantisBTCredentials,
   MantisBTIssue,
+  MantisBTUser,
 } from "./types";
 
 interface MantisBTSyncCursor extends SyncCursor {
@@ -24,6 +25,12 @@ interface MantisBTSyncCursor extends SyncCursor {
   lastPageSignature?: string;
   /** Number of consecutive repeated page signatures. */
   repeatedPageCount?: number;
+  /** Current sync phase. Undefined / missing means "issues". */
+  phase?: "issues" | "users";
+  /** User data accumulated across issue pages (serialized in cursor). */
+  _users?: Record<number, { id: number; name: string; email?: string }>;
+  /** Project data accumulated across issue pages (serialized in cursor). */
+  _projects?: Record<number, { id: number; name: string; categories: string[] }>;
 }
 
 const PAGE_SIZE = 50;
@@ -96,6 +103,10 @@ export class MantisBTCrawler implements Crawler {
   private maxEntities?: number;
   private fetchFn: typeof fetch = globalThis.fetch;
 
+  // Accumulated during the issues phase; emitted in the users phase.
+  private collectedUsers = new Map<number, { id: number; name: string; email?: string }>();
+  private collectedProjects = new Map<number, { id: number; name: string; categories: string[] }>();
+
   async initialize(
     config: Record<string, unknown>,
     credentials: Record<string, unknown>,
@@ -110,6 +121,26 @@ export class MantisBTCrawler implements Crawler {
 
   async sync(cursor: SyncCursor | null): Promise<SyncResult> {
     const c = (cursor as MantisBTSyncCursor) ?? {};
+
+    // Restore accumulated user/project data from cursor (survives across pages).
+    if (cursor === null) {
+      this.collectedUsers.clear();
+      this.collectedProjects.clear();
+    } else if (c._users || c._projects) {
+      this.collectedUsers = new Map(
+        Object.entries(c._users ?? {}).map(([k, v]) => [Number(k), v]),
+      );
+      this.collectedProjects = new Map(
+        Object.entries(c._projects ?? {}).map(([k, v]) => [Number(k), v]),
+      );
+    }
+
+    // Users + projects phase: emit after all issues are processed.
+    if (c.phase === "users") {
+      return this.syncUsersAndProjects(c);
+    }
+
+    // ── Issues phase ─────────────────────────────────────────────
     const isLegacyPageCursor =
       c.page !== undefined &&
       c.updatedSince === undefined &&
@@ -119,7 +150,6 @@ export class MantisBTCrawler implements Crawler {
     const fetched = isLegacyPageCursor ? 0 : (c.fetched ?? 0);
     const updatedSinceTs = parseTimestamp(c.updatedSince);
 
-    // Build URL
     let url = `${this.baseUrl}/api/rest/issues?page_size=${PAGE_SIZE}&page=${page}`;
     if (this.projectId) {
       url += `&project_id=${this.projectId}`;
@@ -129,7 +159,6 @@ export class MantisBTCrawler implements Crawler {
     const data = (await response.json()) as { issues: MantisBTIssue[] };
     const issues = data.issues ?? [];
 
-    // Sort by last_updated descending (API doesn't support sorting)
     issues.sort(
       (a, b) =>
         new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
@@ -145,8 +174,6 @@ export class MantisBTCrawler implements Crawler {
       newestSeenUpdatedAt = maxTimestamp(newestSeenUpdatedAt, issue.updated_at);
     }
 
-    // Incremental filtering: re-process entities with timestamp >= updatedSince.
-    // Keeping equality avoids missing updates when many issues share the same second.
     let issuesToProcess = issues;
     if (updatedSinceTs !== null) {
       issuesToProcess = issues.filter((issue) => {
@@ -155,7 +182,6 @@ export class MantisBTCrawler implements Crawler {
       });
     }
 
-    // Apply max entities limit to entities that passed incremental filtering.
     let remaining = issuesToProcess.length;
     if (this.maxEntities) {
       remaining = Math.max(0, this.maxEntities - fetched);
@@ -173,18 +199,27 @@ export class MantisBTCrawler implements Crawler {
 
     const apiHasMore = issues.length === PAGE_SIZE;
     const reachedMax = this.maxEntities ? (fetched + issuesToProcess.length) >= this.maxEntities : false;
-    const hasMore = apiHasMore && !reachedMax;
+    const issuesHaveMore = apiHasMore && !reachedMax;
     const finalUpdatedSince = maxTimestamp(c.updatedSince, newestSeenUpdatedAt);
 
-    // Some MantisBT instances appear to return the same "page" repeatedly.
-    // If the signature repeats, stop paginating to avoid an infinite loop.
     if (page > 1 && repeatedPageCount > 0) {
       return {
         entities: [],
-        nextCursor: finalUpdatedSince ? { updatedSince: finalUpdatedSince } : null,
-        hasMore: false,
+        nextCursor: {
+          phase: "users",
+          updatedSince: finalUpdatedSince,
+          _users: Object.fromEntries(this.collectedUsers),
+          _projects: Object.fromEntries(this.collectedProjects),
+        },
+        hasMore: true,
         deletedExternalIds: [],
       };
+    }
+
+    // Collect users + projects from ALL fetched issues (not just processed ones)
+    // so we capture every user/project even in incremental syncs.
+    for (const issue of issues) {
+      this.collectUsersAndProjects(issue);
     }
 
     const entities: CrawlerEntityData[] = await Promise.all(
@@ -192,20 +227,66 @@ export class MantisBTCrawler implements Crawler {
     );
 
     const newFetched = fetched + issuesToProcess.length;
+    const serializedCollected = {
+      _users: Object.fromEntries(this.collectedUsers),
+      _projects: Object.fromEntries(this.collectedProjects),
+    };
 
+    if (issuesHaveMore) {
+      return {
+        entities,
+        nextCursor: {
+          page: page + 1,
+          fetched: newFetched,
+          updatedSince: c.updatedSince,
+          newestSeenUpdatedAt,
+          lastPageSignature: pageSignature,
+          repeatedPageCount,
+          ...serializedCollected,
+        },
+        hasMore: true,
+        deletedExternalIds: [],
+      };
+    }
+
+    // Issues exhausted — transition to users+projects phase.
     return {
       entities,
-      nextCursor: hasMore
-        ? {
-            page: page + 1,
-            fetched: newFetched,
-            updatedSince: c.updatedSince,
-            newestSeenUpdatedAt,
-            lastPageSignature: pageSignature,
-            repeatedPageCount,
-          }
-        : (finalUpdatedSince ? { updatedSince: finalUpdatedSince } : null),
-      hasMore,
+      nextCursor: { phase: "users", updatedSince: finalUpdatedSince, ...serializedCollected },
+      hasMore: true,
+      deletedExternalIds: [],
+    };
+  }
+
+  private async syncUsersAndProjects(c: MantisBTSyncCursor): Promise<SyncResult> {
+    const entities: CrawlerEntityData[] = [];
+
+    // Fetch full user profiles; fall back to basic data on error.
+    for (const basic of this.collectedUsers.values()) {
+      if (!basic.name) continue; // Skip users without a name
+      try {
+        const profile = await this.fetchUser(basic.id);
+        entities.push(this.buildUserEntity(profile));
+      } catch {
+        // Build a minimal user entity from data collected during issue sync.
+        entities.push(this.buildUserEntity({
+          id: basic.id,
+          name: basic.name,
+          email: basic.email,
+        }));
+      }
+    }
+
+    // Emit project entities (data already collected from issues).
+    for (const project of this.collectedProjects.values()) {
+      entities.push(this.buildProjectEntity(project));
+    }
+
+    const finalCursor = c.updatedSince ? { updatedSince: c.updatedSince } : null;
+    return {
+      entities,
+      nextCursor: finalCursor,
+      hasMore: false,
       deletedExternalIds: [],
     };
   }
@@ -230,11 +311,7 @@ export class MantisBTCrawler implements Crawler {
         { headers },
       );
 
-      // Accept 200 (valid token) or allow empty token for anonymous instances
       if (response.ok) return true;
-
-      // If token is empty and we get 401, the instance doesn't support
-      // anonymous access — still valid config, user just can't fetch yet
       if (!token && response.status === 401) return true;
 
       return false;
@@ -264,6 +341,85 @@ export class MantisBTCrawler implements Crawler {
       );
     }
     return response;
+  }
+
+  private async fetchUser(userId: number): Promise<MantisBTUser> {
+    const url = `${this.baseUrl}/api/rest/users/${userId}`;
+    const response = await this.apiFetch(url);
+    return (await response.json()) as MantisBTUser;
+  }
+
+  private buildUserEntity(user: MantisBTUser): CrawlerEntityData {
+    const avatarUrl = user.avatar?.attr?.src ?? null;
+    const displayName = user.real_name ? `${user.real_name} (@${user.name})` : user.name;
+    return {
+      externalId: `user:${user.name}`,
+      entityType: "user",
+      title: displayName,
+      url: `${this.baseUrl}/user_summary_page.php?username=${encodeURIComponent(user.name)}`,
+      tags: ["user"],
+      data: {
+        id: user.id,
+        name: user.name,
+        realName: user.real_name ?? null,
+        email: user.email ?? null,
+        avatarUrl,
+      },
+    };
+  }
+
+  private buildProjectEntity(project: { id: number; name: string; categories: string[] }): CrawlerEntityData {
+    return {
+      externalId: `project:${project.id}`,
+      entityType: "project",
+      title: project.name,
+      url: `${this.baseUrl}/set_project.php?project_id=${project.id}`,
+      tags: ["project"],
+      data: {
+        id: project.id,
+        name: project.name,
+        categories: project.categories,
+      },
+    };
+  }
+
+  /** Collect users and projects from an issue into the accumulation maps. */
+  private collectUsersAndProjects(issue: MantisBTIssue): void {
+    if (issue.reporter?.name) {
+      this.collectedUsers.set(issue.reporter.id, {
+        id: issue.reporter.id,
+        name: issue.reporter.name,
+        email: issue.reporter.email,
+      });
+    }
+    if (issue.handler?.name) {
+      this.collectedUsers.set(issue.handler.id, {
+        id: issue.handler.id,
+        name: issue.handler.name,
+        email: issue.handler.email,
+      });
+    }
+    for (const note of issue.notes ?? []) {
+      if (note.reporter?.name) {
+        this.collectedUsers.set(note.reporter.id, {
+          id: note.reporter.id,
+          name: note.reporter.name,
+          email: note.reporter.email,
+        });
+      }
+    }
+    if (issue.project) {
+      const existing = this.collectedProjects.get(issue.project.id);
+      const categories = existing?.categories ?? [];
+      if (issue.category?.name && !categories.includes(issue.category.name)) {
+        categories.push(issue.category.name);
+      }
+      this.collectedProjects.set(issue.project.id, {
+        id: issue.project.id,
+        name: issue.project.name,
+        categories,
+      });
+    }
   }
 
   private async buildIssueEntity(issue: MantisBTIssue): Promise<CrawlerEntityData> {
@@ -357,7 +513,6 @@ export class MantisBTCrawler implements Crawler {
         createdAt: issue.created_at,
         updatedAt: issue.updated_at,
         sticky: issue.sticky,
-        // Only include storagePath when the file was actually downloaded.
         files: (issue.files ?? []).map((f) => {
           const storagePath = `attachments/mantisbt/${attachmentFilename(issue.id, f.filename)}`;
           return {

--- a/packages/crawlers/src/mantisbt/theme.ts
+++ b/packages/crawlers/src/mantisbt/theme.ts
@@ -31,8 +31,141 @@ function formatDate(iso: string): string {
   });
 }
 
+function formatDateCompact(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }) + " " + d.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
 function tableRow(label: string, value: string): string {
   return `| **${label}** | ${value} |`;
+}
+
+// ── HTML rendering helpers ─────────────────────────────────────
+
+function esc(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Deterministic color from a name string. */
+function avatarColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const palette = ["#e74c3c", "#8e44ad", "#2980b9", "#16a085", "#27ae60", "#f39c12", "#d35400", "#34495e", "#c0392b", "#7f8c8d"];
+  return palette[Math.abs(hash) % palette.length];
+}
+
+/** Render a round avatar — real image when URL provided, initials circle otherwise. */
+function mtAvatar(name: string, avatarUrl?: string | null, size = 24): string {
+  if (avatarUrl) {
+    return `<img class="mt-avatar" src="${esc(avatarUrl)}" width="${size}" height="${size}" alt="${esc(name)}" />`;
+  }
+  const initial = (name || "?").charAt(0).toUpperCase();
+  const bg = avatarColor(name || "?");
+  return `<span class="mt-avatar mt-avatar-fallback" style="width:${size}px;height:${size}px;font-size:${Math.round(size * 0.48)}px;background:${bg}">${initial}</span>`;
+}
+
+type Lookup = (externalId: string) => string | undefined;
+
+/**
+ * Convert plain text to HTML with escaped entities, line breaks,
+ * and #1234 issue references / @mentions converted to wikilinks.
+ */
+function textToHtml(text: string, lookup?: Lookup): string {
+  let html = esc(text);
+
+  // Linkify #1234 issue references
+  if (lookup) {
+    html = html.replace(/#(\d+)/g, (match, id) => {
+      const path = lookup(`issue:${id}`);
+      if (!path) return match;
+      return `<a class="mt-issue-ref" href="#wikilink/${encodeURIComponent(path)}">#${padId(parseInt(id))}</a>`;
+    });
+  }
+
+  // Linkify @mentions to user entities
+  if (lookup) {
+    html = html.replace(/@([a-zA-Z0-9_.-]+)/g, (match, name) => {
+      const path = lookup(`user:${name}`);
+      if (!path) return match;
+      return `<a class="mt-user-link" href="#wikilink/${encodeURIComponent(path)}">@${esc(name)}</a>`;
+    });
+  }
+
+  // Bare URLs
+  html = html.replace(
+    /(?<!="|>)(https?:\/\/[^\s<]+)/g,
+    '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>',
+  );
+
+  // Convert line breaks
+  html = html.replace(/\n/g, "<br>");
+
+  return html;
+}
+
+/** Render a user name as a link to the user entity (underline on hover only). */
+function mtUserLink(name: string, lookup?: Lookup): string {
+  const path = lookup?.(`user:${name}`);
+  if (path) {
+    return `<a class="mt-user-link" href="#wikilink/${encodeURIComponent(path)}">${esc(name)}</a>`;
+  }
+  return esc(name);
+}
+
+/** Render a project name as a link to the project entity (underline on hover only). */
+function mtProjectLink(project: { id: number; name: string }, lookup?: Lookup): string {
+  const path = lookup?.(`project:${project.id}`);
+  if (path) {
+    return `<a class="mt-project-link" href="#wikilink/${encodeURIComponent(path)}">${esc(project.name)}</a>`;
+  }
+  return esc(project.name);
+}
+
+function mtSidebarRow(label: string, value: string): string {
+  return `<div class="mt-sidebar-row"><div class="mt-sidebar-label">${esc(label)}</div><div class="mt-sidebar-value">${value}</div></div>`;
+}
+
+function statusColor(status: { color?: string; name?: string }): string {
+  if (status.color) return status.color;
+  // Fallback colors based on common MantisBT status names
+  switch (status.name) {
+    case "new": return "#fcbdbd";
+    case "feedback": return "#e3b7eb";
+    case "acknowledged": return "#ffcd85";
+    case "confirmed": return "#fff494";
+    case "assigned": return "#c2dfff";
+    case "resolved": return "#d2f5b0";
+    case "closed": return "#c9ccc4";
+    default: return "#e8e8e8";
+  }
+}
+
+function priorityIndicator(name: string): string {
+  const colors: Record<string, string> = {
+    none: "#ccc",
+    low: "#83c67e",
+    normal: "#f0ad4e",
+    high: "#e67e22",
+    urgent: "#e74c3c",
+    immediate: "#c0392b",
+  };
+  const color = colors[name.toLowerCase()] ?? "#999";
+  return `<span class="mt-priority-dash" style="color:${color}">&mdash;</span>`;
 }
 
 /**
@@ -73,17 +206,344 @@ export class MantisBTTheme implements Theme {
   crawlerType = "mantisbt";
 
   render(context: ThemeRenderContext): string {
+    if (context.entity.entityType === "user") return this.renderUserMd(context);
+    if (context.entity.entityType === "project") return this.renderProjectMd(context);
     return this.renderIssue(context);
   }
 
   getFilePath(context: ThemeRenderContext): string {
     const d = context.entity.data;
+
+    if (context.entity.entityType === "user") {
+      const name = d.name as string;
+      return `users/${slugify(name)}.md`;
+    }
+
+    if (context.entity.entityType === "project") {
+      const id = d.id as number;
+      const name = d.name as string;
+      const slug = slugify(name);
+      return slug ? `projects/${padId(id)}-${slug}.md` : `projects/${padId(id)}.md`;
+    }
+
     const id = d.id as number;
     const summary = d.summary as string;
     const slug = slugify(summary);
     return slug
       ? `issues/${padId(id)}-${slug}.md`
       : `issues/${padId(id)}.md`;
+  }
+
+  renderHtml(context: ThemeRenderContext): string | null {
+    if (context.entity.entityType === "user") return this.renderUserHtml(context);
+    if (context.entity.entityType === "project") return this.renderProjectHtml(context);
+    return this.renderIssueHtml(context);
+  }
+
+  private renderIssueHtml(context: ThemeRenderContext): string {
+    const d = context.entity.data;
+    const lookup = context.lookupEntityPath;
+
+    const status = d.status as { name: string; label: string; color?: string };
+    const resolution = d.resolution as { name: string; label: string };
+    const priority = d.priority as { name: string; label: string };
+    const severity = d.severity as { name: string; label: string };
+    const project = d.project as { id: number; name: string } | null;
+    const category = d.category as { name: string } | null;
+    const reporter = d.reporter as { name: string } | null;
+    const handler = d.handler as { name: string } | null;
+    const reproducibility = d.reproducibility as { label: string } | null;
+
+    const issueId = padId(d.id as number);
+    const parts: string[] = [];
+
+    parts.push(`<div class="mt-issue-view">`);
+
+    // ── Header ──
+    parts.push(`<div class="mt-header">`);
+    if (project || category) {
+      const projectHtml = project ? mtProjectLink(project, lookup) : null;
+      const crumbs = [projectHtml, category ? esc(category.name) : null, esc(padId(d.id as number))].filter(Boolean);
+      parts.push(`<div class="mt-breadcrumb">${crumbs.join(" &rsaquo; ")}</div>`);
+    }
+    parts.push(`<h1 class="mt-title">${esc(d.summary as string)}</h1>`);
+
+    // Tags as badges
+    const tags = context.entity.tags ?? [];
+    const customTags = tags.filter((t) => !t.includes(":"));
+    if (customTags.length > 0) {
+      parts.push(`<div class="mt-tags">${customTags.map((t) => `<span class="mt-tag">${esc(t)}</span>`).join(" ")}</div>`);
+    }
+    parts.push(`</div>`); // mt-header
+
+    // ── Two-column layout ──
+    parts.push(`<div class="mt-columns">`);
+
+    // ── Main column ──
+    parts.push(`<div class="mt-main-col">`);
+
+    // Details section
+    parts.push(`<div class="mt-section">`);
+    parts.push(`<h2 class="mt-section-title">Details</h2>`);
+    parts.push(`<div class="mt-section-body">`);
+    if (d.description) {
+      parts.push(`<div class="mt-description">${textToHtml(d.description as string, lookup)}</div>`);
+    }
+    if (d.stepsToReproduce) {
+      parts.push(`<h3 class="mt-subsection-title">Steps to Reproduce</h3>`);
+      parts.push(`<div class="mt-description">${textToHtml(d.stepsToReproduce as string, lookup)}</div>`);
+    }
+    if (d.additionalInformation) {
+      parts.push(`<h3 class="mt-subsection-title">Additional Information</h3>`);
+      parts.push(`<div class="mt-description">${textToHtml(d.additionalInformation as string, lookup)}</div>`);
+    }
+
+    // Issue-level attachments
+    const files = d.files as Array<{ filename: string; storagePath?: string; size: number }> | undefined;
+    if (files?.length) {
+      parts.push(`<h3 class="mt-subsection-title">Attachments</h3>`);
+      parts.push(`<div class="mt-attachments">`);
+      for (const f of files) {
+        const sizeKb = Math.round(f.size / 1024);
+        parts.push(`<div class="mt-attachment-item">${esc(f.filename)} <span class="mt-attachment-size">(${sizeKb} KB)</span></div>`);
+      }
+      parts.push(`</div>`);
+    }
+    parts.push(`</div>`); // mt-section-body
+    parts.push(`</div>`); // mt-section
+
+    // Relationships section
+    const relationships = d.relationships as Array<{
+      type: { name: string; label: string };
+      issue: { id: number; summary?: string };
+    }> | undefined;
+    if (relationships?.length) {
+      parts.push(`<div class="mt-section">`);
+      parts.push(`<h2 class="mt-section-title">Relationships</h2>`);
+      parts.push(`<div class="mt-section-body">`);
+      for (const rel of relationships) {
+        const targetPath = issueFilePath(rel.issue.id, rel.issue.summary ?? "");
+        const label = rel.issue.summary
+          ? `${padId(rel.issue.id)} - ${esc(rel.issue.summary)}`
+          : padId(rel.issue.id);
+        parts.push(`<div class="mt-relationship">`);
+        parts.push(`<span class="mt-rel-type">${esc(rel.type.label ?? rel.type.name)}</span>`);
+        parts.push(`<a class="mt-issue-ref" href="#wikilink/${encodeURIComponent(targetPath)}">${label}</a>`);
+        parts.push(`</div>`);
+      }
+      parts.push(`</div>`);
+      parts.push(`</div>`);
+    }
+
+    // Activities section (notes + history interleaved chronologically)
+    const notes = d.notes as Array<{
+      id: number;
+      reporter?: { name: string };
+      text: string;
+      view_state?: { name: string };
+      created_at: string;
+      attachments?: Array<{ filename: string; storagePath?: string; size: number }>;
+    }> | undefined;
+
+    const history = (d.history ?? []) as Array<{
+      created_at: string;
+      user: { name: string };
+      type: { name: string };
+      message: string;
+      field?: { name: string; old_value: string; new_value: string };
+    }>;
+
+    // Build a unified timeline of activities
+    type Activity = { type: "note"; timestamp: string; data: typeof notes extends Array<infer T> | undefined ? T : never }
+                  | { type: "history"; timestamp: string; data: typeof history extends Array<infer T> ? T : never };
+    const activities: Activity[] = [];
+
+    if (notes?.length) {
+      for (const note of notes) {
+        activities.push({ type: "note", timestamp: note.created_at, data: note as any });
+      }
+    }
+    for (const entry of history) {
+      activities.push({ type: "history", timestamp: entry.created_at, data: entry as any });
+    }
+
+    // Sort chronologically (oldest first)
+    activities.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+    if (activities.length > 0) {
+      parts.push(`<div class="mt-section">`);
+      parts.push(`<h2 class="mt-section-title">Activities</h2>`);
+      parts.push(`<div class="mt-activity-list">`);
+
+      for (const activity of activities) {
+        if (activity.type === "note") {
+          const note = activity.data as NonNullable<typeof notes>[number];
+          const author = note.reporter?.name ?? "Unknown";
+          const isPrivate = note.view_state?.name === "private";
+          const borderClass = isPrivate ? "mt-note-private" : "mt-note-public";
+
+          parts.push(`<div class="mt-activity">`);
+          parts.push(`<div class="mt-activity-header">`);
+          parts.push(`${mtAvatar(author)} <strong class="mt-activity-author">${mtUserLink(author, lookup)}</strong>`);
+          parts.push(`<span class="mt-activity-date">${formatDateCompact(note.created_at)}</span>`);
+          if (isPrivate) {
+            parts.push(`<span class="mt-private-badge">private</span>`);
+          }
+          parts.push(`</div>`);
+          parts.push(`<div class="mt-activity-body">`);
+          parts.push(`<div class="mt-note-body ${borderClass}">`);
+          parts.push(`<div class="mt-note-text">${textToHtml(note.text, lookup)}</div>`);
+
+          // Note attachments
+          if (note.attachments?.length) {
+            parts.push(`<div class="mt-note-attachments">`);
+            for (const att of note.attachments) {
+              const sizeKb = Math.round(att.size / 1024);
+              parts.push(`<div class="mt-attachment-item">${esc(att.filename)} <span class="mt-attachment-size">(${sizeKb} KB)</span></div>`);
+            }
+            parts.push(`</div>`);
+          }
+          parts.push(`</div>`);
+          parts.push(`</div>`);
+          parts.push(`</div>`);
+        } else {
+          // History entry
+          const entry = activity.data as typeof history[number];
+          parts.push(`<div class="mt-activity mt-history-entry">`);
+          parts.push(`<div class="mt-activity-header">`);
+          parts.push(`${mtAvatar(entry.user.name)} <strong class="mt-activity-author">${esc(entry.user.name)}</strong>`);
+          parts.push(`<span class="mt-activity-date">${formatDateCompact(entry.created_at)}</span>`);
+          parts.push(`</div>`);
+          if (entry.field || entry.message) {
+            parts.push(`<div class="mt-activity-body">`);
+            if (entry.field) {
+              parts.push(`<div class="mt-history-text">${esc(entry.message || `changed "${entry.field.name}" from "${entry.field.old_value}" to "${entry.field.new_value}"`)}</div>`);
+            } else if (entry.message) {
+              parts.push(`<div class="mt-history-text">${esc(entry.message)}</div>`);
+            }
+            parts.push(`</div>`);
+          }
+          parts.push(`</div>`);
+        }
+      }
+
+      parts.push(`</div>`); // mt-activity-list
+      parts.push(`</div>`); // mt-section
+    }
+
+    parts.push(`</div>`); // mt-main-col
+
+    // ── Sidebar ──
+    parts.push(`<div class="mt-sidebar-col">`);
+    parts.push(`<h3 class="mt-sidebar-heading">Overview</h3>`);
+
+    if (category) {
+      parts.push(mtSidebarRow("Category", esc(category.name)));
+    }
+    parts.push(mtSidebarRow("Priority", `${priorityIndicator(priority.name)} ${esc(priority.label)}`));
+    parts.push(mtSidebarRow("Severity", esc(severity.label)));
+
+    // Status with colored indicator
+    const sColor = statusColor(status);
+    parts.push(mtSidebarRow("Status", `<span class="mt-status-dot" style="background:${sColor}"></span> ${esc(status.label)}`));
+
+    parts.push(mtSidebarRow("Resolution", esc(resolution.label)));
+
+    if (reproducibility) {
+      parts.push(mtSidebarRow("Reproducibility", esc(reproducibility.label)));
+    }
+
+    if (reporter?.name) {
+      parts.push(mtSidebarRow("Reporter", `${mtAvatar(reporter.name, null, 20)} <strong>${mtUserLink(reporter.name, lookup)}</strong>`));
+    }
+    if (handler?.name) {
+      parts.push(mtSidebarRow("Assigned To", `${mtAvatar(handler.name, null, 20)} <strong>${mtUserLink(handler.name, lookup)}</strong>`));
+    }
+
+    parts.push(mtSidebarRow("Created", formatDateCompact(d.createdAt as string)));
+    parts.push(mtSidebarRow("Updated", formatDateCompact(d.updatedAt as string)));
+
+    if (context.entity.url) {
+      parts.push(`<div class="mt-sidebar-row mt-sidebar-link-row"><a class="mt-sidebar-link" href="${esc(context.entity.url)}" target="_blank" rel="noopener noreferrer">View in MantisBT &rarr;</a></div>`);
+    }
+
+    parts.push(`</div>`); // mt-sidebar-col
+    parts.push(`</div>`); // mt-columns
+    parts.push(`</div>`); // mt-issue-view
+
+    return parts.join("\n");
+  }
+
+  private renderUserMd(context: ThemeRenderContext): string {
+    const d = context.entity.data;
+    const fm: Record<string, unknown> = {
+      title: context.entity.title,
+      type: "user",
+      username: d.name,
+    };
+    if (d.email) fm.email = d.email;
+    const lines = [frontmatter(fm), `## ${context.entity.title}`];
+    if (d.realName) lines.push(`**Name:** ${d.realName as string}`);
+    if (d.email) lines.push(`**Email:** ${d.email as string}`);
+    return lines.join("\n\n");
+  }
+
+  private renderProjectMd(context: ThemeRenderContext): string {
+    const d = context.entity.data;
+    const categories = (d.categories ?? []) as string[];
+    const fm: Record<string, unknown> = { title: context.entity.title, type: "project" };
+    if (categories.length) fm.categories = categories;
+    const lines = [frontmatter(fm), `## ${d.name as string}`];
+    if (categories.length) {
+      lines.push("### Categories\n\n" + categories.map((c) => `- ${c}`).join("\n"));
+    }
+    return lines.join("\n\n");
+  }
+
+  private renderUserHtml(context: ThemeRenderContext): string {
+    const d = context.entity.data;
+    const name = (d.name as string) ?? "Unknown";
+    const parts: string[] = [];
+    parts.push(`<div class="mt-issue-view">`);
+    parts.push(`<div class="mt-header">`);
+    parts.push(`<h1 class="mt-title">${esc(context.entity.title)}</h1>`);
+    parts.push(`</div>`);
+    parts.push(`<div class="mt-user-card">`);
+    parts.push(mtAvatar(name, d.avatarUrl as string | null, 80));
+    parts.push(`<div class="mt-user-info">`);
+    if (d.realName) parts.push(`<div class="mt-user-realname">${esc(d.realName as string)}</div>`);
+    parts.push(`<div class="mt-user-username">@${esc(name)}</div>`);
+    if (d.email) parts.push(`<div class="mt-user-email">${esc(d.email as string)}</div>`);
+    parts.push(`</div>`);
+    parts.push(`</div>`);
+    if (context.entity.url) {
+      parts.push(`<div style="margin-top:16px"><a class="mt-sidebar-link" href="${esc(context.entity.url)}" target="_blank" rel="noopener noreferrer">View profile in MantisBT &rarr;</a></div>`);
+    }
+    parts.push(`</div>`);
+    return parts.join("\n");
+  }
+
+  private renderProjectHtml(context: ThemeRenderContext): string {
+    const d = context.entity.data;
+    const categories = (d.categories ?? []) as string[];
+    const parts: string[] = [];
+    parts.push(`<div class="mt-issue-view">`);
+    parts.push(`<div class="mt-header">`);
+    parts.push(`<h1 class="mt-title">${esc(d.name as string)}</h1>`);
+    parts.push(`</div>`);
+    if (categories.length) {
+      parts.push(`<div class="mt-section">`);
+      parts.push(`<h2 class="mt-section-title">Categories</h2>`);
+      parts.push(`<div class="mt-section-body">`);
+      parts.push(`<ul class="mt-category-list">${categories.map((c) => `<li>${esc(c)}</li>`).join("")}</ul>`);
+      parts.push(`</div>`);
+      parts.push(`</div>`);
+    }
+    if (context.entity.url) {
+      parts.push(`<a class="mt-sidebar-link" href="${esc(context.entity.url)}" target="_blank" rel="noopener noreferrer">Open project in MantisBT &rarr;</a>`);
+    }
+    parts.push(`</div>`);
+    return parts.join("\n");
   }
 
   private renderIssue(context: ThemeRenderContext): string {
@@ -138,8 +598,8 @@ export class MantisBTTheme implements Theme {
       tableRow("Priority", priority.label),
       tableRow("Severity", severity.label),
     ];
-    if (reporter) rows.push(tableRow("Reporter", reporter.name));
-    if (handler) rows.push(tableRow("Assigned To", handler.name));
+    if (reporter?.name) rows.push(tableRow("Reporter", reporter.name));
+    if (handler?.name) rows.push(tableRow("Assigned To", handler.name));
     if (reproducibility) rows.push(tableRow("Reproducibility", reproducibility.label));
     rows.push(tableRow("Created", formatDate(d.createdAt as string)));
     rows.push(tableRow("Updated", formatDate(d.updatedAt as string)));

--- a/packages/crawlers/src/mantisbt/types.ts
+++ b/packages/crawlers/src/mantisbt/types.ts
@@ -1,3 +1,21 @@
+export interface MantisBTUser {
+  id: number;
+  name: string;
+  real_name?: string;
+  email?: string;
+  avatar?: {
+    tag?: string;
+    attr?: { src?: string };
+  };
+}
+
+export interface MantisBTProject {
+  id: number;
+  name: string;
+  description?: string;
+  status?: { id: number; name: string; label: string };
+}
+
 export interface MantisBTConfig {
   baseUrl: string;
   projectId?: number;

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -1801,6 +1801,436 @@ body {
   margin-bottom: 12px;
 }
 
+/* ===== MantisBT-Style HTML View ===== */
+
+.mt-issue-view {
+  padding: 16px 24px 32px;
+  font-family: var(--font-sans);
+  color: var(--text);
+}
+
+/* Header — breadcrumb, title, tags */
+.mt-header {
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 16px;
+}
+
+.mt-breadcrumb {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.mt-title {
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0 0 8px;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.mt-id-badge {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  vertical-align: middle;
+  margin-left: 6px;
+  font-family: var(--font-mono);
+}
+
+.mt-tags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.mt-tag {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 2px 10px;
+  border-radius: 12px;
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+/* Two-column layout */
+.mt-columns {
+  display: flex;
+  gap: 24px;
+}
+
+.mt-main-col {
+  flex: 1;
+  min-width: 0;
+}
+
+.mt-sidebar-col {
+  flex: 0 0 240px;
+}
+
+/* Stack vertically when narrow — sidebar goes below main content */
+@container (max-width: 700px) {
+  .mt-columns { flex-direction: column; }
+  .mt-sidebar-col {
+    flex: none;
+    width: 100%;
+  }
+}
+
+@media (max-width: 800px) {
+  .mt-columns { flex-direction: column; }
+  .mt-sidebar-col {
+    flex: none;
+    width: 100%;
+  }
+}
+
+/* Sections — Details, Relationships, Activities */
+.mt-section {
+  margin-bottom: 24px;
+}
+
+.mt-section-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+}
+
+.mt-subsection-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 16px 0 8px;
+  color: var(--text);
+}
+
+.mt-section-body {
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.mt-description {
+  color: var(--text);
+  word-break: break-word;
+}
+
+/* Attachments */
+.mt-attachments {
+  margin-top: 8px;
+}
+
+.mt-attachment-item {
+  font-size: 13px;
+  padding: 4px 0;
+  color: var(--text);
+}
+
+.mt-attachment-size {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+/* Relationships */
+.mt-relationship {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 0;
+  font-size: 14px;
+  border-bottom: 1px solid var(--bg-tertiary);
+}
+
+.mt-relationship:last-child {
+  border-bottom: none;
+}
+
+.mt-rel-type {
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+/* Issue reference links */
+.mt-issue-ref {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.mt-issue-ref:hover {
+  text-decoration: underline;
+}
+
+/* Activities — notes + history interleaved */
+.mt-activity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.mt-activity {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--bg-tertiary);
+}
+
+.mt-activity:last-child {
+  border-bottom: none;
+}
+
+.mt-activity-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 13px;
+}
+
+.mt-activity-author {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.mt-activity-date {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.mt-private-badge {
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+/* Activity body — no wrapper indent; children position themselves */
+.mt-activity-body {
+}
+
+/* Note body: bar centered under avatar (avatar=24px, center=12px → margin=11px),
+   text aligned with author name (11 + 3border + 18padding = 32px = avatar+gap) */
+.mt-note-body {
+  margin-left: 11px;
+  padding: 4px 12px 4px 18px;
+  border-left: 3px solid;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.mt-note-public {
+  border-left-color: var(--text);
+}
+
+.mt-note-private {
+  border-left-color: var(--text-muted);
+}
+
+.mt-note-text {
+  color: var(--text);
+  word-break: break-word;
+}
+
+.mt-note-text a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.mt-note-text a:hover {
+  text-decoration: underline;
+}
+
+.mt-note-attachments {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+/* History entries — compact style */
+.mt-history-entry {
+  padding: 8px 0;
+}
+
+.mt-history-text {
+  font-size: 13px;
+  color: var(--text-secondary);
+  padding-left: 32px;
+}
+
+/* Sidebar */
+.mt-sidebar-heading {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+}
+
+.mt-sidebar-row {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--bg-tertiary);
+}
+
+.mt-sidebar-row:last-child {
+  border-bottom: none;
+}
+
+.mt-sidebar-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+
+.mt-sidebar-value {
+  font-size: 14px;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.mt-sidebar-value strong {
+  font-weight: 600;
+}
+
+.mt-status-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.mt-priority-dash {
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.mt-sidebar-link-row {
+  padding-top: 12px;
+  border-bottom: none;
+}
+
+.mt-sidebar-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.mt-sidebar-link:hover {
+  text-decoration: underline;
+}
+
+/* Avatars — consistent with gh-avatar */
+.mt-avatar {
+  border-radius: 50%;
+  flex-shrink: 0;
+  object-fit: cover;
+  vertical-align: middle;
+}
+
+.mt-avatar-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  line-height: 1;
+  user-select: none;
+}
+
+/* User and project links — inherit color, underline only on hover */
+.mt-user-link,
+.mt-project-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.mt-user-link:hover,
+.mt-project-link:hover {
+  text-decoration: underline;
+}
+
+/* User profile card */
+.mt-user-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 0;
+}
+
+/* Large avatar on user profile card inherits .mt-avatar styles */
+
+.mt-user-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mt-user-realname {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.mt-user-username {
+  font-size: 15px;
+  color: var(--text-secondary);
+}
+
+.mt-user-email {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.mt-category-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.mt-category-list li {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--bg-tertiary);
+  font-size: 14px;
+}
+
+.mt-category-list li:last-child {
+  border-bottom: none;
+}
+
+/* Mobile adjustments for MantisBT view */
+@container (max-width: 500px) {
+  .mt-issue-view { padding: 12px 16px 24px; }
+  .mt-title { font-size: 18px; }
+  .mt-section-title { font-size: 15px; }
+  .mt-note-body { padding: 4px 10px; }
+}
+
+@media (max-width: 600px) {
+  .mt-issue-view { padding: 12px 16px 24px; }
+  .mt-title { font-size: 18px; }
+  .mt-section-title { font-size: 15px; }
+  .mt-note-body { padding: 4px 10px; }
+}
+
 /* ===== Mobile panel overlays ===== */
 .mobile-panel-overlay {
   position: fixed;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -124,7 +124,7 @@ export default function App() {
   const [loading, setLoading] = useState(false);
   const [backlinks, setBacklinks] = useState<Backlink[]>([]);
   const [outgoingLinks, setOutgoingLinks] = useState<LinkItem[]>([]);
-  const [backlinksOpen, setBacklinksOpen] = useState(!isMobile);
+  const [backlinksOpen, setBacklinksOpen] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("markdown");
   const [htmlContent, setHtmlContent] = useState<string | null>(null);
   const [htmlLoading, setHtmlLoading] = useState(false);
@@ -143,7 +143,8 @@ export default function App() {
   // Sync panel defaults when viewport crosses the mobile breakpoint (e.g. window resize)
   useEffect(() => {
     setSidebarOpen(!isMobile);
-    setBacklinksOpen(!isMobile);
+    // Links panel stays closed by default on all breakpoints; close it on mobile transition
+    if (isMobile) setBacklinksOpen(false);
   }, [isMobile]);
   const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
   const resizingRef = useRef(false);


### PR DESCRIPTION
## Summary

- Add multi-phase sync for MantisBT: issues phase → users/projects phase, collecting referenced users and projects from all issues then fetching full profiles
- HTML renderer for MantisBT issues (two-column layout, sidebar metadata, interleaved activity timeline), user pages (avatar + profile), and project pages (categories)
- Deterministic initials avatars with hash-based colors as fallback when no avatar URL available
- @mention and #issue linkification in note text with wikilink navigation
- Fix blank HTML for issues with missing reporter data
- Note layout: left bar centered under avatar, text left-aligned with author name
- Breadcrumb shows zero-padded issue ID; duplicate ID badge removed from title
- Links panel hidden by default on all screen sizes
- AGENTS.md updated with build-before-publish documentation

## Test plan

- [ ] Run crawler tests: `bun test packages/crawlers/src/`
- [ ] Run typecheck: `bun run typecheck`
- [ ] Verify HTML rendering for issues, user pages, and project pages in the worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)