### PR TITLE
feat: rename app from VeeContext to Frozen Ink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ node_modules
 .env
 dist/
 daemon.pid
-.veecontext/
+.frozenink/
 .context
 .wrangler/
 *.tsbuildinfo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # Agents Guide
 
-This file helps AI agents navigate and work effectively in the VeeContext codebase.
+This file helps AI agents navigate and work effectively in the Frozen Ink codebase.
 
 ## Project Overview
 
-VeeContext is a TypeScript monorepo that crawls data sources, stores them in SQLite, renders Obsidian-compatible markdown, and serves via a web UI and MCP server. Collections can be published to Cloudflare as password-protected websites with remote MCP access, or managed through an Electron desktop app. The codebase runs under both **Bun** (CLI, tests) and **Node.js** (Electron desktop) via a compatibility layer. See [README.md](README.md) for the full overview.
+Frozen Ink is a TypeScript monorepo that crawls data sources, stores them in SQLite, renders Obsidian-compatible markdown, and serves via a web UI and MCP server. Collections can be published to Cloudflare as password-protected websites with remote MCP access, or managed through an Electron desktop app. The codebase runs under both **Bun** (CLI, tests) and **Node.js** (Electron desktop) via a compatibility layer. See [README.md](README.md) for the full overview.
 
 ## Repository Layout
 
@@ -17,7 +17,7 @@ packages/
       sqlite.ts           SQLite driver factory (bun:sqlite ↔ better-sqlite3)
       subprocess.ts       spawn() wrapper (Bun.spawn ↔ child_process.spawn)
       paths.ts            getModuleDir() replaces import.meta.dir
-    config/               Zod schemas, defaults, loader (reads ~/.veecontext/config.json)
+    config/               Zod schemas, defaults, loader (reads ~/.frozenink/config.json)
                           context.ts — context.yml management (collections + deployments CRUD)
     crawler/              Crawler interface, CrawlerRegistry, SyncEngine
     db/                   Drizzle ORM schemas (collection-schema.ts), client factory
@@ -68,7 +68,7 @@ packages/
 
   desktop/                Electron desktop app
     src/main/index.ts     Main process (window, API server lifecycle, workspace management)
-    src/main/workspace-manager.ts  Workspace CRUD (~/.veecontext-desktop/workspaces.json)
+    src/main/workspace-manager.ts  Workspace CRUD (~/.frozenink/workspaces.json)
     src/main/ipc-handlers.ts       IPC bridge (file picker, workspace ops)
     src/main/tray.ts      System tray (sync status, quick actions)
     src/preload/index.ts  Context bridge for secure IPC
@@ -89,7 +89,7 @@ The codebase runs in two runtimes: **Bun** (CLI, tests) and **Node.js** (Electro
 **`import.meta.dir` → `getModuleDir(import.meta.url)`.** Bun's non-standard `import.meta.dir` is replaced with `dirname(fileURLToPath(import.meta.url))`. Call sites pass `import.meta.url` and get back the directory. Test files still use `import.meta.dir` directly since tests always run under Bun.
 
 **Import paths within `core/`.** Internal modules must import from specific files, not the barrel index:
-- `getVeeContextHome` is in `config/loader.ts`, NOT `config/context.ts`
+- `getFrozenInkHome` is in `config/loader.ts`, NOT `config/context.ts`
 - `getCollectionDb` is in `db/client.ts`, NOT `config/context.ts`
 - The barrel `core/src/index.ts` re-exports everything, but circular or missing re-exports can cause `SyntaxError: Export named 'X' not found` at runtime — always verify the source module when adding new internal imports.
 
@@ -111,7 +111,7 @@ The same React app (`packages/ui`) serves all three contexts:
 | Context | `GET /api/app-info` returns | UI shows |
 |---------|---------------------------|----------|
 | Published (Cloudflare Worker) | `{ mode: "published" }` | Browse only |
-| Local (`vctx serve`) | `{ mode: "local" }` | Browse only |
+| Local (`fink serve`) | `{ mode: "local" }` | Browse only |
 | Desktop (Electron) | `{ mode: "desktop" }` | Browse + Manage toggle |
 
 The mode is set by calling `setAppMode("desktop")` from the Electron main process before starting the API server. The management API endpoints are always registered but only meaningful in desktop mode.
@@ -120,15 +120,15 @@ In `App.tsx`, the main content area renders `manageContent || browseContent` —
 
 ### Workspace Model (Desktop Only)
 
-A **workspace** maps to a `VEECONTEXT_HOME` directory. The Electron main process manages workspaces:
+A **workspace** maps to a `FROZENINK_HOME` directory. The Electron main process manages workspaces:
 
-1. `~/.veecontext-desktop/workspaces.json` stores workspace metadata (name, path, lastOpened)
+1. `~/.frozenink/workspaces.json` stores workspace metadata (name, path, lastOpened)
 2. On launch, auto-opens the last workspace (or shows a welcome screen)
-3. `process.env.VEECONTEXT_HOME` is set to the workspace path before any core module is loaded
+3. `process.env.FROZENINK_HOME` is set to the workspace path before any core module is loaded
 4. The API server is started bound to that workspace
-5. **Switching workspaces restarts the API server** — the main process calls `stop()` on the current server, updates `VEECONTEXT_HOME`, and creates a new server. Brief loading screen during the switch.
+5. **Switching workspaces restarts the API server** — the main process calls `stop()` on the current server, updates `FROZENINK_HOME`, and creates a new server. Brief loading screen during the switch.
 
-Each workspace is a standard VeeContext home directory (same structure as CLI's `~/.veecontext/`), so CLI and desktop can operate on the same data.
+Each workspace is a standard Frozen Ink home directory (same structure as CLI's `~/.frozenink/`), so CLI and desktop can operate on the same data.
 
 ### Progress Reporting Pattern
 
@@ -153,8 +153,8 @@ For publish specifically, the core logic is in `publishCollections(options, onPr
 ### Adding a New Crawler
 
 1. Create `packages/crawlers/src/<name>/types.ts` with config and credential interfaces
-2. Create `packages/crawlers/src/<name>/crawler.ts` implementing the `Crawler` interface from `@veecontext/core`
-   - Use `createCryptoHasher()` from `@veecontext/core` for hashing (NOT `Bun.CryptoHasher`)
+2. Create `packages/crawlers/src/<name>/crawler.ts` implementing the `Crawler` interface from `@frozenink/core`
+   - Use `createCryptoHasher()` from `@frozenink/core` for hashing (NOT `Bun.CryptoHasher`)
 3. Create `packages/crawlers/src/<name>/theme.ts` implementing the `Theme` interface (markdown generator)
 4. Register in `packages/crawlers/src/index.ts`: add to `createDefaultRegistry()` and export the theme
 5. Update `packages/cli/src/commands/add.ts` with crawler-specific CLI flags
@@ -179,7 +179,7 @@ interface Crawler {
 
 ### Collection Registry (context.yml)
 
-VeeContext uses `~/.veecontext/context.yml` as the collection registry (replacing the previous `master.db`). The file is managed by `packages/core/src/config/context.ts` with atomic writes and Zod validation.
+Frozen Ink uses `~/.frozenink/context.yml` as the collection registry (replacing the previous `master.db`). The file is managed by `packages/core/src/config/context.ts` with atomic writes and Zod validation.
 
 ```yaml
 collections:
@@ -208,13 +208,13 @@ deployments:
 
 Key functions: `loadContext()`, `saveContext()`, `getCollection()`, `listCollections()`, `addCollection()`, `getCollectionDbPath()`, `addDeployment()`, `getDeployment()`.
 
-Collection DB path is inferred: `~/.veecontext/collections/{name}/data.db` (no explicit `dbPath` stored).
+Collection DB path is inferred: `~/.frozenink/collections/{name}/data.db` (no explicit `dbPath` stored).
 
 ### SQLite Schema
 
 Each collection has its own SQLite database.
 
-#### Collection DBs (`~/.veecontext/collections/<name>/data.db`)
+#### Collection DBs (`~/.frozenink/collections/<name>/data.db`)
 
 ```sql
 entities
@@ -294,14 +294,15 @@ Tables are created via raw SQL `CREATE IF NOT EXISTS` in `client.ts` (no migrati
 | Rendered markdown files | Filesystem (`collections/<name>/markdown/`) | Large, rebuildable from DB data |
 | Attachment binary files | Filesystem (`collections/<name>/attachments/`) | Large binaries, served by HTTP |
 | FTS search index | Collection DB (`entities_fts` virtual table) | SQLite FTS5 for fast text search |
-| Desktop workspace list | `~/.veecontext-desktop/workspaces.json` | App-level metadata, not per-workspace |
+| Desktop workspace list | `~/.frozenink/workspaces.json` | App-level metadata, not per-workspace |
 
 ### Filesystem Layout
 
 ```
-~/.veecontext/                               -- default workspace (CLI)
+~/.frozenink/                               -- default workspace (CLI + desktop)
   config.json                                -- app configuration
   context.yml                                -- collection registry + deployment metadata
+  workspaces.json                            -- desktop app workspace registry
   collections/
     <name>/
       data.db                                -- collection database (entities, sync state, etc.)
@@ -312,16 +313,13 @@ Tables are created via raw SQL `CREATE IF NOT EXISTS` in `client.ts` (no migrati
       attachments/                           -- binary files (images, etc.)
         images/photo.png
         git/abc1234/logo.png
-
-~/.veecontext-desktop/                       -- desktop app metadata (NOT a workspace)
-  workspaces.json                            -- { workspaces: [{ name, path, lastOpened }], lastWorkspace }
 ```
 
-A workspace is any directory with a `context.yml` and `collections/` subdirectory. The CLI defaults to `~/.veecontext/`. The desktop app can create and switch between multiple workspaces at arbitrary paths, each functioning as an independent `VEECONTEXT_HOME`.
+A workspace is any directory with a `context.yml` and `collections/` subdirectory. The CLI defaults to `~/.frozenink/`. The desktop app can create and switch between multiple workspaces at arbitrary paths, each functioning as an independent `FROZENINK_HOME`.
 
 ### Publishing to Cloudflare
 
-The `vctx publish` command uses the `wrangler` CLI for all Cloudflare operations. Authentication is handled by wrangler — run `wrangler login` once, or set `CLOUDFLARE_API_TOKEN`. No API tokens or account IDs are passed on the command line.
+The `fink publish` command uses the `wrangler` CLI for all Cloudflare operations. Authentication is handled by wrangler — run `wrangler login` once, or set `CLOUDFLARE_API_TOKEN`. No API tokens or account IDs are passed on the command line.
 
 Three CF resources are created per deployment:
 
@@ -334,7 +332,7 @@ The publish flow:
 - Files are uploaded via `wrangler r2 object put`
 - Worker is deployed by generating a temp `wrangler.toml` and running `wrangler deploy --config`
 
-Re-running `vctx publish --name <existing>` **updates** an existing deployment:
+Re-running `fink publish --name <existing>` **updates** an existing deployment:
 - D1 tables are dropped and recreated with fresh data
 - R2 files are uploaded, then stale files are detected via the `r2_manifest` D1 table and deleted
 - Worker is redeployed with the same bindings
@@ -345,7 +343,7 @@ The worker implements MCP via direct JSON-RPC (not the SDK's StreamableHTTPServe
 
 | Scenario | Command |
 |----------|---------|
-| Changed crawler data, synced new entities | Full publish: `vctx publish <collections...> --name <name>` |
+| Changed crawler data, synced new entities | Full publish: `fink publish <collections...> --name <name>` |
 | Changed `packages/worker/src/**` (server logic, HTML rendering, routes) | Worker-only (after rebuild): see below |
 | Changed `packages/ui/src/**` (React components, CSS) | Worker-only (after rebuild): see below |
 | Changed `packages/crawlers/src/mantisbt/theme.ts` (HTML renderer) | Worker-only — HTML is rendered on-the-fly by the worker at request time, not pre-stored |
@@ -384,7 +382,7 @@ cd packages/worker && bun run build  # esbuild worker bundle
 
 ### Desktop App Build
 
-The Electron desktop app lives in `packages/desktop/`. It uses esbuild to bundle all TypeScript (main process + all `@veecontext/*` workspace packages) into a single ESM file (`dist/main/index.mjs`) that Electron loads directly.
+The Electron desktop app lives in `packages/desktop/`. It uses esbuild to bundle all TypeScript (main process + all `@frozenink/*` workspace packages) into a single ESM file (`dist/main/index.mjs`) that Electron loads directly.
 
 ```bash
 bun install                           # install all workspace deps (from repo root, NOT npm)
@@ -413,7 +411,7 @@ See `packages/desktop/electron-builder.yml` for build targets (macOS DMG, Window
 
 ### Important Conventions
 
-- Package names: `@veecontext/<name>` with `workspace:*` for inter-package deps
+- Package names: `@frozenink/<name>` with `workspace:*` for inter-package deps
 - TypeScript: strict mode, ESNext target, bundler module resolution, project references with `composite: true`
 - Tests: `bun:test` for all packages except UI which uses `vitest` with `happy-dom`
 - Test files: `src/__tests__/*.test.ts` — excluded from tsc dist output via tsconfig `exclude`
@@ -422,11 +420,11 @@ See `packages/desktop/electron-builder.yml` for build targets (macOS DMG, Window
 - Desktop package: separate tsconfig with `module: "commonjs"`, `target: "ES2022"` for Electron
 - DB: WAL journal mode, foreign keys ON, JSON columns via `text(..., { mode: "json" })`
 - Attachment `storagePath`: use optional field to override default `attachments/{externalId}/{filename}` path
-- Markdown generators use helpers from `@veecontext/core`: `frontmatter()`, `wikilink()`, `callout()`, `embed()`
-- Hashing: always use `createCryptoHasher()` from `@veecontext/core`, never `Bun.CryptoHasher` directly
-- Subprocesses: use `spawnProcess()` / `spawnDetached()` from `@veecontext/core`, never `Bun.spawn` directly
-- Module paths: use `getModuleDir(import.meta.url)` from `@veecontext/core`, never `import.meta.dir`
-- New subpath exports in `core` (like `@veecontext/core/export`) require both a barrel `index.ts` and a matching entry in `packages/core/package.json` `exports` field
+- Markdown generators use helpers from `@frozenink/core`: `frontmatter()`, `wikilink()`, `callout()`, `embed()`
+- Hashing: always use `createCryptoHasher()` from `@frozenink/core`, never `Bun.CryptoHasher` directly
+- Subprocesses: use `spawnProcess()` / `spawnDetached()` from `@frozenink/core`, never `Bun.spawn` directly
+- Module paths: use `getModuleDir(import.meta.url)` from `@frozenink/core`, never `import.meta.dir`
+- New subpath exports in `core` (like `@frozenink/core/export`) require both a barrel `index.ts` and a matching entry in `packages/core/package.json` `exports` field
 - UI management components live in `packages/ui/src/components/manage/` — CSS uses existing CSS variable system (--bg, --text, --accent, etc.) from App.css
 
 ## Key Files
@@ -462,7 +460,7 @@ See `packages/desktop/electron-builder.yml` for build targets (macOS DMG, Window
 - Never use `Bun.CryptoHasher`, `Bun.spawn`, `bun:sqlite`, or `import.meta.dir` directly in `packages/core` or `packages/crawlers` — use the compat layer (`createCryptoHasher()`, `spawnProcess()`, `openDatabase()`, `getModuleDir()`)
 - `db/client.ts` uses `require()` not `import()` for drizzle driver selection — this is intentional (sync function)
 - When importing within `packages/core/src/`, use specific file paths (e.g., `../config/loader` not `../config/context`) — barrel re-exports can cause "Export not found" errors if the target module doesn't actually export that symbol
-- The `@veecontext/core/export` subpath requires a matching `exports` entry in `packages/core/package.json`
+- The `@frozenink/core/export` subpath requires a matching `exports` entry in `packages/core/package.json`
 - `better-sqlite3` must be rebuilt for Electron's Node ABI using `npx @electron/rebuild -m .` — without this you get `NODE_MODULE_VERSION` mismatch errors at runtime
 
 ### Server / API
@@ -471,7 +469,7 @@ See `packages/desktop/electron-builder.yml` for build targets (macOS DMG, Window
 - Sync/publish/export progress uses polling (500ms), not SSE/WebSocket — the in-memory state objects reset when the server restarts
 
 ### Desktop App
-- The Electron main process sets `process.env.VEECONTEXT_HOME` before importing any `@veecontext/core` modules — module-level code in core reads this env var via `getVeeContextHome()`
+- The Electron main process sets `process.env.FROZENINK_HOME` before importing any `@frozenink/core` modules — module-level code in core reads this env var via `getFrozenInkHome()`
 - Switching workspaces restarts the API server (creates a new `http.createServer` or `Bun.serve`). The old server must be stopped first or the port will conflict
 - `packages/desktop/tsconfig.json` uses `module: "commonjs"` because Electron's main process expects CJS
 
@@ -488,7 +486,7 @@ See `packages/desktop/electron-builder.yml` for build targets (macOS DMG, Window
 
 ## REST API Endpoints
 
-Served by `vctx serve` locally, or by the Cloudflare Worker when published:
+Served by `fink serve` locally, or by the Cloudflare Worker when published:
 
 | Endpoint | Description |
 |----------|-------------|

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# VeeContext
+# Frozen Ink
 
-VeeContext is a local data aggregation tool that crawls multiple sources (GitHub repositories, Obsidian vaults, Git repos, MantisBT), syncs their content into a local SQLite database, renders navigable Obsidian-compatible markdown, and serves everything through a web UI and Model Context Protocol (MCP) server for AI coding assistants.
+Frozen Ink is a local data aggregation tool that crawls multiple sources (GitHub repositories, Obsidian vaults, Git repos, MantisBT), syncs their content into a local SQLite database, renders navigable Obsidian-compatible markdown, and serves everything through a web UI and Model Context Protocol (MCP) server for AI coding assistants.
 
 Collections can also be **published to Cloudflare** as a password-protected website with remote MCP access, or managed through a **cross-platform desktop app** (Electron).
 
@@ -35,17 +35,17 @@ Data Sources (GitHub API, Obsidian Vault, Git Repo, MantisBT, ...)
 
 | Package | Description |
 |---------|-------------|
-| [`@veecontext/core`](packages/core/) | Shared types, Drizzle ORM + SQLite schemas, sync engine, FTS5 search, config loader, context.yml management, runtime compat layer, static export |
-| [`@veecontext/crawlers`](packages/crawlers/) | Data source crawlers and markdown generators |
-| [`@veecontext/mcp`](packages/mcp/) | MCP server with tools and resources for AI assistants |
-| [`@veecontext/cli`](packages/cli/) | CLI (`vctx`) for init, add, sync, search, serve, daemon, publish, unpublish; management API |
-| [`@veecontext/ui`](packages/ui/) | Vite + React web UI with 6 display themes, browse + management modes |
-| [`@veecontext/worker`](packages/worker/) | Cloudflare Worker for published deployments (Hono + D1 + R2) |
-| [`@veecontext/desktop`](packages/desktop/) | Electron desktop app with workspace management, system tray |
+| [`@frozenink/core`](packages/core/) | Shared types, Drizzle ORM + SQLite schemas, sync engine, FTS5 search, config loader, context.yml management, runtime compat layer, static export |
+| [`@frozenink/crawlers`](packages/crawlers/) | Data source crawlers and markdown generators |
+| [`@frozenink/mcp`](packages/mcp/) | MCP server with tools and resources for AI assistants |
+| [`@frozenink/cli`](packages/cli/) | CLI (`fink`) for init, add, sync, search, serve, daemon, publish, unpublish; management API |
+| [`@frozenink/ui`](packages/ui/) | Vite + React web UI with 6 display themes, browse + management modes |
+| [`@frozenink/worker`](packages/worker/) | Cloudflare Worker for published deployments (Hono + D1 + R2) |
+| [`@frozenink/desktop`](packages/desktop/) | Electron desktop app with workspace management, system tray |
 
 ## Crawlers
 
-Each crawler syncs a different data source into VeeContext. See individual docs for setup and details:
+Each crawler syncs a different data source into Frozen Ink. See individual docs for setup and details:
 
 | Crawler | Source | Entities | Docs |
 |---------|--------|----------|------|
@@ -62,28 +62,28 @@ All commands below run from the **repository root**. No global install required.
 # Install dependencies
 bun install
 
-# Initialize VeeContext (~/.veecontext/)
-bun run vctx -- init
+# Initialize Frozen Ink (~/.frozenink/)
+bun run fink -- init
 ```
 
 ### Adding collections
 
 **Obsidian vault** — syncs all markdown notes and attachments:
 ```bash
-bun run vctx -- add obsidian --name my-vault --path ~/Documents/MyVault
+bun run fink -- add obsidian --name my-vault --path ~/Documents/MyVault
 ```
 
 **Git repository** — syncs commits, branches, and tags:
 ```bash
-bun run vctx -- add git --name my-repo --path ~/projects/my-repo
+bun run fink -- add git --name my-repo --path ~/projects/my-repo
 
 # Include full commit diffs in the rendered markdown:
-bun run vctx -- add git --name my-repo --path ~/projects/my-repo --include-diffs
+bun run fink -- add git --name my-repo --path ~/projects/my-repo --include-diffs
 ```
 
 **GitHub repository** — syncs issues and pull requests via the GitHub API:
 ```bash
-bun run vctx -- add github --name my-gh \
+bun run fink -- add github --name my-gh \
   --token ghp_yourPersonalAccessToken \
   --owner your-username \
   --repo your-repo-name
@@ -93,18 +93,18 @@ bun run vctx -- add github --name my-gh \
 
 ```bash
 # Sync a single collection
-bun run vctx -- sync my-vault
+bun run fink -- sync my-vault
 
 # Sync all collections
-bun run vctx -- sync "*"
+bun run fink -- sync "*"
 
 # Check sync status
-bun run vctx -- status
+bun run fink -- status
 
 # Start the background daemon (syncs on the configured interval)
-bun run vctx -- daemon start
-bun run vctx -- daemon status
-bun run vctx -- daemon stop
+bun run fink -- daemon start
+bun run fink -- daemon status
+bun run fink -- daemon stop
 ```
 
 ### Running the web UI
@@ -117,13 +117,13 @@ bun run dev
 bun run serve
 
 # MCP server only (for AI assistants, no web UI)
-bun run vctx -- serve --mcp-only
+bun run fink -- serve --mcp-only
 ```
 
-> **Optional: install `vctx` globally** to drop the `bun run vctx --` prefix:
+> **Optional: install `fink` globally** to drop the `bun run fink --` prefix:
 > ```bash
 > cd packages/cli && bun link && cd ../..
-> vctx sync "*"   # works from anywhere
+> fink sync "*"   # works from anywhere
 > ```
 
 ### Publishing to Cloudflare
@@ -136,14 +136,14 @@ bun run build:ui
 cd packages/worker && bun run build && cd ../..
 
 # Publish
-bun run vctx -- publish my-github my-notes --password secret123 --name my-pub
+bun run fink -- publish my-github my-notes --password secret123 --name my-pub
 
 # Update (re-sync locally first, then re-publish with same --name)
-bun run vctx -- sync "*"
-bun run vctx -- publish my-github my-notes --password secret123 --name my-pub
+bun run fink -- sync "*"
+bun run fink -- publish my-github my-notes --password secret123 --name my-pub
 
 # Unpublish
-bun run vctx -- unpublish my-pub
+bun run fink -- unpublish my-pub
 ```
 
 See [docs/publish.md](docs/publish.md) for full details.
@@ -166,7 +166,7 @@ cd packages/desktop
 bun run start
 ```
 
-`bun run start` runs two steps: compiles TypeScript to JavaScript via esbuild (bundling all `@veecontext/*` workspace packages inline), then launches Electron.
+`bun run start` runs two steps: compiles TypeScript to JavaScript via esbuild (bundling all `@frozenink/*` workspace packages inline), then launches Electron.
 
 **Packaging for distribution:**
 
@@ -205,19 +205,19 @@ curl -X POST http://localhost:3747/api/export \
 
 | Command | Description |
 |---------|-------------|
-| `vctx init` | Initialize `~/.veecontext/` directory and config |
-| `vctx add <type>` | Add a new collection (github, obsidian, git, mantisbt) |
-| `vctx sync <name\|"*">` | Sync a collection or all (`"*"`) |
-| `vctx status` | Show sync status for all collections |
-| `vctx search <query>` | Full-text search across all collections |
-| `vctx collections list\|remove\|enable\|disable\|rename\|update` | Manage collections |
-| `vctx config get\|set\|list` | View/edit configuration |
-| `vctx generate <name\|"*">` | Re-generate markdown without re-syncing |
-| `vctx index <name\|"*">` | Rebuild search index and links |
-| `vctx serve` | Start API server + MCP server |
-| `vctx daemon start\|stop\|status` | Background sync daemon |
-| `vctx publish <collections...>` | Publish to Cloudflare (see [docs/publish.md](docs/publish.md)) |
-| `vctx unpublish <name>` | Remove a Cloudflare deployment |
+| `fink init` | Initialize `~/.frozenink/` directory and config |
+| `fink add <type>` | Add a new collection (github, obsidian, git, mantisbt) |
+| `fink sync <name\|"*">` | Sync a collection or all (`"*"`) |
+| `fink status` | Show sync status for all collections |
+| `fink search <query>` | Full-text search across all collections |
+| `fink collections list\|remove\|enable\|disable\|rename\|update` | Manage collections |
+| `fink config get\|set\|list` | View/edit configuration |
+| `fink generate <name\|"*">` | Re-generate markdown without re-syncing |
+| `fink index <name\|"*">` | Rebuild search index and links |
+| `fink serve` | Start API server + MCP server |
+| `fink daemon start\|stop\|status` | Background sync daemon |
+| `fink publish <collections...>` | Publish to Cloudflare (see [docs/publish.md](docs/publish.md)) |
+| `fink unpublish <name>` | Remove a Cloudflare deployment |
 
 ## Web UI
 
@@ -250,21 +250,21 @@ Exposes 5 tools and 4 resources for AI assistants:
 
 **Tools:** `collection_list`, `entity_search`, `entity_get_data`, `entity_get_markdown`, `entity_get_attachment`
 
-**Resources:** `veecontext://collections`, `veecontext://collections/{name}`, `veecontext://entities/{collection}/{externalId}`, `veecontext://markdown/{collection}/{+path}`
+**Resources:** `frozenink://collections`, `frozenink://collections/{name}`, `frozenink://entities/{collection}/{externalId}`, `frozenink://markdown/{collection}/{+path}`
 
 ## Development
 
 ```bash
-# Install the vctx CLI globally (one-time)
+# Install the fink CLI globally (one-time)
 cd packages/cli && bun link && cd ../..
 
 # Dev server: API on :3000 + Vite hot reload on :5173
 bun run dev
 
 # Run any CLI command during development
-vctx sync "*"
-vctx status
-vctx search "my query"
+fink sync "*"
+fink status
+fink search "my query"
 
 # Build UI for production
 bun run build:ui
@@ -293,7 +293,7 @@ packages/
   core/           Shared types, DB schemas, sync engine, search, config, compat layer, export
   crawlers/       GitHub, Obsidian, Git, and MantisBT crawlers + markdown generators
   mcp/            MCP server (tools + resources)
-  cli/            CLI entry point (vctx) + management API
+  cli/            CLI entry point (fink) + management API
   ui/             Vite + React web viewer (browse + manage modes)
   worker/         Cloudflare Worker for published deployments
   desktop/        Electron desktop app

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "veecontext",
+      "name": "frozenink",
       "devDependencies": {
         "bun-types": "^1.3.11",
         "drizzle-kit": "^0.31.10",
@@ -12,21 +12,21 @@
       },
     },
     "packages/cli": {
-      "name": "@veecontext/cli",
+      "name": "@frozenink/cli",
       "version": "0.1.0",
       "bin": {
-        "vctx": "src/index.ts",
+        "fink": "src/index.ts",
       },
       "dependencies": {
-        "@veecontext/core": "workspace:*",
-        "@veecontext/crawlers": "workspace:*",
-        "@veecontext/mcp": "workspace:*",
+        "@frozenink/core": "workspace:*",
+        "@frozenink/crawlers": "workspace:*",
+        "@frozenink/mcp": "workspace:*",
         "commander": "^13.0.0",
         "drizzle-orm": "^0.39.0",
       },
     },
     "packages/core": {
-      "name": "@veecontext/core",
+      "name": "@frozenink/core",
       "version": "0.1.0",
       "dependencies": {
         "drizzle-orm": "^0.39.0",
@@ -38,15 +38,15 @@
       },
     },
     "packages/crawlers": {
-      "name": "@veecontext/crawlers",
+      "name": "@frozenink/crawlers",
       "version": "0.1.0",
       "dependencies": {
-        "@veecontext/core": "workspace:*",
+        "@frozenink/core": "workspace:*",
         "gemoji": "^8.1.0",
       },
     },
     "packages/desktop": {
-      "name": "@veecontext/desktop",
+      "name": "@frozenink/desktop",
       "version": "0.1.0",
       "dependencies": {
         "better-sqlite3": "^11.0.0",
@@ -59,18 +59,18 @@
       },
     },
     "packages/mcp": {
-      "name": "@veecontext/mcp",
+      "name": "@frozenink/mcp",
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
-        "@veecontext/core": "workspace:*",
-        "@veecontext/crawlers": "workspace:*",
+        "@frozenink/core": "workspace:*",
+        "@frozenink/crawlers": "workspace:*",
         "drizzle-orm": "^0.39.0",
         "zod": "^3.24.0",
       },
     },
     "packages/ui": {
-      "name": "@veecontext/ui",
+      "name": "@frozenink/ui",
       "version": "0.1.0",
       "dependencies": {
         "highlight.js": "^11.11.1",
@@ -93,11 +93,11 @@
       },
     },
     "packages/worker": {
-      "name": "@veecontext/worker",
+      "name": "@frozenink/worker",
       "version": "0.1.0",
       "dependencies": {
-        "@veecontext/core": "workspace:*",
-        "@veecontext/crawlers": "workspace:*",
+        "@frozenink/core": "workspace:*",
+        "@frozenink/crawlers": "workspace:*",
         "hono": "^4.0.0",
       },
       "devDependencies": {
@@ -448,19 +448,19 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@veecontext/cli": ["@veecontext/cli@workspace:packages/cli"],
+    "@frozenink/cli": ["@frozenink/cli@workspace:packages/cli"],
 
-    "@veecontext/core": ["@veecontext/core@workspace:packages/core"],
+    "@frozenink/core": ["@frozenink/core@workspace:packages/core"],
 
-    "@veecontext/crawlers": ["@veecontext/crawlers@workspace:packages/crawlers"],
+    "@frozenink/crawlers": ["@frozenink/crawlers@workspace:packages/crawlers"],
 
-    "@veecontext/desktop": ["@veecontext/desktop@workspace:packages/desktop"],
+    "@frozenink/desktop": ["@frozenink/desktop@workspace:packages/desktop"],
 
-    "@veecontext/mcp": ["@veecontext/mcp@workspace:packages/mcp"],
+    "@frozenink/mcp": ["@frozenink/mcp@workspace:packages/mcp"],
 
-    "@veecontext/ui": ["@veecontext/ui@workspace:packages/ui"],
+    "@frozenink/ui": ["@frozenink/ui@workspace:packages/ui"],
 
-    "@veecontext/worker": ["@veecontext/worker@workspace:packages/worker"],
+    "@frozenink/worker": ["@frozenink/worker@workspace:packages/worker"],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -1604,7 +1604,7 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "@veecontext/worker/esbuild": ["esbuild@0.24.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.24.2", "@esbuild/android-arm": "0.24.2", "@esbuild/android-arm64": "0.24.2", "@esbuild/android-x64": "0.24.2", "@esbuild/darwin-arm64": "0.24.2", "@esbuild/darwin-x64": "0.24.2", "@esbuild/freebsd-arm64": "0.24.2", "@esbuild/freebsd-x64": "0.24.2", "@esbuild/linux-arm": "0.24.2", "@esbuild/linux-arm64": "0.24.2", "@esbuild/linux-ia32": "0.24.2", "@esbuild/linux-loong64": "0.24.2", "@esbuild/linux-mips64el": "0.24.2", "@esbuild/linux-ppc64": "0.24.2", "@esbuild/linux-riscv64": "0.24.2", "@esbuild/linux-s390x": "0.24.2", "@esbuild/linux-x64": "0.24.2", "@esbuild/netbsd-arm64": "0.24.2", "@esbuild/netbsd-x64": "0.24.2", "@esbuild/openbsd-arm64": "0.24.2", "@esbuild/openbsd-x64": "0.24.2", "@esbuild/sunos-x64": "0.24.2", "@esbuild/win32-arm64": "0.24.2", "@esbuild/win32-ia32": "0.24.2", "@esbuild/win32-x64": "0.24.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA=="],
+    "@frozenink/worker/esbuild": ["esbuild@0.24.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.24.2", "@esbuild/android-arm": "0.24.2", "@esbuild/android-arm64": "0.24.2", "@esbuild/android-x64": "0.24.2", "@esbuild/darwin-arm64": "0.24.2", "@esbuild/darwin-x64": "0.24.2", "@esbuild/freebsd-arm64": "0.24.2", "@esbuild/freebsd-x64": "0.24.2", "@esbuild/linux-arm": "0.24.2", "@esbuild/linux-arm64": "0.24.2", "@esbuild/linux-ia32": "0.24.2", "@esbuild/linux-loong64": "0.24.2", "@esbuild/linux-mips64el": "0.24.2", "@esbuild/linux-ppc64": "0.24.2", "@esbuild/linux-riscv64": "0.24.2", "@esbuild/linux-s390x": "0.24.2", "@esbuild/linux-x64": "0.24.2", "@esbuild/netbsd-arm64": "0.24.2", "@esbuild/netbsd-x64": "0.24.2", "@esbuild/openbsd-arm64": "0.24.2", "@esbuild/openbsd-x64": "0.24.2", "@esbuild/sunos-x64": "0.24.2", "@esbuild/win32-arm64": "0.24.2", "@esbuild/win32-ia32": "0.24.2", "@esbuild/win32-x64": "0.24.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA=="],
 
     "accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -1766,55 +1766,55 @@
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "@veecontext/worker/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.24.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA=="],
+    "@frozenink/worker/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.24.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA=="],
 
-    "@veecontext/worker/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.24.2", "", { "os": "android", "cpu": "arm" }, "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q=="],
+    "@frozenink/worker/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.24.2", "", { "os": "android", "cpu": "arm" }, "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q=="],
 
-    "@veecontext/worker/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.24.2", "", { "os": "android", "cpu": "arm64" }, "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg=="],
+    "@frozenink/worker/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.24.2", "", { "os": "android", "cpu": "arm64" }, "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg=="],
 
-    "@veecontext/worker/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.24.2", "", { "os": "android", "cpu": "x64" }, "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw=="],
+    "@frozenink/worker/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.24.2", "", { "os": "android", "cpu": "x64" }, "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw=="],
 
-    "@veecontext/worker/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.24.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA=="],
+    "@frozenink/worker/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.24.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA=="],
 
-    "@veecontext/worker/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.24.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA=="],
+    "@frozenink/worker/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.24.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA=="],
 
-    "@veecontext/worker/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.24.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg=="],
+    "@frozenink/worker/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.24.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg=="],
 
-    "@veecontext/worker/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.24.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q=="],
+    "@frozenink/worker/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.24.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q=="],
 
-    "@veecontext/worker/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.24.2", "", { "os": "linux", "cpu": "arm" }, "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA=="],
+    "@frozenink/worker/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.24.2", "", { "os": "linux", "cpu": "arm" }, "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA=="],
 
-    "@veecontext/worker/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.24.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg=="],
+    "@frozenink/worker/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.24.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg=="],
 
-    "@veecontext/worker/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.24.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw=="],
+    "@frozenink/worker/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.24.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw=="],
 
-    "@veecontext/worker/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ=="],
+    "@frozenink/worker/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ=="],
 
-    "@veecontext/worker/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw=="],
+    "@frozenink/worker/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw=="],
 
-    "@veecontext/worker/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.24.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw=="],
+    "@frozenink/worker/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.24.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw=="],
 
-    "@veecontext/worker/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q=="],
+    "@frozenink/worker/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q=="],
 
-    "@veecontext/worker/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.24.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw=="],
+    "@frozenink/worker/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.24.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw=="],
 
-    "@veecontext/worker/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.24.2", "", { "os": "linux", "cpu": "x64" }, "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q=="],
+    "@frozenink/worker/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.24.2", "", { "os": "linux", "cpu": "x64" }, "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q=="],
 
-    "@veecontext/worker/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.24.2", "", { "os": "none", "cpu": "arm64" }, "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw=="],
+    "@frozenink/worker/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.24.2", "", { "os": "none", "cpu": "arm64" }, "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw=="],
 
-    "@veecontext/worker/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.24.2", "", { "os": "none", "cpu": "x64" }, "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw=="],
+    "@frozenink/worker/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.24.2", "", { "os": "none", "cpu": "x64" }, "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw=="],
 
-    "@veecontext/worker/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.24.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A=="],
+    "@frozenink/worker/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.24.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A=="],
 
-    "@veecontext/worker/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.24.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA=="],
+    "@frozenink/worker/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.24.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA=="],
 
-    "@veecontext/worker/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.24.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig=="],
+    "@frozenink/worker/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.24.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig=="],
 
-    "@veecontext/worker/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.24.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ=="],
+    "@frozenink/worker/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.24.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ=="],
 
-    "@veecontext/worker/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.24.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA=="],
+    "@frozenink/worker/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.24.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA=="],
 
-    "@veecontext/worker/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg=="],
+    "@frozenink/worker/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg=="],
 
     "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-VeeContext follows a layered architecture where data flows from external sources through crawlers into a local SQLite database, and is then served to AI assistants via the Model Context Protocol.
+Frozen Ink follows a layered architecture where data flows from external sources through crawlers into a local SQLite database, and is then served to AI assistants via the Model Context Protocol.
 
 ```
 External Services (GitHub, Linear, Slack, ...)
@@ -31,7 +31,7 @@ External Services (GitHub, Linear, Slack, ...)
 
 ## Packages
 
-### @veecontext/core
+### @frozenink/core
 
 The foundation package. Contains:
 
@@ -40,7 +40,7 @@ The foundation package. Contains:
 - **Domain types** - TypeScript types derived from Zod schemas
 - **Database utilities** - Connection management, migrations
 
-### @veecontext/crawlers
+### @frozenink/crawlers
 
 Each crawler implements a common interface to:
 
@@ -49,7 +49,7 @@ Each crawler implements a common interface to:
 3. Transform data into normalized core types
 4. Write results to the local database
 
-### @veecontext/mcp
+### @frozenink/mcp
 
 Implements a Model Context Protocol server that:
 
@@ -57,7 +57,7 @@ Implements a Model Context Protocol server that:
 - Serves resources representing project state
 - Runs as a stdio-based server for editor integration
 
-### @veecontext/cli
+### @frozenink/cli
 
 Entry point for users. Provides commands for:
 
@@ -67,7 +67,7 @@ Entry point for users. Provides commands for:
 - `daemon` - Background sync management
 - `status` - View sync status
 
-### @veecontext/ui
+### @frozenink/ui
 
 Terminal UI built for real-time monitoring of sync operations and browsing aggregated context.
 

--- a/docs/crawlers.md
+++ b/docs/crawlers.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Crawlers are the data ingestion layer of VeeContext. Each crawler syncs data from an external service into the local SQLite database, normalizing it into a common schema.
+Crawlers are the data ingestion layer of Frozen Ink. Each crawler syncs data from an external service into the local SQLite database, normalizing it into a common schema.
 
 ## Crawler Interface
 
@@ -40,4 +40,4 @@ This ensures efficient operation even with large data volumes.
 
 ## Configuration
 
-Crawlers are configured per-project in a `.veecontext/config.json` file. Each crawler entry specifies authentication credentials (via environment variables) and crawler-specific options like which repositories or channels to sync.
+Crawlers are configured per-project in a `.frozenink/config.json` file. Each crawler entry specifies authentication credentials (via environment variables) and crawler-specific options like which repositories or channels to sync.

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,8 +1,8 @@
 # Publishing Collections to Cloudflare
 
-VeeContext can publish one or more collections as a read-only, password-protected website on Cloudflare Workers with remote MCP access.
+Frozen Ink can publish one or more collections as a read-only, password-protected website on Cloudflare Workers with remote MCP access.
 
-Sync and collection management remain local. Publishing uploads a snapshot. To update, re-sync locally then re-run `vctx publish`.
+Sync and collection management remain local. Publishing uploads a snapshot. To update, re-sync locally then re-run `fink publish`.
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@ Sync and collection management remain local. Publishing uploads a snapshot. To u
 
 ## Authentication
 
-VeeContext uses the `wrangler` CLI for all Cloudflare operations. Authenticate with one of:
+Frozen Ink uses the `wrangler` CLI for all Cloudflare operations. Authenticate with one of:
 
 ```bash
 # Option 1: Interactive OAuth login (recommended)
@@ -34,20 +34,20 @@ bun run build:ui
 cd packages/worker && bun run build && cd ../..
 
 # Publish one or more collections
-vctx publish my-github my-notes --password secret123 --name my-pub
+fink publish my-github my-notes --password secret123 --name my-pub
 ```
 
 Options:
 - `--password <password>` — Password to protect all access (recommended)
-- `--name <name>` — Worker name (default: `vctx-<first-collection>-<random>`)
+- `--name <name>` — Worker name (default: `fink-<first-collection>-<random>`)
 
 ## Updating a Published Deployment
 
 Re-sync your local data, then publish again with the same `--name`:
 
 ```bash
-vctx sync "*"
-vctx publish my-github my-notes --password secret123 --name my-pub
+fink sync "*"
+fink publish my-github my-notes --password secret123 --name my-pub
 ```
 
 This replaces the D1 database contents, uploads new R2 files, and removes stale files that no longer exist locally.
@@ -63,7 +63,7 @@ A logout button appears at the bottom of the sidebar.
 ### Claude Code
 
 ```bash
-claude mcp add veecontext --transport streamable-http \
+claude mcp add frozenink --transport streamable-http \
   --url https://my-pub.yoursubdomain.workers.dev/mcp \
   --header "Authorization: Bearer <password>"
 ```
@@ -75,7 +75,7 @@ Add to your MCP config:
 ```json
 {
   "mcpServers": {
-    "veecontext": {
+    "frozenink": {
       "url": "https://my-pub.yoursubdomain.workers.dev/mcp",
       "transport": "streamable-http",
       "headers": {
@@ -97,7 +97,7 @@ Add to your MCP config:
 ## Unpublishing
 
 ```bash
-vctx unpublish my-pub
+fink unpublish my-pub
 ```
 
 This deletes the Cloudflare Worker, D1 database, and R2 bucket. Use `--force` to skip confirmation.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-VeeContext supports theming for the terminal UI dashboard, allowing users to customize the visual appearance to match their terminal environment and preferences.
+Frozen Ink supports theming for the terminal UI dashboard, allowing users to customize the visual appearance to match their terminal environment and preferences.
 
 ## Default Theme
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "veecontext",
+  "name": "frozenink",
   "private": true,
   "workspaces": [
     "packages/*"
   ],
   "scripts": {
-    "vctx": "bun run packages/cli/src/index.ts",
+    "fink": "bun run packages/cli/src/index.ts",
     "dev": "bun run packages/cli/src/index.ts serve --ui-only --port 3000 & bun run --cwd packages/ui dev",
     "build:ui": "bun run --cwd packages/ui build",
     "serve": "bun run build:ui && bun run packages/cli/src/index.ts serve --ui-only",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,20 +1,20 @@
 {
-  "name": "@veecontext/cli",
+  "name": "@frozenink/cli",
   "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "bin": {
-    "vctx": "src/index.ts"
+    "fink": "src/index.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@veecontext/crawlers": "workspace:*",
-    "@veecontext/core": "workspace:*",
-    "@veecontext/mcp": "workspace:*",
+    "@frozenink/crawlers": "workspace:*",
+    "@frozenink/core": "workspace:*",
+    "@frozenink/mcp": "workspace:*",
     "commander": "^13.0.0",
     "drizzle-orm": "^0.39.0"
   }

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -9,18 +9,18 @@ import {
   addCollection,
   getCollection,
   listCollections,
-} from "@veecontext/core";
+} from "@frozenink/core";
 
 const TEST_DIR = join(import.meta.dir, ".test-cli");
 
 beforeEach(() => {
   mkdirSync(TEST_DIR, { recursive: true });
-  process.env.VEECONTEXT_HOME = TEST_DIR;
+  process.env.FROZENINK_HOME = TEST_DIR;
 });
 
 afterEach(() => {
   rmSync(TEST_DIR, { recursive: true, force: true });
-  delete process.env.VEECONTEXT_HOME;
+  delete process.env.FROZENINK_HOME;
 });
 
 describe("CLI: init", () => {
@@ -43,7 +43,7 @@ describe("CLI: init", () => {
     expect(existsSync(join(TEST_DIR, "context.yml"))).toBe(true);
     expect(existsSync(join(TEST_DIR, "collections"))).toBe(true);
     expect(listCollections()).toHaveLength(0);
-    expect(logs.some((l) => l.includes("Initialized VeeContext"))).toBe(true);
+    expect(logs.some((l) => l.includes("Initialized Frozen Ink"))).toBe(true);
   });
 
   it("skips if already initialized", async () => {

--- a/packages/cli/src/__tests__/daemon-serve.test.ts
+++ b/packages/cli/src/__tests__/daemon-serve.test.ts
@@ -15,18 +15,18 @@ import {
   SearchIndexer,
   addCollection,
   saveContext,
-} from "@veecontext/core";
+} from "@frozenink/core";
 
 const TEST_DIR = join(import.meta.dir, ".test-daemon-serve");
 
 beforeEach(() => {
   mkdirSync(TEST_DIR, { recursive: true });
-  process.env.VEECONTEXT_HOME = TEST_DIR;
+  process.env.FROZENINK_HOME = TEST_DIR;
 });
 
 afterEach(() => {
   rmSync(TEST_DIR, { recursive: true, force: true });
-  delete process.env.VEECONTEXT_HOME;
+  delete process.env.FROZENINK_HOME;
 });
 
 function initTestEnv() {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -2,15 +2,15 @@ import { Command } from "commander";
 import { mkdirSync } from "fs";
 import { join } from "path";
 import {
-  getVeeContextHome,
+  getFrozenInkHome,
   getCollectionDb,
   isValidCollectionKey,
   contextExists,
   getCollection,
   addCollection,
   getCollectionDbPath,
-} from "@veecontext/core";
-import { createDefaultRegistry } from "@veecontext/crawlers";
+} from "@frozenink/core";
+import { createDefaultRegistry } from "@frozenink/crawlers";
 
 export const addCommand = new Command("add")
   .description("Add a new collection")
@@ -29,7 +29,7 @@ export const addCommand = new Command("add")
   .option("--open-only", "Only sync open issues/PRs, delete closed ones (for github)")
   .action(async (crawlerType: string, opts: Record<string, string>) => {
     if (!contextExists()) {
-      console.error("VeeContext not initialized. Run: vctx init");
+      console.error("Frozen Ink not initialized. Run: fink init");
       process.exit(1);
     }
 
@@ -140,7 +140,7 @@ export const addCommand = new Command("add")
     }
 
     // Create collection directory and database
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
     const collectionDir = join(home, "collections", opts.name);
     mkdirSync(collectionDir, { recursive: true });
     const collectionDbPath = getCollectionDbPath(opts.name);
@@ -160,5 +160,5 @@ export const addCommand = new Command("add")
     const displayName = opts.title ? `${opts.title} (${opts.name})` : opts.name;
     console.log(`Collection "${displayName}" created (${crawlerType})`);
     console.log(`  Database: ${collectionDbPath}`);
-    console.log(`  Run "vctx sync ${opts.name}" to start syncing`);
+    console.log(`  Run "fink sync ${opts.name}" to start syncing`);
   });

--- a/packages/cli/src/commands/collections.ts
+++ b/packages/cli/src/commands/collections.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { existsSync, renameSync, rmSync } from "fs";
 import { join } from "path";
 import {
-  getVeeContextHome,
+  getFrozenInkHome,
   isValidCollectionKey,
   contextExists,
   listCollections,
@@ -11,11 +11,11 @@ import {
   updateCollection,
   renameCollection,
   getCollectionDbPath,
-} from "@veecontext/core";
+} from "@frozenink/core";
 
 function requireInit(): void {
   if (!contextExists()) {
-    console.error("VeeContext not initialized. Run: vctx init");
+    console.error("Frozen Ink not initialized. Run: fink init");
     process.exit(1);
   }
 }
@@ -55,7 +55,7 @@ const removeCommand = new Command("remove")
     }
 
     // Remove collection directory
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
     const collectionDir = join(home, "collections", key);
     if (existsSync(collectionDir)) {
       rmSync(collectionDir, { recursive: true, force: true });
@@ -110,7 +110,7 @@ const renameCommand = new Command("rename")
     }
 
     requireInit();
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
     const col = getCollection(oldKey);
 
     if (!col) {

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,10 +1,10 @@
 import { Command } from "commander";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { getVeeContextHome, loadConfig } from "@veecontext/core";
+import { getFrozenInkHome, loadConfig } from "@frozenink/core";
 
 function getConfigPath(): string {
-  return join(getVeeContextHome(), "config.json");
+  return join(getFrozenInkHome(), "config.json");
 }
 
 function readConfigFile(): Record<string, unknown> {
@@ -86,7 +86,7 @@ const setCommand = new Command("set")
   .action((key: string, value: string) => {
     const configPath = getConfigPath();
     if (!existsSync(configPath)) {
-      console.error("VeeContext not initialized. Run: vctx init");
+      console.error("Frozen Ink not initialized. Run: fink init");
       process.exit(1);
     }
 

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync } from "fs";
 import { join } from "path";
 import { fileURLToPath } from "url";
 import {
-  getVeeContextHome,
+  getFrozenInkHome,
   contextExists,
   listCollections,
   getCollectionDbPath,
@@ -12,11 +12,11 @@ import {
   ThemeEngine,
   LocalStorageBackend,
   spawnDetached,
-} from "@veecontext/core";
-import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme } from "@veecontext/crawlers";
+} from "@frozenink/core";
+import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme } from "@frozenink/crawlers";
 
 function getPidPath(): string {
-  return join(getVeeContextHome(), "daemon.pid");
+  return join(getFrozenInkHome(), "daemon.pid");
 }
 
 function isProcessRunning(pid: number): boolean {
@@ -29,7 +29,7 @@ function isProcessRunning(pid: number): boolean {
 }
 
 async function runSyncLoop(intervalMs: number): Promise<void> {
-  const home = getVeeContextHome();
+  const home = getFrozenInkHome();
 
   const doSync = async () => {
     if (!contextExists()) return;
@@ -87,11 +87,11 @@ const startCommand = new Command("start")
   .description("Start the sync daemon in the background")
   .action(async () => {
     if (!contextExists()) {
-      console.error("VeeContext not initialized. Run: vctx init");
+      console.error("Frozen Ink not initialized. Run: fink init");
       process.exit(1);
     }
 
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
     const pidPath = getPidPath();
 
     // Check if already running
@@ -112,7 +112,7 @@ const startCommand = new Command("start")
     const modulePath = fileURLToPath(import.meta.url);
     const proc = spawnDetached(
       ["bun", "run", modulePath, "__daemon-run", String(intervalMs)],
-      { env: { ...process.env, VEECONTEXT_HOME: home } },
+      { env: { ...process.env, FROZENINK_HOME: home } },
     );
 
     const pid = proc.pid;

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { existsSync } from "fs";
 import { join } from "path";
 import {
-  getVeeContextHome,
+  getFrozenInkHome,
   getCollectionDb,
   contextExists,
   listCollections,
@@ -15,9 +15,9 @@ import {
   LocalStorageBackend,
   SearchIndexer,
   extractWikilinks,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import { eq } from "drizzle-orm";
-import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme, mantisBTTheme } from "@veecontext/crawlers";
+import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme, mantisBTTheme } from "@frozenink/crawlers";
 
 export const generateCommand = new Command("generate")
   .description(
@@ -26,11 +26,11 @@ export const generateCommand = new Command("generate")
   .argument("<collection>", 'Collection name or "*" for all collections')
   .action(async (collection: string) => {
     if (!contextExists()) {
-      console.error("VeeContext not initialized. Run: vctx init");
+      console.error("Frozen Ink not initialized. Run: fink init");
       process.exit(1);
     }
 
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
     let collectionRows = collection === "*"
       ? listCollections()
       : (() => {

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import {
-  getVeeContextHome,
+  getFrozenInkHome,
   getCollectionDb,
   contextExists,
   listCollections,
@@ -13,7 +13,7 @@ import {
   entityLinks,
   SearchIndexer,
   extractWikilinks,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import { eq } from "drizzle-orm";
 
 export const indexCommand = new Command("index")
@@ -23,11 +23,11 @@ export const indexCommand = new Command("index")
   .argument("<collection>", 'Collection name or "*" for all collections')
   .action(async (collection: string) => {
     if (!contextExists()) {
-      console.error("VeeContext not initialized. Run: vctx init");
+      console.error("Frozen Ink not initialized. Run: fink init");
       process.exit(1);
     }
 
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
     let collectionRows = collection === "*"
       ? listCollections()
       : (() => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,15 +1,15 @@
 import { Command } from "commander";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
-import { getVeeContextHome, defaultConfig, saveContext } from "@veecontext/core";
+import { getFrozenInkHome, defaultConfig, saveContext } from "@frozenink/core";
 
 export const initCommand = new Command("init")
-  .description("Initialize VeeContext directory and configuration")
+  .description("Initialize Frozen Ink directory and configuration")
   .action(() => {
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
 
     if (existsSync(join(home, "context.yml"))) {
-      console.log(`VeeContext already initialized at ${home}`);
+      console.log(`Frozen Ink already initialized at ${home}`);
       return;
     }
 
@@ -28,7 +28,7 @@ export const initCommand = new Command("init")
     // Create collections directory
     mkdirSync(join(home, "collections"), { recursive: true });
 
-    console.log(`Initialized VeeContext at ${home}`);
+    console.log(`Initialized Frozen Ink at ${home}`);
     console.log(`  config.json  - configuration`);
     console.log(`  context.yml  - collection registry`);
     console.log(`  collections/ - collection data`);

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -6,7 +6,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import {
-  getVeeContextHome,
+  getFrozenInkHome,
   getCollectionDb,
   listCollections,
   getCollection,
@@ -23,14 +23,14 @@ import {
   LocalStorageBackend,
   syncRuns,
   entities,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import {
   createDefaultRegistry,
   gitHubTheme,
   obsidianTheme,
   gitTheme,
   mantisBTTheme,
-} from "@veecontext/crawlers";
+} from "@frozenink/crawlers";
 import { desc, eq } from "drizzle-orm";
 
 // --- In-memory sync/publish/export progress tracking ---
@@ -138,7 +138,7 @@ export function handleManagementRequest(req: Request): Response | null {
     return jsonResponse({
       mode: appMode,
       version: "0.1.0",
-      workspacePath: getVeeContextHome(),
+      workspacePath: getFrozenInkHome(),
     });
   }
 
@@ -159,7 +159,7 @@ export function handleManagementRequest(req: Request): Response | null {
       addCollection(name, { title, crawler, enabled, config, credentials });
 
       // Ensure collection directory exists
-      const home = getVeeContextHome();
+      const home = getFrozenInkHome();
       const colDir = join(home, "collections", name);
       mkdirSync(join(colDir, "markdown"), { recursive: true });
 
@@ -291,7 +291,7 @@ export function handleManagementRequest(req: Request): Response | null {
   if (deleteDepMatch && method === "DELETE") {
     const name = decodeURIComponent(deleteDepMatch[1]);
     return handleAsync(async () => {
-      const { getDeployment: getDeploymentEntry } = await import("@veecontext/core");
+      const { getDeployment: getDeploymentEntry } = await import("@frozenink/core");
       const deployment = getDeploymentEntry(name);
       if (!deployment) return errorResponse("Deployment not found", 404);
 
@@ -317,7 +317,7 @@ export function handleManagementRequest(req: Request): Response | null {
       }
 
       // Dynamic import to avoid circular deps
-      const { exportStaticSite } = await import("@veecontext/core/export");
+      const { exportStaticSite } = await import("@frozenink/core/export");
       exportProgress = { active: true, step: "starting", current: 0, total: 0, error: null };
       try {
         await exportStaticSite({
@@ -353,7 +353,7 @@ export function handleManagementRequest(req: Request): Response | null {
   if (path === "/api/config" && method === "PATCH") {
     return handleAsync(async () => {
       const body = await readBody(req);
-      const home = getVeeContextHome();
+      const home = getFrozenInkHome();
       const configPath = join(home, "config.json");
 
       let existing: Record<string, unknown> = {};
@@ -371,7 +371,7 @@ export function handleManagementRequest(req: Request): Response | null {
 
   // GET /api/preferences
   if (path === "/api/preferences" && method === "GET") {
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
     const configPath = join(home, "config.json");
     let prefs: Record<string, unknown> = {};
     if (existsSync(configPath)) {
@@ -387,7 +387,7 @@ export function handleManagementRequest(req: Request): Response | null {
   if (path === "/api/preferences" && method === "PATCH") {
     return handleAsync(async () => {
       const body = await readBody(req);
-      const home = getVeeContextHome();
+      const home = getFrozenInkHome();
       const configPath = join(home, "config.json");
 
       let existing: Record<string, unknown> = {};
@@ -404,7 +404,7 @@ export function handleManagementRequest(req: Request): Response | null {
 
   // GET /api/publish-presets
   if (path === "/api/publish-presets" && method === "GET") {
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
     const configPath = join(home, "config.json");
     let presets: unknown[] = [];
     if (existsSync(configPath)) {
@@ -421,7 +421,7 @@ export function handleManagementRequest(req: Request): Response | null {
     return handleAsync(async () => {
       const body = await readBody(req);
       const presets = body.presets as unknown[];
-      const home = getVeeContextHome();
+      const home = getFrozenInkHome();
       const configPath = join(home, "config.json");
 
       let existing: Record<string, unknown> = {};
@@ -479,7 +479,7 @@ function handleAsync(fn: () => Promise<Response>): Response {
 // --- Sync logic ---
 
 async function triggerSync(collectionNames: string[], full: boolean): Promise<void> {
-  const home = getVeeContextHome();
+  const home = getFrozenInkHome();
   const registry = createDefaultRegistry();
   const themeEngine = createThemeEngine();
 
@@ -527,7 +527,7 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
           const dbPath = getCollectionDbPath(name);
           if (existsSync(dbPath)) {
             const colDb = getCollectionDb(dbPath);
-            colDb.delete(require("@veecontext/core").syncState).run();
+            colDb.delete(require("@frozenink/core").syncState).run();
           }
         }
 

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { existsSync, readFileSync, readdirSync } from "fs";
 import { join, extname } from "path";
 import {
-  getVeeContextHome,
+  getFrozenInkHome,
   getCollectionDb,
   contextExists,
   getCollection,
@@ -16,7 +16,7 @@ import {
   getModuleDir,
   resolveWorkerBundle,
   resolveUiDist,
-} from "@veecontext/core";
+} from "@frozenink/core";
 
 const __moduleDir = getModuleDir(import.meta.url);
 import { eq } from "drizzle-orm";
@@ -128,7 +128,7 @@ export async function publishCollections(
     collectionNames = existingDeployment.collections;
   }
 
-  const home = getVeeContextHome();
+  const home = getFrozenInkHome();
 
   // Validate collections
   if (!workerOnly) {
@@ -456,7 +456,7 @@ export const publishCommand = new Command("publish")
   .description("Publish collections to Cloudflare as a password-protected website with MCP access")
   .argument("[collections...]", "Collection names to publish")
   .option("--password <password>", "Password to protect access")
-  .option("--name <name>", "Worker name (default: vctx-<first-collection>-<random>)")
+  .option("--name <name>", "Worker name (default: fink-<first-collection>-<random>)")
   .option("--worker-only", "Deploy worker code only (skip D1/R2 data upload); requires --name for an existing deployment")
   .action(async (collectionNamesArg: string[], opts: {
     password?: string;
@@ -465,7 +465,7 @@ export const publishCommand = new Command("publish")
   }) => {
     try {
       if (!contextExists()) {
-        console.error("VeeContext not initialized. Run: vctx init");
+        console.error("Frozen Ink not initialized. Run: fink init");
         process.exit(1);
       }
 
@@ -481,7 +481,7 @@ export const publishCommand = new Command("publish")
         process.exit(1);
       }
 
-      const workerName = opts.name || `vctx-${collectionNames[0]}-${randomSuffix()}`;
+      const workerName = opts.name || `fink-${collectionNames[0]}-${randomSuffix()}`;
 
       const result = await publishCollections(
         { collectionNames, workerName, password: opts.password, workerOnly },
@@ -498,7 +498,7 @@ export const publishCommand = new Command("publish")
       console.log(`MCP URL: ${result.mcpUrl}`);
       if (opts.password) {
         console.log(`\nMCP Setup (Claude Code):`);
-        console.log(`  claude mcp add veecontext --transport streamable-http \\`);
+        console.log(`  claude mcp add frozenink --transport streamable-http \\`);
         console.log(`    --url ${result.mcpUrl} \\`);
         console.log(`    --header "Authorization: Bearer <password>"`);
       }

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -7,7 +7,7 @@ import {
   getCollectionDbPath,
   SearchIndexer,
   type SearchResult,
-} from "@veecontext/core";
+} from "@frozenink/core";
 
 export const searchCommand = new Command("search")
   .description("Search across synced content")
@@ -27,7 +27,7 @@ export const searchCommand = new Command("search")
       },
     ) => {
       if (!contextExists()) {
-        console.error("VeeContext not initialized. Run: vctx init");
+        console.error("Frozen Ink not initialized. Run: fink init");
         process.exit(1);
       }
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { existsSync, readdirSync, statSync, readFileSync } from "fs";
 import { join, extname } from "path";
 import {
-  getVeeContextHome,
+  getFrozenInkHome,
   getCollectionDb,
   contextExists,
   listCollections,
@@ -17,14 +17,14 @@ import {
   getModuleDir,
   isBun,
   resolveUiDist,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import {
   gitHubTheme,
   obsidianTheme,
   gitTheme,
   mantisBTTheme,
-} from "@veecontext/crawlers";
-import { startStdioServer } from "@veecontext/mcp";
+} from "@frozenink/crawlers";
+import { startStdioServer } from "@frozenink/mcp";
 import { eq, desc, like } from "drizzle-orm";
 import { handleManagementRequest, setAppMode } from "./management-api";
 
@@ -692,10 +692,10 @@ export const serveCommand = new Command("serve")
   .option("--ui-only", "Start only the REST API server (no MCP)")
   .option("--port <port>", "Port for the REST API server")
   .action(async (opts: { mcpOnly?: boolean; uiOnly?: boolean; port?: string }) => {
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
 
     if (!contextExists()) {
-      console.error("VeeContext not initialized. Run: vctx init");
+      console.error("Frozen Ink not initialized. Run: fink init");
       process.exit(1);
     }
 
@@ -703,20 +703,20 @@ export const serveCommand = new Command("serve")
     const port = opts.port ? parseInt(opts.port, 10) : config.ui.port;
 
     if (opts.mcpOnly) {
-      console.error("Starting VeeContext MCP server (STDIO)...");
-      await startStdioServer({ veecontextHome: home });
+      console.error("Starting Frozen Ink MCP server (STDIO)...");
+      await startStdioServer({ frozeninkHome: home });
       return;
     }
 
     if (opts.uiOnly) {
       const server = await Promise.resolve(createApiServer(home, port));
-      console.log(`VeeContext API server running on http://localhost:${server.port}`);
+      console.log(`Frozen Ink API server running on http://localhost:${server.port}`);
       return;
     }
 
     // Start both
     const server = await Promise.resolve(createApiServer(home, port));
-    console.log(`VeeContext API server running on http://localhost:${server.port}`);
-    console.error("Starting VeeContext MCP server (STDIO)...");
-    await startStdioServer({ veecontextHome: home });
+    console.log(`Frozen Ink API server running on http://localhost:${server.port}`);
+    console.error("Starting Frozen Ink MCP server (STDIO)...");
+    await startStdioServer({ frozeninkHome: home });
   });

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -7,21 +7,21 @@ import {
   getCollectionDbPath,
   entities,
   syncRuns,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import { desc } from "drizzle-orm";
 
 export const statusCommand = new Command("status")
   .description("Show sync status for all collections")
   .action(() => {
     if (!contextExists()) {
-      console.error("VeeContext not initialized. Run: vctx init");
+      console.error("Frozen Ink not initialized. Run: fink init");
       process.exit(1);
     }
 
     const collectionRows = listCollections();
 
     if (collectionRows.length === 0) {
-      console.log("No collections configured. Run: vctx add <crawler>");
+      console.log("No collections configured. Run: fink add <crawler>");
       return;
     }
 

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { existsSync } from "fs";
 import { join } from "path";
 import {
-  getVeeContextHome,
+  getFrozenInkHome,
   getCollectionDb,
   contextExists,
   listCollections,
@@ -18,9 +18,9 @@ import {
   attachments,
   entityLinks,
   entityRelations,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import { sql } from "drizzle-orm";
-import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme, mantisBTTheme } from "@veecontext/crawlers";
+import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme, mantisBTTheme } from "@frozenink/crawlers";
 
 export const syncCommand = new Command("sync")
   .description("Sync collections")
@@ -31,11 +31,11 @@ export const syncCommand = new Command("sync")
   .option("--max-prs <count>", "Maximum pull requests to sync (overrides collection config)", parseInt)
   .action(async (collection: string, opts: { full?: boolean; max?: number; maxIssues?: number; maxPrs?: number }) => {
     if (!contextExists()) {
-      console.error("VeeContext not initialized. Run: vctx init");
+      console.error("Frozen Ink not initialized. Run: fink init");
       process.exit(1);
     }
 
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
     let collectionRows = collection === "*"
       ? listCollections()
       : (() => {

--- a/packages/cli/src/commands/unpublish.ts
+++ b/packages/cli/src/commands/unpublish.ts
@@ -5,7 +5,7 @@ import {
   getDeployment,
   removeDeployment,
   type DeploymentEntry,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import {
   checkWranglerAuth,
   deleteWorker,
@@ -97,7 +97,7 @@ export const unpublishCommand = new Command("unpublish")
   }) => {
     try {
       if (!contextExists()) {
-        console.error("VeeContext not initialized. Run: vctx init");
+        console.error("Frozen Ink not initialized. Run: fink init");
         process.exit(1);
       }
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -3,7 +3,7 @@ import {
   contextExists,
   getCollection,
   updateCollection,
-} from "@veecontext/core";
+} from "@frozenink/core";
 
 export const updateCommand = new Command("update")
   .description("Update collection configuration")
@@ -16,7 +16,7 @@ export const updateCommand = new Command("update")
   .option("--sync-check-statuses [value]", "Sync check statuses (true/false)")
   .action(async (collection: string, opts: Record<string, unknown>) => {
     if (!contextExists()) {
-      console.error("VeeContext not initialized. Run: vctx init");
+      console.error("Frozen Ink not initialized. Run: fink init");
       process.exit(1);
     }
 
@@ -94,5 +94,5 @@ export const updateCommand = new Command("update")
     for (const change of changes) {
       console.log(`  ${change}`);
     }
-    console.log(`\nRun "vctx sync ${collection} --full" to re-sync with new settings.`);
+    console.log(`\nRun "fink sync ${collection} --full" to re-sync with new settings.`);
   });

--- a/packages/cli/src/commands/wrangler-api.ts
+++ b/packages/cli/src/commands/wrangler-api.ts
@@ -2,7 +2,7 @@ import { join } from "path";
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from "fs";
 import { homedir } from "os";
 import { randomBytes } from "crypto";
-import { getModuleDir, spawnProcess, resolveWrangler as resolveWranglerPath, getVeeContextHome } from "@veecontext/core";
+import { getModuleDir, spawnProcess, resolveWrangler as resolveWranglerPath, getFrozenInkHome } from "@frozenink/core";
 
 const __moduleDir = getModuleDir(import.meta.url);
 
@@ -16,7 +16,7 @@ async function resolveWranglerBin(): Promise<string> {
   // Check user-configured path in workspace config.json
   let configuredPath: string | undefined;
   try {
-    const home = getVeeContextHome();
+    const home = getFrozenInkHome();
     const configPath = join(home, "config.json");
     if (existsSync(configPath)) {
       const config = JSON.parse(readFileSync(configPath, "utf-8"));
@@ -256,7 +256,7 @@ bucket_name = "${config.r2BucketName}"
 
 export function writeTempFile(content: string, extension: string): string {
   const tmpDir = process.env.TMPDIR || "/tmp";
-  const name = `vctx-${randomBytes(6).toString("hex")}${extension}`;
+  const name = `fink-${randomBytes(6).toString("hex")}${extension}`;
   const path = join(tmpDir, name);
   writeFileSync(path, content, "utf-8");
   return path;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,8 +18,8 @@ import { unpublishCommand } from "./commands/unpublish";
 const program = new Command();
 
 program
-  .name("vctx")
-  .description("VeeContext - Local data replica manager")
+  .name("fink")
+  .description("Frozen Ink - Local data replica manager")
   .version("0.1.0");
 
 program.addCommand(initCommand);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@veecontext/core",
+  "name": "@frozenink/core",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/core/src/config/__tests__/config.test.ts
+++ b/packages/core/src/config/__tests__/config.test.ts
@@ -3,15 +3,15 @@ import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { configSchema } from "../schema";
 import { defaultConfig } from "../defaults";
-import { loadConfig, getVeeContextHome } from "../loader";
+import { loadConfig, getFrozenInkHome } from "../loader";
 
 const TEST_DIR = join(import.meta.dir, ".test-config");
 
 beforeEach(() => {
   mkdirSync(TEST_DIR, { recursive: true });
-  // Clear all VEECONTEXT_ env vars
+  // Clear all FROZENINK_ env vars
   for (const key of Object.keys(process.env)) {
-    if (key.startsWith("VEECONTEXT_")) {
+    if (key.startsWith("FROZENINK_")) {
       delete process.env[key];
     }
   }
@@ -20,7 +20,7 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(TEST_DIR, { recursive: true, force: true });
   for (const key of Object.keys(process.env)) {
-    if (key.startsWith("VEECONTEXT_")) {
+    if (key.startsWith("FROZENINK_")) {
       delete process.env[key];
     }
   }
@@ -34,7 +34,7 @@ describe("Config Schema", () => {
       sync: { interval: 600, concurrency: 4, retries: 5 },
       ui: { port: 8080 },
       mcp: { transport: "sse", port: 9090 },
-      logging: { level: "debug", file: "/var/log/veecontext.log" },
+      logging: { level: "debug", file: "/var/log/frozenink.log" },
     });
 
     expect(config.db.mode).toBe("turso");
@@ -46,7 +46,7 @@ describe("Config Schema", () => {
     expect(config.ui.port).toBe(8080);
     expect(config.mcp.transport).toBe("sse");
     expect(config.logging.level).toBe("debug");
-    expect(config.logging.file).toBe("/var/log/veecontext.log");
+    expect(config.logging.file).toBe("/var/log/frozenink.log");
   });
 
   it("applies defaults for empty config", () => {
@@ -110,23 +110,23 @@ describe("Default Config", () => {
   });
 });
 
-describe("getVeeContextHome", () => {
-  it("returns ~/.veecontext by default", () => {
-    delete process.env.VEECONTEXT_HOME;
-    const home = getVeeContextHome();
-    expect(home).toMatch(/\.veecontext$/);
+describe("getFrozenInkHome", () => {
+  it("returns ~/.frozenink by default", () => {
+    delete process.env.FROZENINK_HOME;
+    const home = getFrozenInkHome();
+    expect(home).toMatch(/\.frozenink$/);
   });
 
-  it("respects VEECONTEXT_HOME env var", () => {
-    process.env.VEECONTEXT_HOME = "/custom/path";
-    const home = getVeeContextHome();
+  it("respects FROZENINK_HOME env var", () => {
+    process.env.FROZENINK_HOME = "/custom/path";
+    const home = getFrozenInkHome();
     expect(home).toBe("/custom/path");
   });
 });
 
 describe("Config Loader", () => {
   it("returns defaults when no config file exists", () => {
-    process.env.VEECONTEXT_HOME = join(TEST_DIR, "empty");
+    process.env.FROZENINK_HOME = join(TEST_DIR, "empty");
     mkdirSync(join(TEST_DIR, "empty"), { recursive: true });
 
     const config = loadConfig();
@@ -146,7 +146,7 @@ describe("Config Loader", () => {
       }),
     );
 
-    process.env.VEECONTEXT_HOME = configDir;
+    process.env.FROZENINK_HOME = configDir;
     const config = loadConfig();
 
     // Overridden values
@@ -160,14 +160,14 @@ describe("Config Loader", () => {
     expect(config.sync.concurrency).toBe(2);
   });
 
-  it("applies VEECONTEXT_* env var overrides", () => {
-    process.env.VEECONTEXT_HOME = join(TEST_DIR, "env-test");
+  it("applies FROZENINK_* env var overrides", () => {
+    process.env.FROZENINK_HOME = join(TEST_DIR, "env-test");
     mkdirSync(join(TEST_DIR, "env-test"), { recursive: true });
 
-    process.env.VEECONTEXT_DB_MODE = "turso";
-    process.env.VEECONTEXT_SYNC_INTERVAL = "60";
-    process.env.VEECONTEXT_UI_PORT = "8080";
-    process.env.VEECONTEXT_LOGGING_LEVEL = "debug";
+    process.env.FROZENINK_DB_MODE = "turso";
+    process.env.FROZENINK_SYNC_INTERVAL = "60";
+    process.env.FROZENINK_UI_PORT = "8080";
+    process.env.FROZENINK_LOGGING_LEVEL = "debug";
 
     const config = loadConfig();
 
@@ -185,8 +185,8 @@ describe("Config Loader", () => {
       JSON.stringify({ ui: { port: 4000 } }),
     );
 
-    process.env.VEECONTEXT_HOME = configDir;
-    process.env.VEECONTEXT_UI_PORT = "9999";
+    process.env.FROZENINK_HOME = configDir;
+    process.env.FROZENINK_UI_PORT = "9999";
 
     const config = loadConfig();
     expect(config.ui.port).toBe(9999);
@@ -200,7 +200,7 @@ describe("Config Loader", () => {
       JSON.stringify({ db: { mode: "postgres" } }),
     );
 
-    process.env.VEECONTEXT_HOME = configDir;
+    process.env.FROZENINK_HOME = configDir;
     expect(() => loadConfig()).toThrow();
   });
 });

--- a/packages/core/src/config/context.ts
+++ b/packages/core/src/config/context.ts
@@ -3,7 +3,7 @@ import { join, dirname } from "path";
 import { randomBytes } from "crypto";
 import { z } from "zod";
 import yaml from "js-yaml";
-import { getVeeContextHome } from "./loader";
+import { getFrozenInkHome } from "./loader";
 
 // --- Zod Schemas ---
 
@@ -28,7 +28,7 @@ const deploymentEntrySchema = z.object({
   publishedAt: z.string(),
 });
 
-const veeContextSchema = z.object({
+const frozenInkSchema = z.object({
   collections: z.record(collectionEntrySchema).default({}),
   deployments: z.record(deploymentEntrySchema).default({}),
 });
@@ -38,27 +38,27 @@ const veeContextSchema = z.object({
 export type CollectionEntry = z.infer<typeof collectionEntrySchema>;
 export type CollectionEntryInput = z.input<typeof collectionEntrySchema>;
 export type DeploymentEntry = z.infer<typeof deploymentEntrySchema>;
-export type VeeContextYaml = z.infer<typeof veeContextSchema>;
+export type FrozenInkYaml = z.infer<typeof frozenInkSchema>;
 
 // --- Paths ---
 
 function getContextPath(): string {
-  return join(getVeeContextHome(), "context.yml");
+  return join(getFrozenInkHome(), "context.yml");
 }
 
 // --- Load / Save ---
 
-export function loadContext(): VeeContextYaml {
+export function loadContext(): FrozenInkYaml {
   const contextPath = getContextPath();
   if (!existsSync(contextPath)) {
     return { collections: {}, deployments: {} };
   }
   const raw = readFileSync(contextPath, "utf-8");
   const parsed = yaml.load(raw) as Record<string, unknown> | null;
-  return veeContextSchema.parse(parsed ?? {});
+  return frozenInkSchema.parse(parsed ?? {});
 }
 
-export function saveContext(ctx: VeeContextYaml): void {
+export function saveContext(ctx: FrozenInkYaml): void {
   const contextPath = getContextPath();
   const dir = dirname(contextPath);
   mkdirSync(dir, { recursive: true });
@@ -89,7 +89,7 @@ export function listCollections(): Array<CollectionEntry & { name: string }> {
 }
 
 export function getCollectionDbPath(name: string): string {
-  const home = getVeeContextHome();
+  const home = getFrozenInkHome();
   return join(home, "collections", name, "data.db");
 }
 

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -1,6 +1,6 @@
-import type { VeeContextConfig } from "./schema";
+import type { FrozenInkConfig } from "./schema";
 
-export const defaultConfig: VeeContextConfig = {
+export const defaultConfig: FrozenInkConfig = {
   db: {
     mode: "local",
     tursoUrl: undefined,

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,6 +1,6 @@
-export { configSchema, type VeeContextConfig, type DbConfig, type StorageConfig, type SyncConfig, type UiConfig, type McpConfig, type LoggingConfig } from "./schema";
+export { configSchema, type FrozenInkConfig, type DbConfig, type StorageConfig, type SyncConfig, type UiConfig, type McpConfig, type LoggingConfig } from "./schema";
 export { defaultConfig } from "./defaults";
-export { loadConfig, getVeeContextHome } from "./loader";
+export { loadConfig, getFrozenInkHome } from "./loader";
 export {
   loadContext,
   saveContext,
@@ -19,5 +19,5 @@ export {
   type CollectionEntry,
   type CollectionEntryInput,
   type DeploymentEntry,
-  type VeeContextYaml,
+  type FrozenInkYaml,
 } from "./context";

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -1,11 +1,11 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { configSchema, type VeeContextConfig } from "./schema";
+import { configSchema, type FrozenInkConfig } from "./schema";
 import { defaultConfig } from "./defaults";
 
-export function getVeeContextHome(): string {
-  return process.env.VEECONTEXT_HOME ?? join(homedir(), ".veecontext");
+export function getFrozenInkHome(): string {
+  return process.env.FROZENINK_HOME ?? join(homedir(), ".frozenink");
 }
 
 function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {
@@ -32,24 +32,24 @@ function deepMerge(target: Record<string, unknown>, source: Record<string, unkno
   return result;
 }
 
-const ENV_MAPPING: Record<string, [keyof VeeContextConfig, string]> = {
-  VEECONTEXT_DB_MODE: ["db", "mode"],
-  VEECONTEXT_DB_TURSO_URL: ["db", "tursoUrl"],
-  VEECONTEXT_DB_TURSO_TOKEN: ["db", "tursoToken"],
-  VEECONTEXT_STORAGE_MODE: ["storage", "mode"],
-  VEECONTEXT_STORAGE_S3_BUCKET: ["storage", "s3Bucket"],
-  VEECONTEXT_STORAGE_S3_REGION: ["storage", "s3Region"],
-  VEECONTEXT_STORAGE_S3_ENDPOINT: ["storage", "s3Endpoint"],
-  VEECONTEXT_STORAGE_S3_ACCESS_KEY_ID: ["storage", "s3AccessKeyId"],
-  VEECONTEXT_STORAGE_S3_SECRET_ACCESS_KEY: ["storage", "s3SecretAccessKey"],
-  VEECONTEXT_SYNC_INTERVAL: ["sync", "interval"],
-  VEECONTEXT_SYNC_CONCURRENCY: ["sync", "concurrency"],
-  VEECONTEXT_SYNC_RETRIES: ["sync", "retries"],
-  VEECONTEXT_UI_PORT: ["ui", "port"],
-  VEECONTEXT_MCP_TRANSPORT: ["mcp", "transport"],
-  VEECONTEXT_MCP_PORT: ["mcp", "port"],
-  VEECONTEXT_LOGGING_LEVEL: ["logging", "level"],
-  VEECONTEXT_LOGGING_FILE: ["logging", "file"],
+const ENV_MAPPING: Record<string, [keyof FrozenInkConfig, string]> = {
+  FROZENINK_DB_MODE: ["db", "mode"],
+  FROZENINK_DB_TURSO_URL: ["db", "tursoUrl"],
+  FROZENINK_DB_TURSO_TOKEN: ["db", "tursoToken"],
+  FROZENINK_STORAGE_MODE: ["storage", "mode"],
+  FROZENINK_STORAGE_S3_BUCKET: ["storage", "s3Bucket"],
+  FROZENINK_STORAGE_S3_REGION: ["storage", "s3Region"],
+  FROZENINK_STORAGE_S3_ENDPOINT: ["storage", "s3Endpoint"],
+  FROZENINK_STORAGE_S3_ACCESS_KEY_ID: ["storage", "s3AccessKeyId"],
+  FROZENINK_STORAGE_S3_SECRET_ACCESS_KEY: ["storage", "s3SecretAccessKey"],
+  FROZENINK_SYNC_INTERVAL: ["sync", "interval"],
+  FROZENINK_SYNC_CONCURRENCY: ["sync", "concurrency"],
+  FROZENINK_SYNC_RETRIES: ["sync", "retries"],
+  FROZENINK_UI_PORT: ["ui", "port"],
+  FROZENINK_MCP_TRANSPORT: ["mcp", "transport"],
+  FROZENINK_MCP_PORT: ["mcp", "port"],
+  FROZENINK_LOGGING_LEVEL: ["logging", "level"],
+  FROZENINK_LOGGING_FILE: ["logging", "file"],
 };
 
 const NUMERIC_FIELDS = new Set([
@@ -77,8 +77,8 @@ function applyEnvOverrides(config: Record<string, unknown>): Record<string, unkn
   return result;
 }
 
-export function loadConfig(): VeeContextConfig {
-  const home = getVeeContextHome();
+export function loadConfig(): FrozenInkConfig {
+  const home = getFrozenInkHome();
   const configPath = join(home, "config.json");
 
   let fileConfig: Record<string, unknown> = {};

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -44,7 +44,7 @@ export const configSchema = z.object({
   logging: loggingConfigSchema.default({}),
 });
 
-export type VeeContextConfig = z.infer<typeof configSchema>;
+export type FrozenInkConfig = z.infer<typeof configSchema>;
 export type DbConfig = z.infer<typeof dbConfigSchema>;
 export type StorageConfig = z.infer<typeof storageConfigSchema>;
 export type SyncConfig = z.infer<typeof syncConfigSchema>;

--- a/packages/core/src/export/static-site.ts
+++ b/packages/core/src/export/static-site.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, statSync, readFileSync, mkdirSync, writeFileSync, copyFileSync } from "fs";
 import { join, relative, dirname, extname } from "path";
-import { getVeeContextHome } from "../config/loader";
+import { getFrozenInkHome } from "../config/loader";
 import { getCollection, getCollectionDbPath } from "../config/context";
 import { getCollectionDb } from "../db/client";
 import { entities, entityTags } from "../db/collection-schema";
@@ -20,7 +20,7 @@ export interface ExportOptions {
  */
 export async function exportStaticSite(options: ExportOptions): Promise<void> {
   const { collections, outputDir, format, onProgress } = options;
-  const home = getVeeContextHome();
+  const home = getFrozenInkHome();
 
   mkdirSync(outputDir, { recursive: true });
 
@@ -39,7 +39,7 @@ async function exportMarkdown(
   outputDir: string,
   onProgress?: (step: string, current: number, total: number) => void,
 ): Promise<void> {
-  const indexLines: string[] = ["# VeeContext Export\n"];
+  const indexLines: string[] = ["# Frozen Ink Export\n"];
   let totalFiles = 0;
   let exported = 0;
 
@@ -261,7 +261,7 @@ function generateIndexHtml(
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>VeeContext Export</title>
+<title>Frozen Ink Export</title>
 <style>
   body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; color: #1f2328; }
   a { color: #0969da; text-decoration: none; }
@@ -273,7 +273,7 @@ function generateIndexHtml(
 </style>
 </head>
 <body>
-<h1>VeeContext Export</h1>
+<h1>Frozen Ink Export</h1>
 ${navHtml}
 </body>
 </html>`;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-// @veecontext/core - Shared types, schemas, and database layer
+// @frozenink/core - Shared types, schemas, and database layer
 export * from "./compat";
 export * from "./db";
 export * from "./config";

--- a/packages/crawlers/package.json
+++ b/packages/crawlers/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@veecontext/crawlers",
+  "name": "@frozenink/crawlers",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@veecontext/core": "workspace:*",
+    "@frozenink/core": "workspace:*",
     "gemoji": "^8.1.0"
   }
 }

--- a/packages/crawlers/src/git/README.md
+++ b/packages/crawlers/src/git/README.md
@@ -8,12 +8,12 @@ Crawls a local Git repository, capturing metadata for all commits, branches, and
 
 ```bash
 # Without diffs (metadata only)
-bunx vctx add git \
+bunx fink add git \
   --name my-repo \
   --path /path/to/repo
 
 # With diffs included
-bunx vctx add git \
+bunx fink add git \
   --name my-repo \
   --path /path/to/repo \
   --include-diffs

--- a/packages/crawlers/src/git/__tests__/theme.test.ts
+++ b/packages/crawlers/src/git/__tests__/theme.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { GitTheme } from "../theme";
-import type { ThemeRenderContext } from "@veecontext/core";
+import type { ThemeRenderContext } from "@frozenink/core";
 
 const theme = new GitTheme();
 

--- a/packages/crawlers/src/git/crawler.ts
+++ b/packages/crawlers/src/git/crawler.ts
@@ -7,8 +7,8 @@ import type {
   CrawlerEntityData,
   SyncCursor,
   SyncResult,
-} from "@veecontext/core";
-import { createCryptoHasher } from "@veecontext/core";
+} from "@frozenink/core";
+import { createCryptoHasher } from "@frozenink/core";
 import type {
   GitConfig,
   GitCredentials,

--- a/packages/crawlers/src/git/theme.ts
+++ b/packages/crawlers/src/git/theme.ts
@@ -1,5 +1,5 @@
-import type { Theme, ThemeRenderContext } from "@veecontext/core/theme";
-import { frontmatter, wikilink, callout } from "@veecontext/core/theme";
+import type { Theme, ThemeRenderContext } from "@frozenink/core/theme";
+import { frontmatter, wikilink, callout } from "@frozenink/core/theme";
 
 function slugify(text: string): string {
   return text

--- a/packages/crawlers/src/github/README.md
+++ b/packages/crawlers/src/github/README.md
@@ -15,7 +15,7 @@ Syncs issues, pull requests, and user profiles from a GitHub repository via the 
 ### 2. Add the Collection
 
 ```bash
-vctx add github \
+fink add github \
   --name my-repo \
   --token ghp_xxxxxxxxxxxx \
   --repo my-org/my-repo
@@ -44,29 +44,29 @@ The token is validated against the GitHub API before the collection is created.
 ### 3. Sync
 
 ```bash
-vctx sync my-repo                      # Incremental sync (only changed items)
-vctx sync my-repo --full               # Full re-sync (wipes and re-fetches everything)
-vctx sync my-repo --max 10             # At most 10 issues + 10 PRs
-vctx sync my-repo --max-issues 5       # Limit issues only (no PR limit)
-vctx sync my-repo --max-prs 3          # Limit PRs only (no issue limit)
+fink sync my-repo                      # Incremental sync (only changed items)
+fink sync my-repo --full               # Full re-sync (wipes and re-fetches everything)
+fink sync my-repo --max 10             # At most 10 issues + 10 PRs
+fink sync my-repo --max-issues 5       # Limit issues only (no PR limit)
+fink sync my-repo --max-prs 3          # Limit PRs only (no issue limit)
 ```
 
-The `--max` flag sets both `maxIssues` and `maxPullRequests` to the same value. The `--max-issues` and `--max-prs` flags override individually. All flags on `vctx sync` override the collection's config for that run and work with both incremental and full syncs.
+The `--max` flag sets both `maxIssues` and `maxPullRequests` to the same value. The `--max-issues` and `--max-prs` flags override individually. All flags on `fink sync` override the collection's config for that run and work with both incremental and full syncs.
 
 ### Updating Collection Config
 
 ```bash
-vctx update my-repo --open-only        # Switch to open-only mode
-vctx update my-repo --max 50           # Change max to 50 per type
-vctx update my-repo --open-only false  # Disable open-only mode
+fink update my-repo --open-only        # Switch to open-only mode
+fink update my-repo --max 50           # Change max to 50 per type
+fink update my-repo --open-only false  # Disable open-only mode
 ```
 
-After updating, re-sync with `vctx sync my-repo --full` to apply the new settings.
+After updating, re-sync with `fink sync my-repo --full` to apply the new settings.
 
 ### Example: Sync Only Open Issues
 
 ```bash
-vctx add github \
+fink add github \
   --name my-repo-open \
   --token $GITHUB_TOKEN \
   --repo my-org/my-repo \
@@ -215,7 +215,7 @@ The sync engine computes a SHA-256 hash of each entity's data. If the hash match
 
 ## Configuration
 
-Stored in `~/.veecontext/context.yml`:
+Stored in `~/.frozenink/context.yml`:
 
 ```yaml
 collections:
@@ -249,7 +249,7 @@ collections:
 | `maxIssues` | none | Maximum issues to sync |
 | `maxPullRequests` | none | Maximum pull requests to sync |
 
-To change options after creation, edit `~/.veecontext/context.yml` directly and re-sync.
+To change options after creation, edit `~/.frozenink/context.yml` directly and re-sync.
 
 ## API Rate Limits
 

--- a/packages/crawlers/src/github/__tests__/theme.test.ts
+++ b/packages/crawlers/src/github/__tests__/theme.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { GitHubTheme } from "../theme";
-import type { ThemeRenderContext } from "@veecontext/core";
+import type { ThemeRenderContext } from "@frozenink/core";
 
 const theme = new GitHubTheme();
 

--- a/packages/crawlers/src/github/crawler.ts
+++ b/packages/crawlers/src/github/crawler.ts
@@ -4,7 +4,7 @@ import type {
   CrawlerEntityData,
   SyncCursor,
   SyncResult,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import type {
   GitHubConfig,
   GitHubCredentials,

--- a/packages/crawlers/src/github/theme.ts
+++ b/packages/crawlers/src/github/theme.ts
@@ -1,5 +1,5 @@
-import type { Theme, ThemeRenderContext } from "@veecontext/core/theme";
-import { frontmatter, wikilink, callout } from "@veecontext/core/theme";
+import type { Theme, ThemeRenderContext } from "@frozenink/core/theme";
+import { frontmatter, wikilink, callout } from "@frozenink/core/theme";
 import { gemoji } from "gemoji";
 
 // Build emoji shortcode lookup map once

--- a/packages/crawlers/src/index.ts
+++ b/packages/crawlers/src/index.ts
@@ -1,4 +1,4 @@
-import { CrawlerRegistry } from "@veecontext/core";
+import { CrawlerRegistry } from "@frozenink/core";
 import { GitHubCrawler } from "./github/crawler";
 import { GitHubTheme } from "./github/theme";
 import { ObsidianCrawler } from "./obsidian/crawler";

--- a/packages/crawlers/src/mantisbt/crawler.ts
+++ b/packages/crawlers/src/mantisbt/crawler.ts
@@ -4,8 +4,8 @@ import type {
   CrawlerEntityData,
   SyncCursor,
   SyncResult,
-} from "@veecontext/core";
-import { createCryptoHasher } from "@veecontext/core";
+} from "@frozenink/core";
+import { createCryptoHasher } from "@frozenink/core";
 import type {
   MantisBTConfig,
   MantisBTCredentials,

--- a/packages/crawlers/src/mantisbt/theme.ts
+++ b/packages/crawlers/src/mantisbt/theme.ts
@@ -1,5 +1,5 @@
-import type { Theme, ThemeRenderContext } from "@veecontext/core/theme";
-import { frontmatter, wikilink } from "@veecontext/core/theme";
+import type { Theme, ThemeRenderContext } from "@frozenink/core/theme";
+import { frontmatter, wikilink } from "@frozenink/core/theme";
 
 function slugify(text: string): string {
   return text

--- a/packages/crawlers/src/obsidian/README.md
+++ b/packages/crawlers/src/obsidian/README.md
@@ -7,7 +7,7 @@ Syncs markdown files and attachments from a local Obsidian vault, preserving the
 ## Setup
 
 ```bash
-bunx vctx add obsidian \
+bunx fink add obsidian \
   --name my-vault \
   --path /path/to/vault
 ```

--- a/packages/crawlers/src/obsidian/__tests__/theme.test.ts
+++ b/packages/crawlers/src/obsidian/__tests__/theme.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { ObsidianTheme } from "../theme";
-import type { ThemeRenderContext } from "@veecontext/core";
+import type { ThemeRenderContext } from "@frozenink/core";
 
 const theme = new ObsidianTheme();
 

--- a/packages/crawlers/src/obsidian/crawler.ts
+++ b/packages/crawlers/src/obsidian/crawler.ts
@@ -6,8 +6,8 @@ import type {
   CrawlerEntityData,
   SyncCursor,
   SyncResult,
-} from "@veecontext/core";
-import { createCryptoHasher } from "@veecontext/core";
+} from "@frozenink/core";
+import { createCryptoHasher } from "@frozenink/core";
 import type { ObsidianConfig, ObsidianCredentials, VaultFile } from "./types";
 
 const EXCLUDED_DIRS = new Set([".obsidian", ".trash", ".git", "node_modules"]);

--- a/packages/crawlers/src/obsidian/theme.ts
+++ b/packages/crawlers/src/obsidian/theme.ts
@@ -1,4 +1,4 @@
-import type { Theme, ThemeRenderContext } from "@veecontext/core/theme";
+import type { Theme, ThemeRenderContext } from "@frozenink/core/theme";
 
 export class ObsidianTheme implements Theme {
   crawlerType = "obsidian";

--- a/packages/desktop/build.mjs
+++ b/packages/desktop/build.mjs
@@ -3,7 +3,7 @@
  * Bundles TypeScript source (main process + preload) into JavaScript
  * that Electron's Node.js runtime can load.
  *
- * - Inlines all @veecontext/* workspace packages (they're TypeScript)
+ * - Inlines all @frozenink/* workspace packages (they're TypeScript)
  * - Externalizes electron, better-sqlite3, and Node builtins (native / provided at runtime)
  */
 import { build } from "esbuild";

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -1,5 +1,5 @@
-appId: com.veecontext.desktop
-productName: VeeContext
+appId: com.frozenink.desktop
+productName: Frozen Ink
 copyright: Copyright © 2026
 
 directories:

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@veecontext/desktop",
+  "name": "@frozenink/desktop",
   "version": "0.1.0",
+  "productName": "Frozen Ink",
   "private": true,
   "main": "dist/main/index.mjs",
   "scripts": {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, shell, nativeImage } from "electron";
+import { app, BrowserWindow, ipcMain, shell, nativeImage, Menu } from "electron";
 import { join, dirname } from "path";
 import { existsSync } from "fs";
 import { fileURLToPath } from "url";
@@ -16,7 +16,7 @@ let apiServer: { port: number; stop?: () => void } | null = null;
 
 async function startApiServer(workspacePath: string): Promise<{ port: number; stop?: () => void }> {
   // Set environment before importing core modules
-  process.env.VEECONTEXT_HOME = workspacePath;
+  process.env.FROZENINK_HOME = workspacePath;
 
   setAppMode("desktop");
 
@@ -52,7 +52,7 @@ function createMainWindow(): BrowserWindow {
     height: 800,
     minWidth: 800,
     minHeight: 500,
-    title: "VeeContext",
+    title: "Frozen Ink",
     icon: existsSync(iconPath) ? iconPath : undefined,
     webPreferences: {
       preload: existsSync(preloadPath) ? preloadPath : undefined,
@@ -77,7 +77,41 @@ function createMainWindow(): BrowserWindow {
   return win;
 }
 
+app.name = "Frozen Ink";
+
 app.whenReady().then(async () => {
+  // Build custom application menu so the menu bar shows "Frozen Ink" instead of "Electron".
+  // Using role: "appMenu" would inherit the binary name, so we construct it manually.
+  if (process.platform === "darwin") {
+    const aboutIconPath = join(__desktopDirname, "../../build/icon.png");
+    app.setAboutPanelOptions({
+      applicationName: "Frozen Ink",
+      applicationVersion: "0.1.0",
+      iconPath: aboutIconPath,
+    });
+    Menu.setApplicationMenu(Menu.buildFromTemplate([
+      {
+        label: "Frozen Ink",
+        submenu: [
+          { role: "about", label: "About Frozen Ink" },
+          { type: "separator" },
+          { role: "services" },
+          { type: "separator" },
+          { role: "hide", label: "Hide Frozen Ink" },
+          { role: "hideOthers" },
+          { role: "unhide" },
+          { type: "separator" },
+          { role: "quit", label: "Quit Frozen Ink" },
+        ],
+      },
+      { role: "fileMenu" },
+      { role: "editMenu" },
+      { role: "viewMenu" },
+      { role: "windowMenu" },
+      { role: "help" },
+    ]));
+  }
+
   // Set dock/taskbar icon (macOS dock icon isn't set by BrowserWindow.icon)
   const appIconPath = join(__desktopDirname, "../../build/icon.png");
   if (existsSync(appIconPath)) {
@@ -135,7 +169,7 @@ function showWelcomeScreen() {
     <html>
     <head>
       <meta charset="utf-8">
-      <title>VeeContext</title>
+      <title>Frozen Ink</title>
       <style>
         body {
           font-family: -apple-system, BlinkMacSystemFont, sans-serif;
@@ -177,7 +211,7 @@ function showWelcomeScreen() {
     </head>
     <body>
       <div class="welcome">
-        <h1>VeeContext</h1>
+        <h1>Frozen Ink</h1>
         <p>Choose a workspace to get started</p>
         <div class="actions">
           <button class="btn-primary" onclick="createWorkspace()">Create Workspace</button>
@@ -186,17 +220,17 @@ function showWelcomeScreen() {
       </div>
       <script>
         async function createWorkspace() {
-          const path = await window.veecontext?.openDirectoryPicker();
+          const path = await window.frozenink?.openDirectoryPicker();
           if (!path) return;
           const name = path.split('/').pop() || 'Workspace';
-          await window.veecontext?.createWorkspace(name, path);
-          await window.veecontext?.switchWorkspace(path);
+          await window.frozenink?.createWorkspace(name, path);
+          await window.frozenink?.switchWorkspace(path);
         }
         async function openWorkspace() {
-          const path = await window.veecontext?.openDirectoryPicker();
+          const path = await window.frozenink?.openDirectoryPicker();
           if (!path) return;
-          await window.veecontext?.openWorkspace(path);
-          await window.veecontext?.switchWorkspace(path);
+          await window.frozenink?.openWorkspace(path);
+          await window.frozenink?.switchWorkspace(path);
         }
       </script>
     </body>

--- a/packages/desktop/src/main/tray.ts
+++ b/packages/desktop/src/main/tray.ts
@@ -18,7 +18,7 @@ export function createTray(callbacks: {
     : nativeImage.createEmpty();
 
   tray = new Tray(icon);
-  tray.setToolTip("VeeContext");
+  tray.setToolTip("Frozen Ink");
 
   updateTrayMenu("idle", callbacks);
 
@@ -42,7 +42,7 @@ export function updateTrayMenu(
     },
     { type: "separator" },
     {
-      label: "Open VeeContext",
+      label: "Open Frozen Ink",
       click: callbacks.onShowApp,
     },
     { type: "separator" },

--- a/packages/desktop/src/main/workspace-manager.ts
+++ b/packages/desktop/src/main/workspace-manager.ts
@@ -13,7 +13,7 @@ export interface WorkspacesData {
   lastWorkspace: string | null;
 }
 
-const WORKSPACES_DIR = join(homedir(), ".veecontext-desktop");
+const WORKSPACES_DIR = join(homedir(), ".frozenink");
 const WORKSPACES_FILE = join(WORKSPACES_DIR, "workspaces.json");
 
 function ensureDir() {

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from "electron";
 
-contextBridge.exposeInMainWorld("veecontext", {
+contextBridge.exposeInMainWorld("frozenink", {
   openDirectoryPicker: () => ipcRenderer.invoke("open-directory-picker"),
   getWorkspaces: () => ipcRenderer.invoke("get-workspaces"),
   createWorkspace: (name: string, path: string) =>

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@veecontext/mcp",
+  "name": "@frozenink/mcp",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -9,8 +9,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@veecontext/core": "workspace:*",
-    "@veecontext/crawlers": "workspace:*",
+    "@frozenink/core": "workspace:*",
+    "@frozenink/crawlers": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "drizzle-orm": "^0.39.0",
     "zod": "^3.24.0"

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -10,7 +10,7 @@ import {
   SearchIndexer,
   addCollection as coreAddCollection,
   saveContext,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import { createMcpServer, type McpServerOptions } from "../server";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -22,9 +22,9 @@ let client: Client;
 
 function setupTestEnv() {
   mkdirSync(TEST_DIR, { recursive: true });
-  options = { veecontextHome: TEST_DIR };
-  // Required so getVeeContextHome() / listCollections() / getCollection() etc. resolve to TEST_DIR
-  process.env.VEECONTEXT_HOME = TEST_DIR;
+  options = { frozeninkHome: TEST_DIR };
+  // Required so getFrozenInkHome() / listCollections() / getCollection() etc. resolve to TEST_DIR
+  process.env.FROZENINK_HOME = TEST_DIR;
 
   // Create context.yml (required by contextExists() checks in MCP tools/resources)
   saveContext({ collections: {}, deployments: {} });
@@ -138,7 +138,7 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(TEST_DIR, { recursive: true, force: true });
-  delete process.env.VEECONTEXT_HOME;
+  delete process.env.FROZENINK_HOME;
 });
 
 describe("collection_list tool", () => {
@@ -311,7 +311,7 @@ describe("MCP resources", () => {
     await setupClient();
     const result = await client.listResources();
 
-    const collectionsRes = result.resources.find((r) => r.uri === "veecontext://collections");
+    const collectionsRes = result.resources.find((r) => r.uri === "frozenink://collections");
     expect(collectionsRes).toBeDefined();
   });
 
@@ -319,7 +319,7 @@ describe("MCP resources", () => {
     addCollection("read-col");
 
     await setupClient();
-    const result = await client.readResource({ uri: "veecontext://collections" });
+    const result = await client.readResource({ uri: "frozenink://collections" });
 
     const data = JSON.parse(result.contents[0].text as string);
     expect(data).toHaveLength(1);
@@ -331,7 +331,7 @@ describe("MCP resources", () => {
     addEntity(dbPath, { externalId: "e-1", entityType: "issue", title: "Test", data: {} });
 
     await setupClient();
-    const result = await client.readResource({ uri: "veecontext://collections/detail-col" });
+    const result = await client.readResource({ uri: "frozenink://collections/detail-col" });
 
     const data = JSON.parse(result.contents[0].text as string);
     expect(data.name).toBe("detail-col");
@@ -344,7 +344,7 @@ describe("MCP resources", () => {
     addEntity(dbPath, { externalId: "issue-99", entityType: "issue", title: "Resource entity", data: { number: 99 }, tags: ["test"] });
 
     await setupClient();
-    const result = await client.readResource({ uri: "veecontext://entities/ent-res-col/issue-99" });
+    const result = await client.readResource({ uri: "frozenink://entities/ent-res-col/issue-99" });
 
     const data = JSON.parse(result.contents[0].text as string);
     expect(data.externalId).toBe("issue-99");
@@ -360,7 +360,7 @@ describe("MCP resources", () => {
     writeFileSync(join(collectionDir, "markdown", "issues", "1-test.md"), "# Test Issue\n\nBody content.");
 
     await setupClient();
-    const result = await client.readResource({ uri: "veecontext://markdown/md-res-col/markdown/issues/1-test.md" });
+    const result = await client.readResource({ uri: "frozenink://markdown/md-res-col/markdown/issues/1-test.md" });
 
     expect(result.contents[0].text).toBe("# Test Issue\n\nBody content.");
     expect(result.contents[0].mimeType).toBe("text/markdown");

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,3 +1,3 @@
-// @veecontext/mcp - Model Context Protocol server
+// @frozenink/mcp - Model Context Protocol server
 export { createMcpServer, startStdioServer } from "./server";
 export type { McpServerOptions } from "./server";

--- a/packages/mcp/src/resources/collection.ts
+++ b/packages/mcp/src/resources/collection.ts
@@ -9,7 +9,7 @@ import {
   getCollectionDbPath,
   entities,
   syncRuns,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import { desc } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
 
@@ -20,9 +20,9 @@ export function registerCollectionResources(
   // Static resource: list all collections
   server.registerResource(
     "collections",
-    "veecontext://collections",
+    "frozenink://collections",
     {
-      description: "List of all configured VeeContext collections",
+      description: "List of all configured Frozen Ink collections",
       mimeType: "application/json",
     },
     async () => {
@@ -30,9 +30,9 @@ export function registerCollectionResources(
         return {
           contents: [
             {
-              uri: "veecontext://collections",
+              uri: "frozenink://collections",
               mimeType: "application/json",
-              text: JSON.stringify({ error: "VeeContext not initialized" }),
+              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
             },
           ],
         };
@@ -48,7 +48,7 @@ export function registerCollectionResources(
       return {
         contents: [
           {
-            uri: "veecontext://collections",
+            uri: "frozenink://collections",
             mimeType: "application/json",
             text: JSON.stringify(result),
           },
@@ -59,7 +59,7 @@ export function registerCollectionResources(
 
   // Template resource: single collection details
   const collectionTemplate = new ResourceTemplate(
-    "veecontext://collections/{name}",
+    "frozenink://collections/{name}",
     {
       list: async () => {
         if (!contextExists()) return { resources: [] };
@@ -68,7 +68,7 @@ export function registerCollectionResources(
 
         return {
           resources: rows.map((col) => ({
-            uri: `veecontext://collections/${col.name}`,
+            uri: `frozenink://collections/${col.name}`,
             name: col.name,
             description: `${col.crawler} collection: ${col.name}`,
             mimeType: "application/json",
@@ -82,7 +82,7 @@ export function registerCollectionResources(
     "collection",
     collectionTemplate,
     {
-      description: "Details for a specific VeeContext collection",
+      description: "Details for a specific Frozen Ink collection",
       mimeType: "application/json",
     },
     async (uri, variables) => {
@@ -94,7 +94,7 @@ export function registerCollectionResources(
             {
               uri: uri.toString(),
               mimeType: "application/json",
-              text: JSON.stringify({ error: "VeeContext not initialized" }),
+              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
             },
           ],
         };

--- a/packages/mcp/src/resources/entity.ts
+++ b/packages/mcp/src/resources/entity.ts
@@ -9,7 +9,7 @@ import {
   getCollectionDbPath,
   entities,
   entityTags,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import { eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
 
@@ -19,7 +19,7 @@ export function registerEntityResources(
 ): void {
   // Template resource: entity by collection and externalId
   const entityTemplate = new ResourceTemplate(
-    "veecontext://entities/{collection}/{externalId}",
+    "frozenink://entities/{collection}/{externalId}",
     {
       list: undefined,
     },
@@ -43,7 +43,7 @@ export function registerEntityResources(
             {
               uri: uri.toString(),
               mimeType: "application/json",
-              text: JSON.stringify({ error: "VeeContext not initialized" }),
+              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
             },
           ],
         };
@@ -118,7 +118,7 @@ export function registerEntityResources(
 
   // Template resource: markdown by collection and path
   const markdownTemplate = new ResourceTemplate(
-    "veecontext://markdown/{collection}/{+path}",
+    "frozenink://markdown/{collection}/{+path}",
     {
       list: undefined,
     },
@@ -141,7 +141,7 @@ export function registerEntityResources(
             {
               uri: uri.toString(),
               mimeType: "text/plain",
-              text: "VeeContext not initialized",
+              text: "Frozen Ink not initialized",
             },
           ],
         };
@@ -161,7 +161,7 @@ export function registerEntityResources(
       }
 
       const collectionDir = join(
-        options.veecontextHome,
+        options.frozeninkHome,
         "collections",
         collectionName,
       );

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -9,18 +9,18 @@ import { registerCollectionResources } from "./resources/collection";
 import { registerEntityResources } from "./resources/entity";
 
 export interface McpServerOptions {
-  veecontextHome: string;
+  frozeninkHome: string;
 }
 
 export function createMcpServer(options: McpServerOptions): McpServer {
   const server = new McpServer(
     {
-      name: "veecontext",
+      name: "frozenink",
       version: "0.1.0",
     },
     {
       instructions:
-        "VeeContext MCP server. Provides collection and entity retrieval tools over synced collections for LLM clients.",
+        "Frozen Ink MCP server. Provides collection and entity retrieval tools over synced collections for LLM clients.",
     },
   );
 

--- a/packages/mcp/src/tools/get-attachment.ts
+++ b/packages/mcp/src/tools/get-attachment.ts
@@ -9,7 +9,7 @@ import {
   getCollectionDbPath,
   entities,
   attachments,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import { and, eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
 
@@ -104,7 +104,7 @@ export function registerGetAttachment(
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify({ error: "VeeContext not initialized" }),
+              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
             },
           ],
         };
@@ -248,7 +248,7 @@ export function registerGetAttachment(
         };
       }
 
-      const collectionDir = join(options.veecontextHome, "collections", args.collection);
+      const collectionDir = join(options.frozeninkHome, "collections", args.collection);
       const fullPath = join(collectionDir, attachmentRow.storagePath);
       const normalizedCollectionDir = join(collectionDir, "/");
       if (!join(fullPath, "/").startsWith(normalizedCollectionDir)) {

--- a/packages/mcp/src/tools/get-entity.ts
+++ b/packages/mcp/src/tools/get-entity.ts
@@ -9,7 +9,7 @@ import {
   getCollectionDbPath,
   entities,
   entityTags,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import { eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
 
@@ -35,7 +35,7 @@ export function registerGetEntity(
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify({ error: "VeeContext not initialized" }),
+              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
             },
           ],
         };
@@ -97,7 +97,7 @@ export function registerGetEntity(
       let markdown: string | null = null;
       if (entity.markdownPath) {
         const collectionDir = join(
-          options.veecontextHome,
+          options.frozeninkHome,
           "collections",
           args.collection,
         );

--- a/packages/mcp/src/tools/get-markdown.ts
+++ b/packages/mcp/src/tools/get-markdown.ts
@@ -8,7 +8,7 @@ import {
   getCollectionDb,
   getCollectionDbPath,
   entities,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import { eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
 
@@ -34,7 +34,7 @@ export function registerGetMarkdown(
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify({ error: "VeeContext not initialized" }),
+              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
             },
           ],
         };
@@ -99,7 +99,7 @@ export function registerGetMarkdown(
         };
       }
 
-      const collectionDir = join(options.veecontextHome, "collections", args.collection);
+      const collectionDir = join(options.frozeninkHome, "collections", args.collection);
       const markdownPath = join(collectionDir, entity.markdownPath);
 
       if (!existsSync(markdownPath)) {

--- a/packages/mcp/src/tools/list-collections.ts
+++ b/packages/mcp/src/tools/list-collections.ts
@@ -7,7 +7,7 @@ import {
   getCollectionDbPath,
   entities,
   syncRuns,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import { desc } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
 
@@ -29,7 +29,7 @@ export function registerListCollections(
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify({ error: "VeeContext not initialized" }),
+              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
             },
           ],
         };

--- a/packages/mcp/src/tools/search.ts
+++ b/packages/mcp/src/tools/search.ts
@@ -8,7 +8,7 @@ import {
   getCollectionDbPath,
   SearchIndexer,
   type SearchResult,
-} from "@veecontext/core";
+} from "@frozenink/core";
 import type { McpServerOptions } from "../server";
 
 export function registerSearch(
@@ -47,7 +47,7 @@ export function registerSearch(
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify({ error: "VeeContext not initialized" }),
+              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
             },
           ],
         };

--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <title>VeeContext</title>
+    <title>Frozen Ink</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@veecontext/ui",
+  "name": "@frozenink/ui",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -20,7 +20,7 @@ import type { Collection, TreeNode, AppInfo, UIMode } from "./types";
 
 function loadTheme(): ThemeId {
   try {
-    const stored = localStorage.getItem("veecontext-theme");
+    const stored = localStorage.getItem("frozenink-theme");
     if (stored) return stored as ThemeId;
   } catch {}
   return "default";
@@ -28,29 +28,29 @@ function loadTheme(): ThemeId {
 
 function applyTheme(theme: ThemeId) {
   document.documentElement.setAttribute("data-theme", theme);
-  try { localStorage.setItem("veecontext-theme", theme); } catch {}
+  try { localStorage.setItem("frozenink-theme", theme); } catch {}
 }
 
 
 function loadSidebarWidth(): number {
   try {
-    const stored = localStorage.getItem("veecontext-sidebar-width");
+    const stored = localStorage.getItem("frozenink-sidebar-width");
     if (stored) return Math.max(160, Math.min(600, Number(stored)));
   } catch {}
   return 280;
 }
 
 function saveSidebarWidth(width: number) {
-  try { localStorage.setItem("veecontext-sidebar-width", String(width)); } catch {}
+  try { localStorage.setItem("frozenink-sidebar-width", String(width)); } catch {}
   savePreferenceToServer("sidebarWidth", width);
 }
 
 function loadLastCollection(): string | null {
-  try { return localStorage.getItem("veecontext-collection") ?? null; } catch { return null; }
+  try { return localStorage.getItem("frozenink-collection") ?? null; } catch { return null; }
 }
 
 function saveLastCollection(name: string) {
-  try { localStorage.setItem("veecontext-collection", name); } catch {}
+  try { localStorage.setItem("frozenink-collection", name); } catch {}
   savePreferenceToServer("lastCollection", name);
 }
 
@@ -61,13 +61,13 @@ interface SavedTabs {
 
 function loadCollectionTabs(collection: string): SavedTabs | null {
   try {
-    const raw = localStorage.getItem(`veecontext-tabs:${collection}`);
+    const raw = localStorage.getItem(`frozenink-tabs:${collection}`);
     return raw ? JSON.parse(raw) : null;
   } catch { return null; }
 }
 
 function saveCollectionTabs(collection: string, tabs: { file: string }[], activeFile: string | null) {
-  try { localStorage.setItem(`veecontext-tabs:${collection}`, JSON.stringify({ tabs, activeFile })); } catch {}
+  try { localStorage.setItem(`frozenink-tabs:${collection}`, JSON.stringify({ tabs, activeFile })); } catch {}
   savePreferenceToServer(`tabs:${collection}`, { tabs, activeFile });
 }
 
@@ -119,14 +119,14 @@ function useIsMobile(breakpoint = 768) {
 
 function loadUIMode(): UIMode {
   try {
-    const stored = localStorage.getItem("veecontext-ui-mode");
+    const stored = localStorage.getItem("frozenink-ui-mode");
     if (stored === "manage") return "manage";
   } catch {}
   return "browse";
 }
 
 function saveUIMode(mode: UIMode) {
-  try { localStorage.setItem("veecontext-ui-mode", mode); } catch {}
+  try { localStorage.setItem("frozenink-ui-mode", mode); } catch {}
 }
 
 export default function App() {
@@ -243,13 +243,13 @@ export default function App() {
         setSelectedCollection((prev) => prev ?? (prefs.lastCollection as string));
       }
       // Hydrate localStorage with server values so subsequent reads work
-      if (prefs.theme) try { localStorage.setItem("veecontext-theme", prefs.theme as string); } catch {}
-      if (prefs.lastCollection) try { localStorage.setItem("veecontext-collection", prefs.lastCollection as string); } catch {}
-      if (prefs.sidebarWidth) try { localStorage.setItem("veecontext-sidebar-width", String(prefs.sidebarWidth)); } catch {}
+      if (prefs.theme) try { localStorage.setItem("frozenink-theme", prefs.theme as string); } catch {}
+      if (prefs.lastCollection) try { localStorage.setItem("frozenink-collection", prefs.lastCollection as string); } catch {}
+      if (prefs.sidebarWidth) try { localStorage.setItem("frozenink-sidebar-width", String(prefs.sidebarWidth)); } catch {}
       // Hydrate tab state for each collection
       for (const [key, value] of Object.entries(prefs)) {
         if (key.startsWith("tabs:") && value) {
-          try { localStorage.setItem(`veecontext-${key}`, JSON.stringify(value)); } catch {}
+          try { localStorage.setItem(`frozenink-${key}`, JSON.stringify(value)); } catch {}
         }
       }
     });

--- a/packages/ui/src/components/manage/PublishPanel.tsx
+++ b/packages/ui/src/components/manage/PublishPanel.tsx
@@ -129,7 +129,25 @@ export default function PublishPanel() {
     closeForm();
   };
 
-  const handleDeleteSite = (idx: number) => {
+  const handleDeleteSite = async (idx: number) => {
+    const preset = presets[idx];
+    const dep = preset ? getDeployment(preset.workerName) : undefined;
+    if (dep) {
+      setUnpublishing(preset.workerName);
+      setError(null);
+      try {
+        const res = await fetch(`/api/deployments/${encodeURIComponent(dep.name)}`, { method: "DELETE" });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({ error: "Unpublish failed" }));
+          setError(data.error || "Unpublish failed");
+        }
+      } catch (err) {
+        setError(String(err));
+      } finally {
+        setUnpublishing(null);
+        loadDeployments();
+      }
+    }
     persistPresets(presets.filter((_, i) => i !== idx));
     if (editIdx === idx) closeForm();
   };
@@ -163,28 +181,6 @@ export default function PublishPanel() {
         }
       } catch {}
     }, 1000);
-  };
-
-  // --- Unpublish ---
-
-  const handleUnpublish = async (preset: PublishPreset) => {
-    const dep = getDeployment(preset.workerName);
-    if (!dep) return;
-
-    setUnpublishing(preset.workerName);
-    setError(null);
-    try {
-      const res = await fetch(`/api/deployments/${encodeURIComponent(dep.name)}`, { method: "DELETE" });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({ error: "Unpublish failed" }));
-        setError(data.error || "Unpublish failed");
-      }
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setUnpublishing(null);
-      loadDeployments();
-    }
   };
 
   // --- Render ---
@@ -226,7 +222,6 @@ export default function PublishPanel() {
           <div className="preset-list">
             {presets.map((p, i) => {
               const dep = getDeployment(p.workerName);
-              const isUnpublishing = unpublishing === p.workerName;
               return (
                 <div key={i} className="preset-card">
                   <div className="preset-card-header">
@@ -260,15 +255,6 @@ export default function PublishPanel() {
                       >
                         {publishing ? "Publishing..." : "Publish"}
                       </button>
-                      {dep && (
-                        <button
-                          className="btn btn-sm btn-danger"
-                          onClick={() => handleUnpublish(p)}
-                          disabled={isUnpublishing || publishing}
-                        >
-                          {isUnpublishing ? "Removing..." : "Unpublish"}
-                        </button>
-                      )}
                     </div>
                   </div>
                   <div className="preset-card-details">
@@ -316,7 +302,7 @@ export default function PublishPanel() {
               type="text"
               value={workerName}
               onChange={(e) => setWorkerName(e.target.value)}
-              placeholder="vctx-my-project"
+              placeholder="fink-my-project"
               className="form-input"
             />
           </div>

--- a/packages/ui/src/components/manage/SettingsPanel.tsx
+++ b/packages/ui/src/components/manage/SettingsPanel.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
-import type { VeeContextConfig } from "../../types";
+import type { FrozenInkConfig } from "../../types";
 
 export default function SettingsPanel() {
-  const [config, setConfig] = useState<VeeContextConfig | null>(null);
+  const [config, setConfig] = useState<FrozenInkConfig | null>(null);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 

--- a/packages/ui/src/components/manage/WorkspaceScreen.tsx
+++ b/packages/ui/src/components/manage/WorkspaceScreen.tsx
@@ -20,7 +20,7 @@ export default function WorkspaceScreen({
   return (
     <div className="workspace-screen">
       <div className="workspace-header">
-        <h1>VeeContext</h1>
+        <h1>Frozen Ink</h1>
         <p className="workspace-subtitle">Choose a workspace to get started</p>
       </div>
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,3 @@
-// @veecontext/ui - Web UI for browsing collections
-// Built with Vite + React, served as static files by `vctx serve`
+// @frozenink/ui - Web UI for browsing collections
+// Built with Vite + React, served as static files by `fink serve`
 export {};

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -110,7 +110,7 @@ export interface CollectionConfig {
   credentials: Record<string, unknown>;
 }
 
-export interface VeeContextConfig {
+export interface FrozenInkConfig {
   sync: { interval: number; concurrency: number; retries: number };
   logging: { level: string };
   [key: string]: unknown;

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@veecontext/worker",
+  "name": "@frozenink/worker",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "hono": "^4.0.0",
-    "@veecontext/core": "workspace:*",
-    "@veecontext/crawlers": "workspace:*"
+    "@frozenink/core": "workspace:*",
+    "@frozenink/crawlers": "workspace:*"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.0.0",

--- a/packages/worker/src/auth.ts
+++ b/packages/worker/src/auth.ts
@@ -1,7 +1,7 @@
 import type { Context, Next } from "hono";
 import type { Env } from "./types";
 
-const COOKIE_NAME = "vctx_token";
+const COOKIE_NAME = "fink_token";
 const COOKIE_MAX_AGE = 30 * 24 * 60 * 60; // 30 days
 
 export async function hashPassword(password: string): Promise<string> {

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -14,8 +14,8 @@ import {
 } from "../db/client";
 import { searchEntities } from "../db/search";
 import { getR2Object, getMimeType } from "../storage/r2";
-import { ThemeEngine } from "@veecontext/core/theme";
-import { GitHubTheme, ObsidianTheme, GitTheme, MantisBTTheme } from "@veecontext/crawlers/themes";
+import { ThemeEngine } from "@frozenink/core/theme";
+import { GitHubTheme, ObsidianTheme, GitTheme, MantisBTTheme } from "@frozenink/crawlers/themes";
 
 const themeEngine = new ThemeEngine();
 themeEngine.register(new GitHubTheme());

--- a/packages/worker/src/handlers/mcp.ts
+++ b/packages/worker/src/handlers/mcp.ts
@@ -38,8 +38,8 @@ export async function handleMcpRequest(
       {
         protocolVersion: "2025-03-26",
         capabilities: { tools: {} },
-        serverInfo: { name: "veecontext", version: "0.1.0" },
-        instructions: "VeeContext MCP server. Provides collection and entity retrieval tools over published collections.",
+        serverInfo: { name: "frozenink", version: "0.1.0" },
+        instructions: "Frozen Ink MCP server. Provides collection and entity retrieval tools over published collections.",
       },
       rpc.id,
     );

--- a/packages/worker/src/login.ts
+++ b/packages/worker/src/login.ts
@@ -4,7 +4,7 @@ import type { Env } from "./types";
 export function renderLoginPage(c: Context<{ Bindings: Env }>): Response {
   const url = new URL(c.req.url);
   const hasError = url.searchParams.has("error");
-  const workerName = c.env.WORKER_NAME || "VeeContext";
+  const workerName = c.env.WORKER_NAME || "Frozen Ink";
 
   const html = `<!DOCTYPE html>
 <html lang="en">

--- a/packages/worker/wrangler.toml
+++ b/packages/worker/wrangler.toml
@@ -1,17 +1,17 @@
-# Local development template — actual deployment is done via CF API in `vctx publish`
-name = "vctx-dev"
+# Local development template — actual deployment is done via CF API in `fink publish`
+name = "fink-dev"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
 
 [vars]
 PASSWORD_HASH = ""
-WORKER_NAME = "vctx-dev"
+WORKER_NAME = "fink-dev"
 
 [[d1_databases]]
 binding = "DB"
-database_name = "vctx-dev-db"
+database_name = "fink-dev-db"
 database_id = "local"
 
 [[r2_buckets]]
 binding = "BUCKET"
-bucket_name = "vctx-dev-bucket"
+bucket_name = "fink-dev-bucket"


### PR DESCRIPTION
## Summary
- Comprehensive rename of the app from **VeeContext** to **Frozen Ink** across all 86 files
- Renames display name, package names (`@veecontext/*` → `@frozenink/*`), CLI command (`vctx` → `fink`), home directory (`~/.veecontext` → `~/.frozenink`), env vars (`VEECONTEXT_*` → `FROZENINK_*`), TypeScript types/functions, and MCP URIs
- Desktop app: custom macOS application menu with proper app name, About panel with icon, consolidated workspace directory under `~/.frozenink/`
- Publish UI: removed redundant "Unpublish" button from preset cards; "Delete Site" in the edit form now handles both unpublishing and preset removal

## Test plan
- [ ] Verify `bun test` passes across all packages
- [ ] Verify `bun run typecheck` passes
- [ ] Verify desktop app shows "Frozen Ink" in menu bar and About dialog
- [ ] Verify CLI displays "Frozen Ink" in help text and error messages
- [ ] Verify Publish panel shows Edit → Delete Site flow without separate Unpublish button

🤖 Generated with [Claude Code](https://claude.com/claude-code)