### PR TITLE
Harden remote auth flows and enforce explicit public publish

### DIFF
--- a/packages/cli/src/__tests__/management-api-publish.test.ts
+++ b/packages/cli/src/__tests__/management-api-publish.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdirSync, rmSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, ".test-management-publish");
+
+type HandleManagementRequest = (req: Request) => Response | null;
+type SetPublishOverride = (fn: ((options: {
+  collectionNames: string[];
+  workerName: string;
+  password?: string;
+  removePassword?: boolean;
+  forcePublic?: boolean;
+}, onProgress: (step: string, detail: string) => void) => Promise<unknown>) | null) => void;
+
+let handleManagementRequest: HandleManagementRequest;
+let setPublishCollectionsOverride: SetPublishOverride;
+
+beforeEach(async () => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  process.env.FROZENINK_HOME = TEST_DIR;
+
+  mock.module("@frozenink/core", () => ({
+    getFrozenInkHome: () => TEST_DIR,
+    getCollectionDb: () => ({
+      select: () => ({ from: () => ({ where: () => ({ all: () => [] }) }) }),
+      insert: () => ({ values: () => ({ run: () => {} }) }),
+      delete: () => ({ where: () => ({ run: () => {} }) }),
+      update: () => ({ set: () => ({ where: () => ({ run: () => {} }) }) }),
+      query: { entities: { findMany: async () => [] } },
+      prepare: () => ({ bind: () => ({ all: async () => ({ results: [] }) }) }),
+    }),
+    listCollections: () => [],
+    getCollection: () => null,
+    getCollectionDbPath: () => "",
+    addCollection: () => {},
+    removeCollection: () => {},
+    updateCollection: () => {},
+    renameCollection: () => {},
+    listDeployments: () => [],
+    removeDeployment: () => {},
+    loadConfig: () => ({}),
+    SyncEngine: class {},
+    ThemeEngine: class { register() {} },
+    LocalStorageBackend: class {},
+    syncRuns: {},
+    entities: {},
+  }));
+
+  mock.module("@frozenink/crawlers", () => ({
+    createDefaultRegistry: () => ({ get: () => null }),
+    gitHubTheme: {},
+    obsidianTheme: {},
+    gitTheme: {},
+    mantisBTTheme: {},
+  }));
+
+  mock.module("drizzle-orm", () => ({
+    desc: () => ({}),
+    eq: () => ({}),
+  }));
+
+  const mod = await import("../commands/management-api");
+  handleManagementRequest = mod.handleManagementRequest as HandleManagementRequest;
+  setPublishCollectionsOverride = mod.setPublishCollectionsOverride as SetPublishOverride;
+});
+
+afterEach(() => {
+  setPublishCollectionsOverride(null);
+  mock.restore();
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  delete process.env.FROZENINK_HOME;
+});
+
+async function call(req: Request): Promise<Response> {
+  const res = handleManagementRequest(req);
+  expect(res).not.toBeNull();
+  return await Promise.resolve(res as Response);
+}
+
+describe("management API publish security options", () => {
+  it("forwards password/removal/public flags to publishCollections", async () => {
+    let captured: Record<string, unknown> | null = null;
+    setPublishCollectionsOverride(async (options) => {
+      captured = options as unknown as Record<string, unknown>;
+    });
+
+    const postRes = await call(
+      new Request("http://localhost/api/publish", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          collections: ["alpha"],
+          name: "worker-alpha",
+          password: "secret123",
+          removePassword: false,
+          forcePublic: true,
+        }),
+      }),
+    );
+    expect(postRes.status).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(captured).toBeTruthy();
+    expect(captured?.collectionNames).toEqual(["alpha"]);
+    expect(captured?.workerName).toBe("worker-alpha");
+    expect(captured?.password).toBe("secret123");
+    expect(captured?.removePassword).toBe(false);
+    expect(captured?.forcePublic).toBe(true);
+
+    const statusRes = await call(new Request("http://localhost/api/publish/status", { method: "GET" }));
+    const status = await statusRes.json() as { active: boolean; step: string; error: string | null };
+    expect(status.active).toBe(false);
+    expect(status.step).toBe("done");
+    expect(status.error).toBeNull();
+  });
+
+  it("surfaces failed publish in /api/publish/status", async () => {
+    setPublishCollectionsOverride(async () => {
+      throw new Error("publish boom");
+    });
+
+    await call(
+      new Request("http://localhost/api/publish", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ collections: ["alpha"], name: "worker-alpha" }),
+      }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const statusRes = await call(new Request("http://localhost/api/publish/status", { method: "GET" }));
+    const status = await statusRes.json() as { active: boolean; step: string; error: string | null };
+    expect(status.active).toBe(false);
+    expect(status.step).toBe("failed");
+    expect(status.error ?? "").toContain("publish boom");
+  });
+});

--- a/packages/cli/src/__tests__/publish-security.test.ts
+++ b/packages/cli/src/__tests__/publish-security.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { assertInitialPublishConfirmation } from "../commands/publish-policy";
+
+describe("publish security policy", () => {
+  it("rejects initial public publish without explicit confirmation", () => {
+    expect(() =>
+      assertInitialPublishConfirmation({
+        isUpdate: false,
+        workerOnly: false,
+        passwordHash: "",
+        forcePublic: false,
+      }),
+    ).toThrow("publicly accessible");
+  });
+
+  it("allows initial public publish with explicit forcePublic", () => {
+    expect(() =>
+      assertInitialPublishConfirmation({
+        isUpdate: false,
+        workerOnly: false,
+        passwordHash: "",
+        forcePublic: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows initial publish when password protection is set", () => {
+    expect(() =>
+      assertInitialPublishConfirmation({
+        isUpdate: false,
+        workerOnly: false,
+        passwordHash: "salt:hash",
+        forcePublic: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not require forcePublic for updates", () => {
+    expect(() =>
+      assertInitialPublishConfirmation({
+        isUpdate: true,
+        workerOnly: false,
+        passwordHash: "",
+        forcePublic: false,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -85,6 +85,23 @@ let exportProgress: ExportProgress = {
   error: null,
 };
 
+type PublishCollectionsFn = (
+  options: {
+    collectionNames: string[];
+    workerName: string;
+    password?: string;
+    removePassword?: boolean;
+    forcePublic?: boolean;
+  },
+  onProgress: (step: string, detail: string) => void,
+) => Promise<unknown>;
+
+let publishCollectionsOverride: PublishCollectionsFn | null = null;
+
+export function setPublishCollectionsOverride(fn: PublishCollectionsFn | null): void {
+  publishCollectionsOverride = fn;
+}
+
 // --- Mode detection ---
 let appMode: "desktop" | "local" | "published" = "local";
 
@@ -581,13 +598,16 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
 async function triggerPublish(opts: Record<string, unknown>): Promise<void> {
   publishProgress = { active: true, step: "starting", detail: "Starting publish...", error: null };
   try {
-    const { publishCollections } = await import("./publish");
+    const publishCollections = publishCollectionsOverride
+      ?? (await import("./publish")).publishCollections;
     const collectionNames = (opts.collections as string[]) ?? [];
     const workerName = (opts.name as string) ?? "";
     const password = opts.password as string | undefined;
+    const removePassword = opts.removePassword as boolean | undefined;
+    const forcePublic = opts.forcePublic as boolean | undefined;
 
     await publishCollections(
-      { collectionNames, workerName, password },
+      { collectionNames, workerName, password, removePassword, forcePublic },
       (step, detail) => {
         publishProgress = { ...publishProgress, step, detail };
       },

--- a/packages/cli/src/commands/publish-policy.ts
+++ b/packages/cli/src/commands/publish-policy.ts
@@ -1,0 +1,13 @@
+export function assertInitialPublishConfirmation(params: {
+  isUpdate: boolean;
+  workerOnly: boolean;
+  passwordHash: string;
+  forcePublic: boolean;
+}): void {
+  if (!params.isUpdate && !params.workerOnly && params.passwordHash.length === 0 && !params.forcePublic) {
+    throw new Error(
+      "Initial publish without a password would make data publicly accessible. " +
+      "Re-run with --public to confirm intentional public access.",
+    );
+  }
+}

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { existsSync, readFileSync, readdirSync } from "fs";
 import { join, extname } from "path";
+import { createInterface } from "readline";
 import {
   getFrozenInkHome,
   getCollectionDb,
@@ -33,6 +34,7 @@ import {
   writeTempFile,
   cleanupTempFile,
 } from "./wrangler-api";
+import { assertInitialPublishConfirmation } from "./publish-policy";
 
 function randomSuffix(): string {
   return Math.random().toString(36).slice(2, 8);
@@ -90,6 +92,8 @@ export interface PublishOptions {
   collectionNames: string[];
   workerName: string;
   password?: string;
+  removePassword?: boolean;
+  forcePublic?: boolean;
   workerOnly?: boolean;
 }
 
@@ -104,6 +108,16 @@ export interface PublishResult {
 
 export type PublishProgressCallback = (step: string, detail: string) => void;
 
+async function hashPassword(password: string): Promise<string> {
+  const salt = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+  const data = new TextEncoder().encode(salt + password);
+  const hashBuf = await crypto.subtle.digest("SHA-256", data);
+  const hashHex = Array.from(new Uint8Array(hashBuf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `${salt}:${hashHex}`;
+}
+
 /**
  * Core publish logic, callable from both CLI and desktop app.
  * Progress is reported via the onProgress callback instead of console.log.
@@ -114,7 +128,11 @@ export async function publishCollections(
 ): Promise<PublishResult> {
   await checkWranglerAuth();
 
-  const { workerName, workerOnly = false } = options;
+  const { workerName, workerOnly = false, removePassword = false, forcePublic = false } = options;
+  const password = options.password?.trim();
+  if (password && removePassword) {
+    throw new Error("Cannot use --password and --remove-password together.");
+  }
   let collectionNames = [...options.collectionNames];
 
   const existingDeployment = getDeployment(workerName);
@@ -154,17 +172,25 @@ export async function publishCollections(
     r2BucketName = `${workerName}-files`;
   }
 
-  // Hash password
+  // Password behavior:
+  // - New password supplied: rotate hash.
+  // - removePassword=true: clear protection.
+  // - Otherwise preserve existing hash on updates.
   let passwordHash = "";
-  if (options.password) {
-    const salt = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
-    const data = new TextEncoder().encode(salt + options.password);
-    const hashBuf = await crypto.subtle.digest("SHA-256", data);
-    const hashHex = Array.from(new Uint8Array(hashBuf))
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-    passwordHash = `${salt}:${hashHex}`;
+  if (password) {
+    passwordHash = await hashPassword(password);
+  } else if (removePassword) {
+    passwordHash = "";
+  } else if (existingDeployment?.passwordHash) {
+    passwordHash = existingDeployment.passwordHash;
+  } else if (isUpdate && existingDeployment?.passwordProtected) {
+    throw new Error(
+      `Deployment "${workerName}" is password protected but no reusable password hash is stored locally. ` +
+      "Re-publish with --password <new-password> to rotate credentials or --remove-password to disable protection.",
+    );
   }
+
+  assertInitialPublishConfirmation({ isUpdate, workerOnly, passwordHash, forcePublic });
 
   // --- Phase 1: Create resources + deploy worker ---
   // The worker must be deployed before data so the site is reachable
@@ -431,7 +457,7 @@ export async function publishCollections(
     workerUrl = `https://${workerName}.workers.dev`;
   }
   const mcpUrl = `${workerUrl}/mcp`;
-  const passwordProtected = options.password ? true : (existingDeployment?.passwordProtected ?? false);
+  const passwordProtected = passwordHash.length > 0;
 
   // Save deployment
   addDeployment(workerName, {
@@ -442,6 +468,7 @@ export async function publishCollections(
     d1DatabaseName,
     r2BucketName,
     passwordProtected,
+    passwordHash: passwordHash || undefined,
     publishedAt: new Date().toISOString(),
   });
 
@@ -456,10 +483,14 @@ export const publishCommand = new Command("publish")
   .description("Publish collections to Cloudflare as a password-protected website with MCP access")
   .argument("[collections...]", "Collection names to publish")
   .option("--password <password>", "Password to protect access")
+  .option("--remove-password", "Explicitly remove password protection")
+  .option("--public", "Explicitly allow public access on initial publish (skip confirmation prompt)")
   .option("--name <name>", "Worker name (default: fink-<first-collection>-<random>)")
   .option("--worker-only", "Deploy worker code only (skip D1/R2 data upload); requires --name for an existing deployment")
   .action(async (collectionNamesArg: string[], opts: {
     password?: string;
+    removePassword?: boolean;
+    public?: boolean;
     name?: string;
     workerOnly?: boolean;
   }) => {
@@ -482,9 +513,36 @@ export const publishCommand = new Command("publish")
       }
 
       const workerName = opts.name || `fink-${collectionNames[0]}-${randomSuffix()}`;
+      let forcePublic = !!opts.public;
+
+      if (!forcePublic && !opts.password && !workerOnly) {
+        const existingDeployment = getDeployment(workerName);
+        const isInitialPublish = !existingDeployment;
+        if (isInitialPublish && process.stdin.isTTY && process.stdout.isTTY) {
+          console.warn("\nWARNING: No password was provided.");
+          console.warn("This initial publish will make collection data publicly accessible.");
+          const rl = createInterface({ input: process.stdin, output: process.stdout });
+          const answer = await new Promise<string>((resolve) => {
+            rl.question("Continue with public publish? Type 'yes' to continue: ", (value) => resolve(value));
+          });
+          rl.close();
+          if (answer.trim().toLowerCase() !== "yes") {
+            console.log("Publish cancelled.");
+            process.exit(0);
+          }
+          forcePublic = true;
+        }
+      }
 
       const result = await publishCollections(
-        { collectionNames, workerName, password: opts.password, workerOnly },
+        {
+          collectionNames,
+          workerName,
+          password: opts.password,
+          removePassword: opts.removePassword,
+          forcePublic,
+          workerOnly,
+        },
         (step, detail) => console.log(`  [${step}] ${detail}`),
       );
 

--- a/packages/core/src/config/context.ts
+++ b/packages/core/src/config/context.ts
@@ -25,6 +25,7 @@ const deploymentEntrySchema = z.object({
   r2BucketName: z.string(),
   cfAccountId: z.string().optional(),
   passwordProtected: z.boolean(),
+  passwordHash: z.string().optional(),
   publishedAt: z.string(),
 });
 

--- a/packages/ui/src/components/manage/PublishPanel.tsx
+++ b/packages/ui/src/components/manage/PublishPanel.tsx
@@ -15,6 +15,7 @@ export default function PublishPanel() {
   const [selectedCollections, setSelectedCollections] = useState<string[]>([]);
   const [workerName, setWorkerName] = useState("");
   const [password, setPassword] = useState("");
+  const [removePassword, setRemovePassword] = useState(false);
 
   // Auth
   const [authChecked, setAuthChecked] = useState<boolean | null>(null);
@@ -51,7 +52,18 @@ export default function PublishPanel() {
   const loadPresets = () => {
     fetch("/api/publish-presets")
       .then((r) => r.json())
-      .then((data: PublishPreset[]) => setPresets(Array.isArray(data) ? data : []))
+      .then((data: PublishPreset[]) => {
+        if (!Array.isArray(data)) {
+          setPresets([]);
+          return;
+        }
+        const normalized = data.map((p) => ({
+          ...p,
+          password: p.password ?? "",
+          removePassword: !!p.removePassword,
+        }));
+        setPresets(normalized);
+      })
       .catch(() => {});
   };
 
@@ -89,6 +101,7 @@ export default function PublishPanel() {
     setWorkerName("");
     setSelectedCollections([]);
     setPassword("");
+    setRemovePassword(false);
   };
 
   const openEdit = (idx: number) => {
@@ -99,6 +112,7 @@ export default function PublishPanel() {
     setWorkerName(p.workerName);
     setSelectedCollections([...p.collections]);
     setPassword(p.password);
+    setRemovePassword(!!p.removePassword);
   };
 
   const closeForm = () => {
@@ -118,6 +132,7 @@ export default function PublishPanel() {
       workerName,
       collections: selectedCollections,
       password,
+      removePassword,
     };
     if (formMode === "editing" && editIdx !== null) {
       const updated = [...presets];
@@ -155,6 +170,19 @@ export default function PublishPanel() {
   // --- Publish ---
 
   const handlePublish = (preset: PublishPreset) => {
+    const existingDeployment = getDeployment(preset.workerName);
+    const isInitialPublish = !existingDeployment;
+    const isPublicInitialPublish = isInitialPublish && !preset.password && !preset.removePassword;
+    let forcePublic = false;
+
+    if (isPublicInitialPublish) {
+      const confirmed = window.confirm(
+        "No password is configured for this initial publish. Collection data will be publicly accessible. Continue?",
+      );
+      if (!confirmed) return;
+      forcePublic = true;
+    }
+
     setPublishing(true);
     setProgress(null);
     setError(null);
@@ -166,6 +194,8 @@ export default function PublishPanel() {
         collections: preset.collections,
         name: preset.workerName || undefined,
         password: preset.password || undefined,
+        removePassword: preset.removePassword || undefined,
+        forcePublic: forcePublic || undefined,
       }),
     }).catch(() => {});
 
@@ -259,6 +289,9 @@ export default function PublishPanel() {
                   </div>
                   <div className="preset-card-details">
                     <span className="text-muted">Collections: {p.collections.join(", ") || "none"}</span>
+                    <span className="text-muted">
+                      Password: {p.removePassword ? "remove on next publish" : p.password ? "set/rotate on next publish" : "preserve current"}
+                    </span>
                     {dep && (
                       <span className="preset-deployment-info">
                         Published {formatTimestamp(dep.publishedAt)}
@@ -322,14 +355,26 @@ export default function PublishPanel() {
           </div>
 
           <div className="form-group">
-            <label>Password (optional — leave blank for public access)</label>
+            <label>Password (optional)</label>
             <input
               type="password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="Leave blank for no password"
+              onChange={(e) => {
+                setPassword(e.target.value);
+                if (e.target.value) setRemovePassword(false);
+              }}
+              placeholder="Leave blank to preserve current password setting"
               className="form-input"
+              disabled={removePassword}
             />
+            <label className="checkbox-label" style={{ marginTop: 8 }}>
+              <input
+                type="checkbox"
+                checked={removePassword}
+                onChange={(e) => setRemovePassword(e.target.checked)}
+              />
+              Explicitly remove password protection on next publish
+            </label>
           </div>
 
           <div className="form-actions">

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -99,6 +99,7 @@ export interface PublishPreset {
   workerName: string;
   collections: string[];
   password: string;
+  removePassword?: boolean;
 }
 
 export interface CollectionConfig {

--- a/packages/worker/src/__tests__/auth-enforcement.test.ts
+++ b/packages/worker/src/__tests__/auth-enforcement.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { authMiddleware, handleLogin, hashPassword } from "../auth";
+
+interface TestEnv {
+  PASSWORD_HASH: string;
+}
+
+function createTestApp() {
+  const app = new Hono<{ Bindings: TestEnv }>();
+  app.post("/login", handleLogin);
+  app.get("/api/collections", authMiddleware, (c) => c.json({ ok: true }));
+  app.post("/mcp", authMiddleware, (c) => c.json({ ok: true }));
+  app.get("/", authMiddleware, (c) => c.text("ui"));
+  return app;
+}
+
+describe("worker auth enforcement across channels", () => {
+  it("denies unauthenticated API and MCP access when password is set", async () => {
+    const app = createTestApp();
+    const passwordHash = await hashPassword("secret123");
+
+    const apiRes = await app.request("http://local/api/collections", {}, { PASSWORD_HASH: passwordHash });
+    expect(apiRes.status).toBe(401);
+
+    const mcpRes = await app.request(
+      "http://local/mcp",
+      { method: "POST", body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }) },
+      { PASSWORD_HASH: passwordHash },
+    );
+    expect(mcpRes.status).toBe(401);
+  });
+
+  it("redirects unauthenticated UI requests to login when password is set", async () => {
+    const app = createTestApp();
+    const passwordHash = await hashPassword("secret123");
+
+    const res = await app.request("http://local/", {}, { PASSWORD_HASH: passwordHash });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/login");
+  });
+
+  it("accepts bearer password for API and MCP", async () => {
+    const app = createTestApp();
+    const passwordHash = await hashPassword("secret123");
+    const headers = { Authorization: "Bearer secret123" };
+
+    const apiRes = await app.request("http://local/api/collections", { headers }, { PASSWORD_HASH: passwordHash });
+    expect(apiRes.status).toBe(200);
+
+    const mcpRes = await app.request(
+      "http://local/mcp",
+      { method: "POST", headers, body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }) },
+      { PASSWORD_HASH: passwordHash },
+    );
+    expect(mcpRes.status).toBe(200);
+  });
+
+  it("creates session cookie on login and accepts it for UI/API access", async () => {
+    const app = createTestApp();
+    const passwordHash = await hashPassword("secret123");
+
+    const loginRes = await app.request(
+      "http://local/login",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ password: "secret123" }).toString(),
+      },
+      { PASSWORD_HASH: passwordHash },
+    );
+    expect(loginRes.status).toBe(302);
+    const setCookie = loginRes.headers.get("set-cookie");
+    expect(setCookie).toBeTruthy();
+    const cookieHeader = (setCookie ?? "").split(";")[0];
+
+    const uiRes = await app.request("http://local/", { headers: { Cookie: cookieHeader } }, { PASSWORD_HASH: passwordHash });
+    expect(uiRes.status).toBe(200);
+
+    const apiRes = await app.request(
+      "http://local/api/collections",
+      { headers: { Cookie: cookieHeader } },
+      { PASSWORD_HASH: passwordHash },
+    );
+    expect(apiRes.status).toBe(200);
+  });
+
+  it("allows all channels when password is not configured", async () => {
+    const app = createTestApp();
+
+    const apiRes = await app.request("http://local/api/collections", {}, { PASSWORD_HASH: "" });
+    expect(apiRes.status).toBe(200);
+
+    const mcpRes = await app.request(
+      "http://local/mcp",
+      { method: "POST", body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }) },
+      { PASSWORD_HASH: "" },
+    );
+    expect(mcpRes.status).toBe(200);
+
+    const uiRes = await app.request("http://local/", {}, { PASSWORD_HASH: "" });
+    expect(uiRes.status).toBe(200);
+  });
+});

--- a/packages/worker/src/auth.ts
+++ b/packages/worker/src/auth.ts
@@ -4,13 +4,74 @@ import type { Env } from "./types";
 const COOKIE_NAME = "fink_token";
 const COOKIE_MAX_AGE = 30 * 24 * 60 * 60; // 30 days
 
+function toHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+function base64UrlEncode(input: string): string {
+  return btoa(input).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function base64UrlDecode(input: string): string {
+  const padded = `${input}${"=".repeat((4 - (input.length % 4)) % 4)}`
+    .replace(/-/g, "+")
+    .replace(/_/g, "/");
+  return atob(padded);
+}
+
+async function signSession(payloadB64: string, key: string): Promise<string> {
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(key),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sigBuf = await crypto.subtle.sign("HMAC", cryptoKey, new TextEncoder().encode(payloadB64));
+  return base64UrlEncode(String.fromCharCode(...new Uint8Array(sigBuf)));
+}
+
+async function createSessionToken(passwordHash: string): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const payload = JSON.stringify({ iat: now, exp: now + COOKIE_MAX_AGE });
+  const payloadB64 = base64UrlEncode(payload);
+  const sig = await signSession(payloadB64, passwordHash);
+  return `${payloadB64}.${sig}`;
+}
+
+async function verifySessionToken(token: string, passwordHash: string): Promise<boolean> {
+  const [payloadB64, providedSig] = token.split(".");
+  if (!payloadB64 || !providedSig) return false;
+
+  const expectedSig = await signSession(payloadB64, passwordHash);
+  if (!constantTimeEqual(providedSig, expectedSig)) return false;
+
+  try {
+    const payloadRaw = base64UrlDecode(payloadB64);
+    const payload = JSON.parse(payloadRaw) as { exp?: number };
+    const now = Math.floor(Date.now() / 1000);
+    return typeof payload.exp === "number" && payload.exp > now;
+  } catch {
+    return false;
+  }
+}
+
 export async function hashPassword(password: string): Promise<string> {
   const salt = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
   const data = new TextEncoder().encode(salt + password);
   const hashBuf = await crypto.subtle.digest("SHA-256", data);
-  const hashHex = Array.from(new Uint8Array(hashBuf))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+  const hashHex = toHex(hashBuf);
   return `${salt}:${hashHex}`;
 }
 
@@ -19,10 +80,8 @@ async function verifyPassword(password: string, storedHash: string): Promise<boo
   if (!salt || !expectedHash) return false;
   const data = new TextEncoder().encode(salt + password);
   const hashBuf = await crypto.subtle.digest("SHA-256", data);
-  const hashHex = Array.from(new Uint8Array(hashBuf))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  return hashHex === expectedHash;
+  const hashHex = toHex(hashBuf);
+  return constantTimeEqual(hashHex, expectedHash);
 }
 
 function parseCookies(header: string): Record<string, string> {
@@ -34,8 +93,8 @@ function parseCookies(header: string): Record<string, string> {
   return cookies;
 }
 
-export function setCookieHeader(password: string): string {
-  return `${COOKIE_NAME}=${encodeURIComponent(password)}; HttpOnly; Secure; SameSite=Strict; Max-Age=${COOKIE_MAX_AGE}; Path=/`;
+export function setCookieHeader(token: string): string {
+  return `${COOKIE_NAME}=${encodeURIComponent(token)}; HttpOnly; Secure; SameSite=Strict; Max-Age=${COOKIE_MAX_AGE}; Path=/`;
 }
 
 export function clearCookieHeader(): string {
@@ -65,7 +124,7 @@ export async function authMiddleware(c: Context<{ Bindings: Env }>, next: Next) 
   if (cookieHeader) {
     const cookies = parseCookies(cookieHeader);
     const token = cookies[COOKIE_NAME];
-    if (token && await verifyPassword(decodeURIComponent(token), passwordHash)) {
+    if (token && await verifySessionToken(decodeURIComponent(token), passwordHash)) {
       return next();
     }
   }
@@ -93,11 +152,13 @@ export async function handleLogin(c: Context<{ Bindings: Env }>): Promise<Respon
     return c.redirect("/login?error=1");
   }
 
+  const sessionToken = await createSessionToken(passwordHash);
+
   return new Response(null, {
     status: 302,
     headers: {
       Location: "/",
-      "Set-Cookie": setCookieHeader(password),
+      "Set-Cookie": setCookieHeader(sessionToken),
     },
   });
 }


### PR DESCRIPTION
## Summary
- preserve deployment password protection across re-publish unless user explicitly rotates (`--password`) or removes (`--remove-password`)
- require explicit confirmation for initial public publish (`--public` bypass)
- replace raw-password cookie storage with signed/expiring session tokens and constant-time comparisons in worker auth
- wire management API and desktop UI publish flow for `removePassword` and `forcePublic`
- add tests for worker UI/API/MCP auth enforcement, publish policy, and management API publish option forwarding/status behavior

## Testing
- bun test packages/cli/src/__tests__/management-api-publish.test.ts packages/cli/src/__tests__/publish-security.test.ts packages/worker/src/__tests__/auth-enforcement.test.ts