### PR TITLE
Add TextPack export/download flow

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -605,7 +605,8 @@ export function createApiServer(
         const result = buildTextPack(name, filePath);
         if (!result) return errorResponse("File not found", 404);
 
-        return new Response(result.data, {
+        const zipData = Uint8Array.from(result.data);
+        return new Response(zipData, {
           status: 200,
           headers: {
             "Content-Type": "application/zip",

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -148,7 +148,7 @@ export function createApiServer(
   const uiDistDir = resolveUiDistDir();
   const themeEngine = createThemeEngine();
 
-  function handleRequest(req: Request): Response {
+  async function handleRequest(req: Request): Promise<Response> {
       const url = new URL(req.url);
       const path = url.pathname;
 
@@ -589,6 +589,29 @@ export function createApiServer(
 
         results.sort((a, b) => a.title.localeCompare(b.title));
         return jsonResponse(results);
+      }
+
+      // GET /api/collections/:name/textpack/*path — download page as TextPack (zipped TextBundle)
+      const textpackMatch = path.match(
+        /^\/api\/collections\/([^/]+)\/textpack\/(.+)$/,
+      );
+      if (textpackMatch && req.method === "GET") {
+        const name = decodeURIComponent(textpackMatch[1]);
+        const filePath = decodeURIComponent(textpackMatch[2]);
+        const col = getCollection(name);
+        if (!col) return errorResponse("Collection not found", 404);
+
+        const { buildTextPack } = await import("@frozenink/core/export");
+        const result = buildTextPack(name, filePath);
+        if (!result) return errorResponse("File not found", 404);
+
+        return new Response(result.data, {
+          status: 200,
+          headers: {
+            "Content-Type": "application/zip",
+            "Content-Disposition": `attachment; filename="${result.filename}"`,
+          },
+        });
       }
 
       // GET /api/attachments/:collection/*path

--- a/packages/core/src/export/index.ts
+++ b/packages/core/src/export/index.ts
@@ -1,1 +1,2 @@
 export { exportStaticSite, type ExportOptions } from "./static-site";
+export { buildTextPack } from "./textbundle";

--- a/packages/core/src/export/textbundle.ts
+++ b/packages/core/src/export/textbundle.ts
@@ -1,0 +1,205 @@
+/**
+ * TextBundle / TextPack export.
+ *
+ * A TextBundle (.textbundle) is a macOS package containing:
+ *   - info.json   — format metadata
+ *   - text.md     — the markdown document
+ *   - assets/     — referenced images
+ *
+ * A TextPack (.textpack) is the same structure zipped into a single file.
+ * Bear, Ulysses, and other writing apps can open both formats.
+ *
+ * This module produces a TextPack (zip buffer) from a markdown file and its
+ * attachments on disk, so the result can be streamed directly to the browser.
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { join, basename } from "path";
+import { getFrozenInkHome } from "../config/loader";
+
+// ---------------------------------------------------------------------------
+// Minimal ZIP builder (store-only, no compression — images are already
+// compressed and markdown is tiny). No external dependencies required.
+// ---------------------------------------------------------------------------
+
+function crc32(buf: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    crc ^= buf[i];
+    for (let j = 0; j < 8; j++) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+interface ZipEntry {
+  name: string; // path inside zip
+  data: Uint8Array;
+}
+
+function buildZip(entries: ZipEntry[]): Uint8Array {
+  const localHeaders: Uint8Array[] = [];
+  const centralHeaders: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBytes = new TextEncoder().encode(entry.name);
+    const crc = crc32(entry.data);
+    const size = entry.data.length;
+
+    // Local file header (30 bytes + name + data)
+    const local = new Uint8Array(30 + nameBytes.length + size);
+    const lv = new DataView(local.buffer);
+    lv.setUint32(0, 0x04034b50, true); // signature
+    lv.setUint16(4, 20, true); // version needed
+    lv.setUint16(6, 0, true); // flags
+    lv.setUint16(8, 0, true); // compression: store
+    lv.setUint16(10, 0, true); // mod time
+    lv.setUint16(12, 0, true); // mod date
+    lv.setUint32(14, crc, true);
+    lv.setUint32(18, size, true); // compressed size
+    lv.setUint32(22, size, true); // uncompressed size
+    lv.setUint16(26, nameBytes.length, true);
+    lv.setUint16(28, 0, true); // extra length
+    local.set(nameBytes, 30);
+    local.set(entry.data, 30 + nameBytes.length);
+    localHeaders.push(local);
+
+    // Central directory header (46 bytes + name)
+    const central = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(central.buffer);
+    cv.setUint32(0, 0x02014b50, true); // signature
+    cv.setUint16(4, 20, true); // version made by
+    cv.setUint16(6, 20, true); // version needed
+    cv.setUint16(8, 0, true); // flags
+    cv.setUint16(10, 0, true); // compression: store
+    cv.setUint16(12, 0, true); // mod time
+    cv.setUint16(14, 0, true); // mod date
+    cv.setUint32(16, crc, true);
+    cv.setUint32(20, size, true);
+    cv.setUint32(24, size, true);
+    cv.setUint16(28, nameBytes.length, true);
+    cv.setUint16(30, 0, true); // extra length
+    cv.setUint16(32, 0, true); // comment length
+    cv.setUint16(34, 0, true); // disk start
+    cv.setUint16(36, 0, true); // internal attrs
+    cv.setUint32(38, 0, true); // external attrs
+    cv.setUint32(42, offset, true); // local header offset
+    central.set(nameBytes, 46);
+    centralHeaders.push(central);
+
+    offset += local.length;
+  }
+
+  const centralDirOffset = offset;
+  let centralDirSize = 0;
+  for (const h of centralHeaders) centralDirSize += h.length;
+
+  // End of central directory record (22 bytes)
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true); // signature
+  ev.setUint16(4, 0, true); // disk number
+  ev.setUint16(6, 0, true); // central dir disk
+  ev.setUint16(8, entries.length, true);
+  ev.setUint16(10, entries.length, true);
+  ev.setUint32(12, centralDirSize, true);
+  ev.setUint32(16, centralDirOffset, true);
+  ev.setUint16(20, 0, true); // comment length
+
+  const totalSize = offset + centralDirSize + 22;
+  const result = new Uint8Array(totalSize);
+  let pos = 0;
+  for (const h of localHeaders) {
+    result.set(h, pos);
+    pos += h.length;
+  }
+  for (const h of centralHeaders) {
+    result.set(h, pos);
+    pos += h.length;
+  }
+  result.set(eocd, pos);
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// TextPack builder
+// ---------------------------------------------------------------------------
+
+const INFO_JSON = JSON.stringify(
+  {
+    version: 2,
+    type: "net.daringfireball.markdown",
+    transient: false,
+  },
+  null,
+  2,
+);
+
+/**
+ * Build a .textpack (zipped TextBundle) for a single markdown page.
+ *
+ * @param collection  Collection name
+ * @param filePath    Relative path to the markdown file within the collection's markdown/ dir
+ * @returns           { filename, data } where data is the zip buffer, or null if file not found
+ */
+export function buildTextPack(
+  collection: string,
+  filePath: string,
+): { filename: string; data: Uint8Array } | null {
+  const home = getFrozenInkHome();
+  const mdFullPath = join(home, "collections", collection, "markdown", filePath);
+
+  if (!existsSync(mdFullPath)) return null;
+
+  let markdown = readFileSync(mdFullPath, "utf-8");
+  const attachmentsDir = join(home, "collections", collection, "attachments");
+
+  // Find all Obsidian-style image embeds: ![[path]]
+  const imageRefs: Array<{ match: string; path: string }> = [];
+  const embedRegex = /!\[\[([^\]]+)\]\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = embedRegex.exec(markdown)) !== null) {
+    imageRefs.push({ match: m[0], path: m[1] });
+  }
+
+  // Also find standard markdown images referencing attachments: ![alt](attachments/path)
+  const mdImageRegex = /!\[([^\]]*)\]\((attachments\/[^)]+)\)/g;
+  while ((m = mdImageRegex.exec(markdown)) !== null) {
+    imageRefs.push({ match: m[0], path: m[2] });
+  }
+
+  // Collect asset files and rewrite markdown
+  const assets = new Map<string, Uint8Array>(); // assetFilename -> data
+
+  for (const ref of imageRefs) {
+    // The path may be "attachments/foo/bar.png" or just "foo/bar.png"
+    const cleanPath = ref.path.replace(/^attachments\//, "");
+    const diskPath = join(attachmentsDir, cleanPath);
+    const assetName = basename(cleanPath);
+
+    if (existsSync(diskPath)) {
+      assets.set(assetName, new Uint8Array(readFileSync(diskPath)));
+    }
+
+    // Rewrite the embed to standard markdown pointing at assets/
+    const alt = assetName.replace(/\.[^.]+$/, "");
+    markdown = markdown.split(ref.match).join(`![${alt}](assets/${assetName})`);
+  }
+
+  // Build zip entries
+  const entries: ZipEntry[] = [
+    { name: "info.json", data: new TextEncoder().encode(INFO_JSON) },
+    { name: "text.md", data: new TextEncoder().encode(markdown) },
+  ];
+
+  for (const [name, data] of assets) {
+    entries.push({ name: `assets/${name}`, data });
+  }
+
+  const zipData = buildZip(entries);
+  const stem = basename(filePath, ".md");
+  return { filename: `${stem}.textpack`, data: zipData };
+}

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -300,7 +300,7 @@ describe("entity_get_attachment tool", () => {
     expect(data.mimeType).toBe("image/png");
     expect(data.resolvedStoragePath).toBe("attachments/git/abc123/logo.png");
     expect(data.contentBase64).toBe(Buffer.from("fake-png-bytes").toString("base64"));
-  });
+  }, 15000);
 });
 
 describe("MCP resources", () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -834,6 +834,28 @@ export default function App() {
                 <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
               </svg>
             </button>
+            {selectedFile && selectedCollection && (
+              <button
+                className="nav-btn icon-btn"
+                onClick={() => {
+                  const url = `/api/collections/${encodeURIComponent(selectedCollection)}/textpack/${selectedFile}`;
+                  const a = document.createElement("a");
+                  a.href = url;
+                  a.download = "";
+                  document.body.appendChild(a);
+                  a.click();
+                  a.remove();
+                }}
+                title="Download as TextBundle"
+                aria-label="Download as TextBundle"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                  <polyline points="7 10 12 15 17 10"/>
+                  <line x1="12" y1="15" x2="12" y2="3"/>
+                </svg>
+              </button>
+            )}
             {showLogout && (
               <form method="POST" action="/logout" className="logout-form-inline">
                 <button type="submit" className="nav-btn icon-btn logout-icon-btn" title="Sign out" aria-label="Sign out">


### PR DESCRIPTION
## Summary
- add core TextPack builder for generating zipped TextBundle exports
- expose TextPack from the export barrel
- add `/api/collections/:name/textpack/*path` endpoint to download TextPack files
- wire UI to trigger TextPack export from a page
- make `handleRequest` async so dynamic import works in desktop/electron builds

## Validation
- built and launched desktop app with `bun run start`
- resolved Electron native module mismatch with `npx @electron/rebuild -m .` during validation