### PR TITLE
Add full-text search across local server, worker, and UI

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -408,6 +408,7 @@ export function createApiServer(
           title: string;
           markdownPath: string | null;
           rank: number;
+          snippet: string;
         }> = [];
 
         for (const col of collectionRows) {
@@ -432,6 +433,7 @@ export function createApiServer(
                 ...r,
                 collection: col.name,
                 markdownPath,
+                snippet: r.snippet,
               });
             }
           } finally {

--- a/packages/core/src/search/indexer.ts
+++ b/packages/core/src/search/indexer.ts
@@ -6,6 +6,7 @@ export interface SearchResult {
   entityType: string;
   title: string;
   rank: number;
+  snippet: string;
 }
 
 export interface SearchFilters {
@@ -89,7 +90,8 @@ export class SearchIndexer {
     if (!ftsQuery) return [];
 
     let sql = `
-      SELECT entity_id, external_id, entity_type, title, rank
+      SELECT entity_id, external_id, entity_type, title, rank,
+        snippet(entities_fts, 4, '<mark>', '</mark>', '…', 48) AS snippet
       FROM entities_fts
       WHERE entities_fts MATCH ?
     `;
@@ -109,6 +111,7 @@ export class SearchIndexer {
       entity_type: string;
       title: string;
       rank: number;
+      snippet: string;
     }>;
 
     return rows.map((row) => ({
@@ -117,6 +120,7 @@ export class SearchIndexer {
       entityType: row.entity_type,
       title: row.title,
       rank: row.rank,
+      snippet: row.snippet ?? "",
     }));
   }
 

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -1230,6 +1230,110 @@ body {
   font-size: 14px;
 }
 
+/* ===== Full-Text Search ===== */
+.fts-dialog {
+  width: 640px;
+}
+
+.fts-search-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.fts-result {
+  gap: 4px;
+}
+
+.fts-snippet-wrapper {
+  display: block;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary, var(--text-muted));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.fts-snippet {
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.fts-snippet mark {
+  background: none;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.fts-hint {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ===== Toolbar Menu ===== */
+.toolbar-menu-wrapper {
+  position: relative;
+}
+
+.toolbar-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  min-width: 220px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-dialog);
+  padding: 4px 0;
+  z-index: 200;
+}
+
+.toolbar-menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 7px 12px;
+  border: none;
+  background: none;
+  color: var(--text);
+  font-size: 13px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  text-align: left;
+  gap: 16px;
+}
+
+.toolbar-menu-item:hover:not(:disabled) {
+  background: var(--hover-bg);
+}
+
+.toolbar-menu-item:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.toolbar-menu-item kbd {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  background: none;
+  border: none;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.toolbar-menu-separator {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
 /* ===== View Mode Toggle ===== */
 .view-mode-toggle {
   display: flex;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -5,6 +5,7 @@ import FileTree from "./components/FileTree";
 import MarkdownView from "./components/MarkdownView";
 import HtmlView from "./components/HtmlView";
 import SearchBar from "./components/SearchBar";
+import FullTextSearch from "./components/FullTextSearch";
 import ThemeSwitcher, { type ThemeId } from "./components/ThemeSwitcher";
 import ViewModeToggle, { type ViewMode } from "./components/ViewModeToggle";
 import TabBar, { type Tab } from "./components/TabBar";
@@ -144,6 +145,9 @@ export default function App() {
   const [fileTree, setFileTree] = useState<TreeNode[]>([]);
   const [fileContent, setFileContent] = useState<string | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
+  const [ftsOpen, setFtsOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
   const [loading, setLoading] = useState(false);
   const [backlinks, setBacklinks] = useState<Backlink[]>([]);
   const [outgoingLinks, setOutgoingLinks] = useState<LinkItem[]>([]);
@@ -560,10 +564,29 @@ export default function App() {
     [],
   );
 
+  // Close menu on outside click
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [menuOpen]);
+
   // Keyboard shortcuts
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
+
+      // Full-text search: Shift+Cmd+F
+      if (mod && e.shiftKey && e.key === "f") {
+        e.preventDefault();
+        setFtsOpen((open) => !open);
+        return;
+      }
 
       // Search: Cmd+P or Cmd+K
       if (mod && (e.key === "p" || e.key === "k")) {
@@ -574,6 +597,7 @@ export default function App() {
 
       if (e.key === "Escape") {
         setSearchOpen(false);
+        setFtsOpen(false);
         return;
       }
 
@@ -667,6 +691,15 @@ export default function App() {
     (collection: string, markdownPath: string, openNewTab?: boolean) => {
       navigateTo(collection, markdownPath, openNewTab);
       setSearchOpen(false);
+      if (isMobile) setSidebarOpen(false);
+    },
+    [navigateTo, isMobile],
+  );
+
+  const handleFtsNavigate = useCallback(
+    (collection: string, markdownPath: string, openNewTab?: boolean) => {
+      navigateTo(collection, markdownPath, openNewTab);
+      setFtsOpen(false);
       if (isMobile) setSidebarOpen(false);
     },
     [navigateTo, isMobile],
@@ -824,6 +857,17 @@ export default function App() {
               ⌘P
             </button>
             <button
+              className="nav-btn"
+              onClick={() => setFtsOpen(true)}
+              title="Full-text search (⇧⌘F)"
+              aria-label="Full-text search"
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
+            </button>
+            <button
               className={`nav-btn icon-btn${backlinksOpen ? " active" : ""}`}
               onClick={() => setBacklinksOpen((o) => !o)}
               title="Toggle links panel"
@@ -856,6 +900,53 @@ export default function App() {
                 </svg>
               </button>
             )}
+            <div className="toolbar-menu-wrapper" ref={menuRef}>
+              <button
+                className={`nav-btn icon-btn${menuOpen ? " active" : ""}`}
+                onClick={() => setMenuOpen((o) => !o)}
+                title="Menu"
+                aria-label="Menu"
+                aria-expanded={menuOpen}
+              >
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+                  <circle cx="12" cy="5" r="2" />
+                  <circle cx="12" cy="12" r="2" />
+                  <circle cx="12" cy="19" r="2" />
+                </svg>
+              </button>
+              {menuOpen && (
+                <div className="toolbar-menu" role="menu">
+                  <button className="toolbar-menu-item" role="menuitem" onClick={() => { setSearchOpen(true); setMenuOpen(false); }}>
+                    <span>Find by title</span><kbd>⌘P</kbd>
+                  </button>
+                  <button className="toolbar-menu-item" role="menuitem" onClick={() => { setFtsOpen(true); setMenuOpen(false); }}>
+                    <span>Search content</span><kbd>⇧⌘F</kbd>
+                  </button>
+                  <div className="toolbar-menu-separator" />
+                  <button className="toolbar-menu-item" role="menuitem" onClick={() => { setSidebarOpen((o) => !o); setMenuOpen(false); }}>
+                    <span>{sidebarOpen ? "Hide" : "Show"} sidebar</span><kbd>⌘\</kbd>
+                  </button>
+                  <button className="toolbar-menu-item" role="menuitem" onClick={() => { setBacklinksOpen((o) => !o); setMenuOpen(false); }}>
+                    <span>{backlinksOpen ? "Hide" : "Show"} links panel</span>
+                  </button>
+                  <div className="toolbar-menu-separator" />
+                  <button className="toolbar-menu-item" role="menuitem" onClick={() => { navigateBack(); setMenuOpen(false); }} disabled={!canGoBack}>
+                    <span>Go back</span><kbd>⌥←</kbd>
+                  </button>
+                  <button className="toolbar-menu-item" role="menuitem" onClick={() => { navigateForward(); setMenuOpen(false); }} disabled={!canGoForward}>
+                    <span>Go forward</span><kbd>⌥→</kbd>
+                  </button>
+                  {activeTabId && (
+                    <>
+                      <div className="toolbar-menu-separator" />
+                      <button className="toolbar-menu-item" role="menuitem" onClick={() => { handleCloseTab(activeTabId); setMenuOpen(false); }}>
+                        <span>Close tab</span><kbd>⌘W</kbd>
+                      </button>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
             {showLogout && (
               <form method="POST" action="/logout" className="logout-form-inline">
                 <button type="submit" className="nav-btn icon-btn logout-icon-btn" title="Sign out" aria-label="Sign out">
@@ -889,7 +980,7 @@ export default function App() {
               <p>{isMobile ? "Tap the sidebar icon below to browse files" : "Select a file from the sidebar to view its contents"}</p>
               {!isMobile && (
                 <p className="hint">
-                  Press <kbd>⌘P</kbd> or <kbd>⌘K</kbd> to search
+                  Press <kbd>⌘P</kbd> to find by title · <kbd>⇧⌘F</kbd> to search content
                 </p>
               )}
             </div>
@@ -1006,6 +1097,13 @@ export default function App() {
           collection={selectedCollection ?? ""}
           onClose={() => setSearchOpen(false)}
           onNavigate={handleSearchNavigate}
+        />
+      )}
+      {ftsOpen && (
+        <FullTextSearch
+          collection={selectedCollection ?? ""}
+          onClose={() => setFtsOpen(false)}
+          onNavigate={handleFtsNavigate}
         />
       )}
     </>

--- a/packages/ui/src/components/FullTextSearch.tsx
+++ b/packages/ui/src/components/FullTextSearch.tsx
@@ -1,0 +1,167 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+
+interface FTSResult {
+  collection: string;
+  entityId: number;
+  externalId: string;
+  entityType: string;
+  title: string;
+  markdownPath: string | null;
+  rank: number;
+  snippet: string;
+}
+
+interface FullTextSearchProps {
+  collection: string;
+  onClose: () => void;
+  onNavigate: (collection: string, markdownPath: string, openNewTab?: boolean) => void;
+}
+
+function SnippetDisplay({ html }: { html: string }) {
+  return (
+    <span
+      className="fts-snippet"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+export default function FullTextSearch({ collection, onClose, onNavigate }: FullTextSearchProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<FTSResult[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const doSearch = useCallback(
+    async (q: string) => {
+      if (!q.trim()) {
+        setResults([]);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({ q: q.trim(), limit: "30" });
+        if (collection) params.set("collection", collection);
+        const res = await fetch(`/api/search?${params}`);
+        if (res.ok) {
+          const data: FTSResult[] = await res.json();
+          setResults(data);
+          setSelectedIndex(0);
+        }
+      } catch {
+        // ignore network errors
+      } finally {
+        setLoading(false);
+      }
+    },
+    [collection],
+  );
+
+  const handleChange = (value: string) => {
+    setQuery(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => doSearch(value), 200);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const item = list.children[selectedIndex] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter" && results.length > 0) {
+      e.preventDefault();
+      const result = results[selectedIndex];
+      if (result.markdownPath) {
+        onNavigate(result.collection, result.markdownPath);
+      }
+    } else if (e.key === "Escape") {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="search-overlay" onClick={onClose}>
+      <div className="search-dialog fts-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="search-input-wrapper">
+          <svg className="fts-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            className="search-input"
+            placeholder="Search content across all pages…"
+            value={query}
+            onChange={(e) => handleChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+          {loading && <span className="search-spinner">⏳</span>}
+        </div>
+        {results.length > 0 && (
+          <ul className="search-results" role="listbox" ref={listRef}>
+            {results.map((r, i) => (
+              <li
+                key={`${r.collection}-${r.entityId}`}
+                className={`search-result fts-result${i === selectedIndex ? " selected" : ""}`}
+                role="option"
+                aria-selected={i === selectedIndex}
+                onClick={(e) => {
+                  if (r.markdownPath) {
+                    onNavigate(r.collection, r.markdownPath, e.metaKey || e.ctrlKey);
+                  }
+                }}
+              >
+                <span className="search-result-title">{r.title}</span>
+                {r.snippet && (
+                  <span className="fts-snippet-wrapper">
+                    <SnippetDisplay html={r.snippet} />
+                  </span>
+                )}
+                <span className="search-result-meta">
+                  {r.entityType}
+                  {r.markdownPath && r.markdownPath.includes("/") && (
+                    <> · {r.markdownPath.split("/").slice(0, -1).join("/")}</>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+        {query && !loading && results.length === 0 && (
+          <div className="search-empty">No results found</div>
+        )}
+        {!query && (
+          <div className="search-empty fts-hint">
+            Type to search across all page content
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/worker/src/db/search.ts
+++ b/packages/worker/src/db/search.ts
@@ -5,6 +5,7 @@ export interface SearchResult {
   title: string;
   collectionName: string;
   rank: number;
+  snippet: string;
 }
 
 export async function searchEntities(
@@ -18,7 +19,8 @@ export async function searchEntities(
   let sql = `
     SELECT
       entity_id, external_id, entity_type, title, collection_name,
-      rank
+      rank,
+      snippet(entities_fts, 4, '<mark>', '</mark>', '…', 48) AS snippet
     FROM entities_fts
     WHERE entities_fts MATCH ?
   `;
@@ -44,6 +46,7 @@ export async function searchEntities(
     title: string;
     collection_name: string;
     rank: number;
+    snippet: string;
   }>();
 
   return (results ?? []).map((r) => ({
@@ -53,5 +56,6 @@ export async function searchEntities(
     title: r.title,
     collectionName: r.collection_name,
     rank: r.rank,
+    snippet: r.snippet ?? "",
   }));
 }

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -186,7 +186,7 @@ api.get("/api/search", async (c) => {
       const entity = await getEntityByExternalId(c.env.DB, r.collectionName, r.externalId);
       const rawPath = entity?.markdown_path ?? null;
       const markdownPath = rawPath ? rawPath.replace(/^markdown\//, "") : null;
-      return { ...r, collection: r.collectionName, markdownPath };
+      return { ...r, collection: r.collectionName, markdownPath, snippet: r.snippet };
     }),
   );
 


### PR DESCRIPTION
## Summary
- add full-text entity search endpoint handling in local serve and worker API layers
- extend search indexing/query logic in core and worker DB search modules
- add a new FullTextSearch UI component and wire it into the app
- add accompanying UI styling updates for the search experience

## Changed files
- packages/cli/src/commands/serve.ts
- packages/core/src/search/indexer.ts
- packages/ui/src/App.css
- packages/ui/src/App.tsx
- packages/ui/src/components/FullTextSearch.tsx
- packages/worker/src/db/search.ts
- packages/worker/src/handlers/api.ts