### PR TITLE
[codex] combine PR CI checks into one job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,74 +7,18 @@ on:
     branches: [main]
 
 jobs:
-  typecheck:
-    name: Type Check
+  ci:
+    name: CI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
-
-  test-core:
-    name: Test Core
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
       - run: bun test packages/core/src/
-
-  test-crawlers:
-    name: Test Crawlers
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
       - run: bun test packages/crawlers/src/
-
-  test-mcp:
-    name: Test MCP
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
       - run: bun test packages/mcp/src/
-
-  test-cli:
-    name: Test CLI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
       - run: bun test packages/cli/src/
-
-  test-ui:
-    name: Test UI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
       - run: cd packages/ui && npx vitest run
-
-  build-ui:
-    name: Build UI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
       - run: bun run build:ui
-
-  build-worker:
-    name: Build Worker
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
       - run: cd packages/worker && bun run build


### PR DESCRIPTION
## Summary
- replace the 8 parallel jobs in \.github/workflows/ci.yml with a single ci job
- keep the same checks (typecheck, package tests, UI test, UI build, worker build)
- run setup/install once, then execute checks sequentially

## Why
PRs were spawning 8 parallel jobs for a small/fast pipeline, which adds overhead and noise.

## Impact
- each PR now has one CI job instead of eight
- CI still validates the same commands, just in one runner

## Validation
- workflow file updated and committed
- branch pushed to GitHub