### PR TITLE
Add interactive TUI, npm publishing, and standalone executables for CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,10 +41,24 @@ packages/
 
   cli/src/                CLI entry point
     index.ts              Commander program with all subcommands
-    commands/             init, add, sync, status, collections, search, config, serve, daemon, generate, index, publish, unpublish
+    commands/             init, add, sync, status, collections, search, config, serve, daemon, generate, index, publish, unpublish, tui
     commands/wrangler-api.ts     Wrangler CLI subprocess helpers (D1, R2, Workers)
     commands/management-api.ts   Management REST API (collection CRUD, sync, publish, export, config)
     commands/publish.ts          publishCollections() reusable function + CLI command
+    tui/                         Interactive TUI (Ink + React)
+      index.tsx                  Entry point, renders the Ink app
+      components/App.tsx         Main app shell with keyboard navigation
+      components/Dashboard.tsx   Status overview (collections + deployments)
+      components/CollectionList.tsx  Collection CRUD (enable/disable, rename, delete, edit title)
+      components/AddCollection.tsx   Step-by-step collection creation wizard
+      components/SyncView.tsx    Sync with real-time progress
+      components/PublishView.tsx  Publish wizard (new/update/worker-only)
+      components/ExportView.tsx  Export to markdown/HTML
+      components/SettingsView.tsx Settings management (sync interval, concurrency, retries, log level)
+      components/SearchView.tsx  Full-text search
+      components/DeploymentList.tsx  View/unpublish deployments
+      components/SelectInput.tsx Reusable arrow-key select component
+      components/TextInput.tsx   Reusable text input component
 
   worker/src/             Cloudflare Worker (published deployments)
     index.ts              Worker entry (export default { fetch })
@@ -103,6 +117,27 @@ The API server supports both runtimes via a `handleRequest(req: Request): Respon
 Management API endpoints can return `Promise<Response>` (for async operations like reading request body, running sync). The `handleAsync()` helper casts `Promise<Response>` to `Response`. This works because Bun.serve's `fetch` handler accepts `Promise<Response>`, and the Node adapter uses `await Promise.resolve(handleRequest(req))`.
 
 Management routes are checked first via `handleManagementRequest(req)` which returns `Response | null`. On `null`, the request falls through to browse API routes.
+
+### CLI TUI (`fink tui`)
+
+The CLI includes an interactive TUI built with Ink (React for terminals). It provides **feature parity with the Desktop app's management UI** for collection management:
+
+| Feature | Desktop (Electron) | CLI TUI (`fink tui`) |
+|---------|-------------------|---------------------|
+| Collection CRUD | CollectionList + CollectionForm | CollectionList + AddCollection |
+| Enable/disable collections | Toggle in CollectionList | [t] key in CollectionList |
+| Sync with progress | SyncPanel + SyncProgress | SyncView with real-time output |
+| Publish wizard | PublishPanel with presets | PublishView (new/update/worker-only) |
+| Export markdown/HTML | ExportPanel | ExportView |
+| Settings (sync, logging) | SettingsPanel | SettingsView |
+| Deployment management | DeploymentList | DeploymentList with unpublish |
+| Full-text search | SearchBar (browse mode) | SearchView |
+| Rename/delete collections | CollectionList actions | [r]/[x] keys in CollectionList |
+| Edit title | CollectionForm | [n] key in CollectionList |
+
+**Navigation**: Keyboard shortcuts `[d]`ashboard, `[c]`ollections, `[a]`dd, `[s]`ync, `[p]`ublish, `[e]`xport, `[f]`ind/search, `[v]` deployments, `[g]` settings. ESC goes back, `q` quits.
+
+**Architecture**: The TUI uses Ink 7 with React 19 to render terminal UI components. Each screen is a standalone React component in `packages/cli/src/tui/components/`. The TUI reuses the same core logic as the CLI commands (e.g., `publishCollections()`, `unpublishDeployment()`, `exportStaticSite()`).
 
 ### UI Mode Architecture
 

--- a/README.md
+++ b/README.md
@@ -82,17 +82,45 @@ Each crawler syncs a different data source into Frozen Ink. See individual docs 
 | [Git](packages/crawlers/src/git/) | Local Git repository | Commits, Branches, Tags | [README](packages/crawlers/src/git/README.md) |
 | MantisBT | MantisBT REST API | Issues, Attachments | — |
 
-## Quick Start
+## Install the CLI
 
-All commands below run from the **repository root**. No global install required.
+### From npm (easiest)
 
 ```bash
-# Install dependencies
-bun install
-
-# Initialize Frozen Ink (~/.frozenink/)
-bun run fink -- init
+npm install -g @vboctor/fink
+fink    # launches the interactive TUI
 ```
+
+### Standalone binary (no Node.js required)
+
+Download pre-built binaries from the [releases page](https://github.com/vboctor/fink/releases):
+
+```bash
+# macOS Apple Silicon
+curl -L -o fink https://github.com/vboctor/fink/releases/latest/download/fink-darwin-arm64
+chmod +x fink && sudo mv fink /usr/local/bin/
+```
+
+Available binaries: `fink-darwin-arm64`, `fink-darwin-x64`, `fink-linux-x64`, `fink-linux-arm64`
+
+### From source (development)
+
+```bash
+git clone https://github.com/vboctor/fink.git && cd fink
+bun install
+cd packages/cli && bun link && cd ../..   # links `fink` globally
+fink    # works from anywhere
+```
+
+## Quick Start
+
+```bash
+# Initialize Frozen Ink (~/.frozenink/)
+fink init
+```
+
+> **Note:** If running from source without `bun link`, prefix commands with `bun run fink --`:
+> `bun run fink -- init`, `bun run fink -- sync "*"`, etc.
 
 ### Adding collections
 
@@ -231,14 +259,18 @@ curl -X POST http://localhost:3747/api/export \
 
 ## CLI Commands
 
+Running `fink` with no arguments launches the **interactive TUI** with keyboard-driven access to all features (dashboard, collections, sync, publish, export, search, settings).
+
 | Command | Description |
 |---------|-------------|
+| `fink` | Launch interactive TUI |
 | `fink init` | Initialize `~/.frozenink/` directory and config |
 | `fink add <type>` | Add a new collection (github, obsidian, git, mantisbt) |
 | `fink sync <name\|"*">` | Sync a collection or all (`"*"`) |
 | `fink status` | Show sync status for all collections |
 | `fink search <query>` | Full-text search across all collections |
 | `fink collections list\|remove\|enable\|disable\|rename\|update` | Manage collections |
+| `fink update <name>` | Update collection config |
 | `fink config get\|set\|list` | View/edit configuration |
 | `fink generate <name\|"*">` | Re-generate markdown without re-syncing |
 | `fink index <name\|"*">` | Rebuild search index and links |
@@ -246,6 +278,7 @@ curl -X POST http://localhost:3747/api/export \
 | `fink daemon start\|stop\|status` | Background sync daemon |
 | `fink publish <collections...>` | Publish to Cloudflare (see [docs/publish.md](docs/publish.md)) |
 | `fink unpublish <name>` | Remove a Cloudflare deployment |
+| `fink tui` | Launch TUI explicitly |
 
 ## Web UI
 
@@ -283,7 +316,10 @@ Exposes 5 tools and 4 resources for AI assistants:
 ## Development
 
 ```bash
-# Install the fink CLI globally (one-time)
+# Install dependencies (always from repo root, never npm)
+bun install
+
+# Link the fink CLI globally (one-time)
 cd packages/cli && bun link && cd ../..
 
 # Dev server: API on :3000 + Vite hot reload on :5173
@@ -293,12 +329,6 @@ bun run dev
 fink sync "*"
 fink status
 fink search "my query"
-
-# Build UI for production
-bun run build:ui
-
-# Build worker for publishing
-cd packages/worker && bun run build
 
 # Type-check all packages
 bun run typecheck
@@ -313,6 +343,59 @@ cd packages/ui && npx vitest run
 # Clean dist output
 bun run clean
 ```
+
+## Building & Releasing
+
+### CLI npm package (`@vboctor/fink`)
+
+The CLI is published to npm as a minified ESM bundle with the `better-sqlite3` native dependency.
+
+```bash
+cd packages/cli
+
+# Build the minified bundle (dist/fink.mjs + dist/package.json)
+bun run build
+
+# Build standalone Bun executables for all platforms
+bun run build:exe
+
+# Build everything (npm bundle + executables)
+bun run build:all
+
+# Publish to npm (builds automatically, then publishes dist/)
+bun run publish:npm
+```
+
+**What the build produces:**
+
+| Output | Size | Description |
+|--------|------|-------------|
+| `dist/fink.mjs` | ~1.7 MB | Minified ESM bundle (npm package) |
+| `dist/fink-darwin-arm64` | ~60 MB | macOS Apple Silicon standalone |
+| `dist/fink-darwin-x64` | ~65 MB | macOS Intel standalone |
+| `dist/fink-linux-x64` | ~96 MB | Linux x64 standalone |
+| `dist/fink-linux-arm64` | ~96 MB | Linux ARM64 standalone |
+| `dist/package.json` | — | npm package manifest (`@vboctor/fink`) |
+
+The standalone binaries include the Bun runtime and all dependencies — no Node.js or Bun install required. Upload them to GitHub Releases.
+
+**Version bumping:**
+
+Update the version in `packages/cli/package.json` before publishing. The build script copies the version to `dist/package.json`.
+
+### UI and Worker
+
+```bash
+# Build UI for production (required before serve or publish)
+bun run build:ui
+
+# Build worker for Cloudflare publishing
+cd packages/worker && bun run build
+```
+
+### Desktop app
+
+See the [Desktop App](#desktop-app) section above.
 
 ## Project Structure
 

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,12 @@
         "@frozenink/mcp": "workspace:*",
         "commander": "^13.0.0",
         "drizzle-orm": "^0.39.0",
+        "ink": "^7.0.0",
+        "react": "^19.2.5",
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.14",
+        "esbuild": "^0.25.0",
       },
     },
     "packages/core": {
@@ -118,6 +124,8 @@
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
 
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -505,9 +513,11 @@
 
     "ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "app-builder-bin": ["app-builder-bin@5.0.0-alpha.10", "", {}, "sha512-Ev4jj3D7Bo+O0GPD2NMvJl+PGiBAfS7pUGawntBNpCbxtpncfUixqFj9z9Jme7V7s3LBGqsWZZP54fxBX3JKJw=="],
 
@@ -538,6 +548,8 @@
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "at-least-node": ["at-least-node@1.0.0", "", {}, "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -599,7 +611,7 @@
 
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
-    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
@@ -619,17 +631,21 @@
 
     "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
-    "cli-cursor": ["cli-cursor@3.1.0", "", { "dependencies": { "restore-cursor": "^3.1.0" } }, "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="],
+    "cli-boxes": ["cli-boxes@4.0.1", "", {}, "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw=="],
+
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
 
     "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
 
-    "cli-truncate": ["cli-truncate@2.1.0", "", { "dependencies": { "slice-ansi": "^3.0.0", "string-width": "^4.2.0" } }, "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg=="],
+    "cli-truncate": ["cli-truncate@6.0.0", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
 
     "clone-response": ["clone-response@1.0.3", "", { "dependencies": { "mimic-response": "^1.0.0" } }, "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA=="],
+
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -658,6 +674,8 @@
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -757,6 +775,8 @@
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
     "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
@@ -771,6 +791,8 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
+
     "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
@@ -779,7 +801,7 @@
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
-    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
@@ -850,6 +872,8 @@
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -923,7 +947,7 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
-    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
     "infer-owner": ["infer-owner@1.0.4", "", {}, "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="],
 
@@ -932,6 +956,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "ink": ["ink@7.0.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-fMie5/VwIYXofMyND0s+fOVhwVBBPYx+uuqJ6V6rUBGjui+2UYp+0fWtvhSeKT4z+X1uH98a4ge5Vj3aTlL6mg=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
@@ -947,9 +973,11 @@
 
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-interactive": ["is-interactive@1.0.0", "", {}, "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="],
 
@@ -1213,6 +1241,8 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
+
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -1271,13 +1301,15 @@
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
-    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-markdown": ["react-markdown@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw=="],
+
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
@@ -1311,7 +1343,7 @@
 
     "responselike": ["responselike@2.0.1", "", { "dependencies": { "lowercase-keys": "^2.0.0" } }, "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw=="],
 
-    "restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
@@ -1371,7 +1403,7 @@
 
     "simple-update-notifier": ["simple-update-notifier@2.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w=="],
 
-    "slice-ansi": ["slice-ansi@3.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ=="],
+    "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
@@ -1391,6 +1423,8 @@
 
     "ssri": ["ssri@9.0.1", "", { "dependencies": { "minipass": "^3.1.1" } }, "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q=="],
 
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "stat-mode": ["stat-mode@1.0.0", "", {}, "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg=="],
@@ -1399,7 +1433,7 @@
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1407,7 +1441,7 @@
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1423,6 +1457,8 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
     "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
@@ -1430,6 +1466,8 @@
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "temp-file": ["temp-file@3.4.0", "", { "dependencies": { "async-exit-hook": "^2.0.1", "fs-extra": "^10.0.0" } }, "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg=="],
+
+    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -1461,7 +1499,7 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+    "type-fest": ["type-fest@5.5.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -1529,17 +1567,19 @@
 
     "wide-align": ["wide-align@1.1.5", "", { "dependencies": { "string-width": "^1.0.2 || 2 || 3 || 4" } }, "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg=="],
 
+    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
+
     "workerd": ["workerd@1.20260401.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260401.1", "@cloudflare/workerd-darwin-arm64": "1.20260401.1", "@cloudflare/workerd-linux-64": "1.20260401.1", "@cloudflare/workerd-linux-arm64": "1.20260401.1", "@cloudflare/workerd-windows-64": "1.20260401.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-mUYCd+ohaWJWF5nhDzxugWaAD/DM8Dw0ze3B7bu8JaA7S70+XQJXcvcvwE8C4qGcxSdCyqjsrFzqxKubECDwzg=="],
 
     "wrangler": ["wrangler@4.80.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260401.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260401.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260401.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-2ZKF7uPeOZy65BGk3YfvqBCPo/xH1MrAlMmH9mVP+tCNBrTUMnwOHSj1HrZHgR8LttkAqhko0fGz+I4ax1rzyQ=="],
 
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
@@ -1554,6 +1594,8 @@
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
@@ -1591,17 +1633,19 @@
 
     "@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
 
+    "@electron/rebuild/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "@electron/universal/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
     "@electron/universal/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
+    "@frozenink/ui/react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+
     "@frozenink/worker/esbuild": ["esbuild@0.24.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.24.2", "@esbuild/android-arm": "0.24.2", "@esbuild/android-arm64": "0.24.2", "@esbuild/android-x64": "0.24.2", "@esbuild/darwin-arm64": "0.24.2", "@esbuild/darwin-x64": "0.24.2", "@esbuild/freebsd-arm64": "0.24.2", "@esbuild/freebsd-x64": "0.24.2", "@esbuild/linux-arm": "0.24.2", "@esbuild/linux-arm64": "0.24.2", "@esbuild/linux-ia32": "0.24.2", "@esbuild/linux-loong64": "0.24.2", "@esbuild/linux-mips64el": "0.24.2", "@esbuild/linux-ppc64": "0.24.2", "@esbuild/linux-riscv64": "0.24.2", "@esbuild/linux-s390x": "0.24.2", "@esbuild/linux-x64": "0.24.2", "@esbuild/netbsd-arm64": "0.24.2", "@esbuild/netbsd-x64": "0.24.2", "@esbuild/openbsd-arm64": "0.24.2", "@esbuild/openbsd-x64": "0.24.2", "@esbuild/sunos-x64": "0.24.2", "@esbuild/win32-arm64": "0.24.2", "@esbuild/win32-ia32": "0.24.2", "@esbuild/win32-x64": "0.24.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
@@ -1617,6 +1661,8 @@
 
     "accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
+    "aggregate-error/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
     "ajv-keywords/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "app-builder-lib/@electron/rebuild": ["@electron/rebuild@3.6.1", "", { "dependencies": { "@malept/cross-spawn-promise": "^2.0.0", "chalk": "^4.0.0", "debug": "^4.1.1", "detect-libc": "^2.0.1", "fs-extra": "^10.0.0", "got": "^11.7.0", "node-abi": "^3.45.0", "node-api-version": "^0.2.0", "node-gyp": "^9.0.0", "ora": "^5.1.0", "read-binary-file-arch": "^1.0.6", "semver": "^7.3.5", "tar": "^6.0.5", "yargs": "^17.0.1" }, "bin": { "electron-rebuild": "lib/cli.js" } }, "sha512-f6596ZHpEq/YskUd8emYvOUne89ij8mQgjYFA5ru25QwbrRO+t1SImofdDv7kKOuWCmVOuU5tvfkbgGxIl3E/w=="],
@@ -1627,7 +1673,15 @@
 
     "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "builder-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "cacache/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
 
@@ -1641,6 +1695,10 @@
 
     "electron/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
+    "electron-builder/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "electron-publish/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
@@ -1649,11 +1707,19 @@
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
+    "gauge/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "gauge/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
+    "iconv-corefoundation/cli-truncate": ["cli-truncate@2.1.0", "", { "dependencies": { "slice-ansi": "^3.0.0", "string-width": "^4.2.0" } }, "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg=="],
+
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "log-symbols/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "make-fetch-happen/http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
 
@@ -1661,7 +1727,11 @@
 
     "make-fetch-happen/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
+    "matcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "minipass-collect/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
@@ -1677,11 +1747,19 @@
 
     "node-gyp/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
+    "ora/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "ora/cli-cursor": ["cli-cursor@3.1.0", "", { "dependencies": { "restore-cursor": "^3.1.0" } }, "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="],
+
+    "ora/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
@@ -1689,13 +1767,23 @@
 
     "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
+    "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
+    "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+
     "socks-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "ssri/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "string-width-cjs/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
@@ -1707,7 +1795,17 @@
 
     "vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
+    "wide-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -1722,6 +1820,8 @@
     "@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "@electron/get/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
+
+    "@electron/rebuild/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@electron/universal/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
@@ -1821,17 +1921,23 @@
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
-    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
     "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "app-builder-lib/@electron/rebuild/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "archiver-utils/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "archiver-utils/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "archiver-utils/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "builder-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "config-file-ts/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
@@ -1841,17 +1947,31 @@
 
     "dmg-license/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
+    "electron-builder/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "electron-publish/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "electron/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "gauge/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "gauge/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "glob/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
+
+    "iconv-corefoundation/cli-truncate/slice-ansi": ["slice-ansi@3.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ=="],
+
+    "iconv-corefoundation/cli-truncate/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "log-symbols/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "make-fetch-happen/http-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
@@ -1859,9 +1979,17 @@
 
     "node-gyp/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
+    "ora/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "ora/cli-cursor/restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
+
+    "ora/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
     "rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -1919,6 +2047,10 @@
 
     "vitest/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
+    "wide-align/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "wide-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
     "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
@@ -1971,11 +2103,21 @@
 
     "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
+    "wrap-ansi-cjs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "zip-stream/archiver-utils/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "@electron/asar/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@electron/universal/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "app-builder-lib/@electron/rebuild/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "archiver-utils/glob/minimatch/brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
 
@@ -1986,6 +2128,14 @@
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "iconv-corefoundation/cli-truncate/slice-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "iconv-corefoundation/cli-truncate/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "iconv-corefoundation/cli-truncate/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "iconv-corefoundation/cli-truncate/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "node-gyp/glob/minimatch/brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
 
@@ -2085,11 +2235,17 @@
 
     "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
+    "wide-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "zip-stream/archiver-utils/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "config-file-ts/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "iconv-corefoundation/cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "node-gyp/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,191 @@
+# @vboctor/fink
+
+**Frozen Ink CLI** — crawl, sync, search, and publish local data replicas from GitHub, Obsidian, Git repos, and MantisBT.
+
+Frozen Ink creates a unified, queryable, markdown-native workspace from your data sources. It stores everything in local SQLite with full-text search, renders Obsidian-compatible markdown, and optionally publishes to Cloudflare as a password-protected website with MCP access for AI tools.
+
+## Install
+
+### npm (recommended)
+
+```bash
+npm install -g @vboctor/fink
+```
+
+Requires Node.js >= 20 and a C++ toolchain for the SQLite native module (`better-sqlite3`).
+
+### Standalone binary (no dependencies)
+
+Download the pre-built binary for your platform from the [releases page](https://github.com/vboctor/fink/releases):
+
+| Platform | Binary |
+|----------|--------|
+| macOS Apple Silicon | `fink-darwin-arm64` |
+| macOS Intel | `fink-darwin-x64` |
+| Linux x64 | `fink-linux-x64` |
+| Linux ARM64 | `fink-linux-arm64` |
+
+```bash
+# Example: macOS Apple Silicon
+curl -L -o fink https://github.com/vboctor/fink/releases/latest/download/fink-darwin-arm64
+chmod +x fink
+sudo mv fink /usr/local/bin/
+```
+
+### From source (development)
+
+```bash
+git clone https://github.com/vboctor/fink.git
+cd fink
+bun install
+cd packages/cli && bun link    # makes `fink` available globally
+```
+
+## Quick Start
+
+```bash
+# Initialize (creates ~/.frozenink/)
+fink init
+
+# Add a GitHub repository
+fink add github --name my-repo --token ghp_xxx --repo owner/repo
+
+# Add a local Obsidian vault
+fink add obsidian --name my-notes --path ~/Documents/MyVault
+
+# Add a local Git repo
+fink add git --name my-code --path ~/projects/my-project
+
+# Sync everything
+fink sync "*"
+
+# Check status
+fink status
+
+# Search across all collections
+fink search "authentication bug"
+```
+
+## Interactive TUI
+
+Running `fink` without arguments launches the interactive TUI:
+
+```bash
+fink
+```
+
+The TUI provides keyboard-driven access to all features:
+
+| Key | Screen |
+|-----|--------|
+| `d` | Dashboard (overview) |
+| `c` | Collections (manage) |
+| `a` | Add collection |
+| `s` | Sync |
+| `p` | Publish to Cloudflare |
+| `e` | Export |
+| `f` | Search |
+| `v` | Deployments |
+| `g` | Settings |
+| `ESC` | Go back |
+| `q` | Quit |
+
+## Commands
+
+All commands are also available in headless mode for scripting and CI:
+
+| Command | Description |
+|---------|-------------|
+| `fink` | Launch interactive TUI |
+| `fink init` | Initialize `~/.frozenink/` |
+| `fink add <type>` | Add a collection (github, obsidian, git, mantisbt) |
+| `fink sync <name\|"*">` | Sync one or all collections |
+| `fink sync <name> --full` | Full re-sync from scratch |
+| `fink status` | Show sync status |
+| `fink search <query>` | Full-text search |
+| `fink collections list` | List all collections |
+| `fink collections remove <name>` | Delete a collection |
+| `fink collections enable <name>` | Enable a collection |
+| `fink collections disable <name>` | Disable a collection |
+| `fink collections rename <old> <new>` | Rename a collection |
+| `fink update <name>` | Update collection config |
+| `fink config list` | Show configuration |
+| `fink config get <key>` | Get a config value |
+| `fink config set <key> <value>` | Set a config value |
+| `fink generate <name\|"*">` | Re-render markdown from DB |
+| `fink index <name\|"*">` | Rebuild search index |
+| `fink serve` | Start API server + web UI |
+| `fink serve --mcp-only` | Start MCP server only |
+| `fink daemon start\|stop\|status` | Background sync daemon |
+| `fink publish <collections...>` | Publish to Cloudflare |
+| `fink unpublish <name>` | Remove a deployment |
+| `fink tui` | Launch TUI explicitly |
+
+## Publishing to Cloudflare
+
+Publish collections as a password-protected website with remote MCP access:
+
+```bash
+# Authenticate with Cloudflare first
+npx wrangler login
+
+# Publish
+fink publish my-repo my-notes --password secret123 --name my-site
+
+# Update an existing deployment
+fink publish my-repo my-notes --password secret123 --name my-site
+
+# Remove
+fink unpublish my-site
+```
+
+Published sites include:
+- Web UI for browsing synced data
+- Full-text search
+- MCP endpoint for AI assistants at `https://my-site.workers.dev/mcp`
+
+## MCP Server
+
+Frozen Ink includes an MCP server for AI tools (Claude, etc.):
+
+```bash
+# Local MCP server (STDIO transport)
+fink serve --mcp-only
+
+# Or use the published MCP endpoint
+claude mcp add frozenink --transport streamable-http \
+  --url https://my-site.workers.dev/mcp \
+  --header "Authorization: Bearer <password>"
+```
+
+**Tools:** `collection_list`, `entity_search`, `entity_get_data`, `entity_get_markdown`, `entity_get_attachment`
+
+## Configuration
+
+Configuration is stored in `~/.frozenink/config.json`:
+
+```bash
+fink config set sync.interval 1800    # sync every 30 minutes
+fink config set sync.concurrency 2    # parallel sync workers
+fink config set sync.retries 5        # retry count
+fink config set logging.level debug   # log level
+```
+
+## Data Storage
+
+All data is stored locally in `~/.frozenink/`:
+
+```
+~/.frozenink/
+  config.json                # app configuration
+  context.yml                # collection registry + deployment metadata
+  collections/
+    <name>/
+      data.db                # SQLite database (entities, sync state, FTS5)
+      markdown/              # rendered markdown files
+      attachments/           # binary files (images, etc.)
+```
+
+## License
+
+MIT

--- a/packages/cli/build.mjs
+++ b/packages/cli/build.mjs
@@ -1,0 +1,169 @@
+/**
+ * Build script for the Frozen Ink CLI.
+ *
+ * Produces two outputs:
+ *   1. dist/fink.mjs  — Minified ESM bundle for npm publishing (runs via Node/Bun)
+ *   2. dist/fink-*     — Standalone Bun executables for direct download
+ *
+ * All @frozenink/* workspace packages are inlined. External native dependencies
+ * (better-sqlite3, bun:sqlite) are resolved at runtime.
+ */
+import { build } from "esbuild";
+import { execSync } from "child_process";
+import { existsSync, mkdirSync, writeFileSync, readFileSync, copyFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distDir = join(__dirname, "dist");
+
+// ── Step 1: Bundle with esbuild ────────────────────────────────────────
+
+async function bundleJS() {
+  mkdirSync(distDir, { recursive: true });
+
+  await build({
+    entryPoints: [join(__dirname, "src/index.ts")],
+    bundle: true,
+    platform: "node",
+    target: "node20",
+    format: "esm",
+    outfile: join(distDir, "fink.mjs"),
+    minify: true,
+    treeShaking: true,
+    sourcemap: false,
+    legalComments: "none",
+    // ESM shim for packages that use require()
+    banner: {
+      js: [
+        "#!/usr/bin/env node",
+        'import { createRequire } from "node:module";',
+        "const require = createRequire(import.meta.url);",
+      ].join("\n"),
+    },
+    external: [
+      // Native SQLite — resolved at runtime via the compat layer
+      "better-sqlite3",
+      "bun:sqlite",
+      "drizzle-orm/bun-sqlite",
+      // Native Node modules
+      "fsevents",
+      // Optional dev dependency of ink
+      "react-devtools-core",
+    ],
+    resolveExtensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
+    // Ensure JSX is handled
+    jsx: "automatic",
+    loader: { ".tsx": "tsx", ".ts": "ts" },
+  });
+
+  console.log("✓ Bundled dist/fink.mjs");
+}
+
+// ── Step 2: Compile standalone Bun executables ─────────────────────────
+
+async function compileBunExecutables() {
+  // Bun's `bun build --compile` resolves all imports including native ones.
+  // For Bun executables, bun:sqlite is built-in and better-sqlite3 is not needed.
+  // We compile directly from source — Bun handles TypeScript natively.
+  //
+  // Note: Cross-compilation (e.g., building linux binary on macOS) requires
+  // that the target runtime can resolve all imports. We compile only the
+  // current platform by default; CI builds each platform natively.
+
+  const targets = [
+    { name: "fink-darwin-arm64", target: "bun-darwin-arm64" },
+    { name: "fink-darwin-x64", target: "bun-darwin-x64" },
+    { name: "fink-linux-x64", target: "bun-linux-x64" },
+    { name: "fink-linux-arm64", target: "bun-linux-arm64" },
+  ];
+
+  for (const { name, target } of targets) {
+    const outPath = join(distDir, name);
+    try {
+      execSync(
+        `bun build --compile --minify --target=${target} src/index.ts --outfile ${outPath} --external better-sqlite3 --external react-devtools-core`,
+        { cwd: __dirname, stdio: "pipe" },
+      );
+      console.log(`✓ Compiled ${name}`);
+    } catch (err) {
+      // Cross-compilation may fail for some targets — that's expected
+      const stderr = err.stderr ? err.stderr.toString().split("\n")[0] : "";
+      console.warn(`⚠ Skipped ${name}${stderr ? ": " + stderr : ""}`);
+    }
+  }
+}
+
+// ── Step 3: Generate npm package.json for dist ─────────────────────────
+
+function generateDistPackageJson() {
+  const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf-8"));
+
+  const distPkg = {
+    name: "@vboctor/fink",
+    version: pkg.version,
+    description: "Frozen Ink CLI — crawl, sync, search, and publish local data replicas",
+    license: "MIT",
+    author: "Victor Boctor",
+    repository: {
+      type: "git",
+      url: "https://github.com/vboctor/fink",
+    },
+    homepage: "https://github.com/vboctor/fink#readme",
+    bugs: {
+      url: "https://github.com/vboctor/fink/issues",
+    },
+    keywords: [
+      "cli",
+      "data-sync",
+      "obsidian",
+      "github",
+      "git",
+      "markdown",
+      "mcp",
+      "cloudflare-workers",
+      "sqlite",
+      "full-text-search",
+    ],
+    type: "module",
+    bin: {
+      fink: "./fink.mjs",
+    },
+    engines: {
+      node: ">=20.0.0",
+    },
+    files: ["fink.mjs", "README.md", "LICENSE"],
+    // Runtime deps that are externalized from the bundle
+    dependencies: {
+      "better-sqlite3": "^11.0.0",
+    },
+  };
+
+  writeFileSync(join(distDir, "package.json"), JSON.stringify(distPkg, null, 2));
+  console.log("✓ Generated dist/package.json");
+}
+
+// ── Main ───────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const bundleOnly = args.includes("--bundle-only");
+const exeOnly = args.includes("--exe-only");
+const all = !bundleOnly && !exeOnly;
+
+if (all || bundleOnly) {
+  await bundleJS();
+  generateDistPackageJson();
+
+  // Copy README for npm
+  const readmeSrc = join(__dirname, "README.md");
+  if (existsSync(readmeSrc)) {
+    copyFileSync(readmeSrc, join(distDir, "README.md"));
+    console.log("✓ Copied README.md to dist/");
+  }
+}
+
+if (all || exeOnly) {
+  await compileBunExecutables();
+}
+
+console.log("\nBuild complete.");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,13 +9,24 @@
     "fink": "src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build": "bun build.mjs --bundle-only",
+    "build:exe": "bun build.mjs --exe-only",
+    "build:all": "bun build.mjs",
+    "prepublish": "bun build.mjs --bundle-only",
+    "publish:npm": "bun build.mjs --bundle-only && cd dist && npm publish --access public"
   },
   "dependencies": {
-    "@frozenink/crawlers": "workspace:*",
     "@frozenink/core": "workspace:*",
+    "@frozenink/crawlers": "workspace:*",
     "@frozenink/mcp": "workspace:*",
     "commander": "^13.0.0",
-    "drizzle-orm": "^0.39.0"
+    "drizzle-orm": "^0.39.0",
+    "ink": "^7.0.0",
+    "react": "^19.2.5"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "esbuild": "^0.25.0"
   }
 }

--- a/packages/cli/src/commands/tui.ts
+++ b/packages/cli/src/commands/tui.ts
@@ -1,0 +1,8 @@
+import { Command } from "commander";
+import { startTui } from "../tui/index.js";
+
+export const tuiCommand = new Command("tui")
+  .description("Launch the interactive TUI interface")
+  .action(async () => {
+    await startTui();
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,8 @@ import { daemonCommand } from "./commands/daemon";
 import { publishCommand } from "./commands/publish";
 import { updateCommand } from "./commands/update";
 import { unpublishCommand } from "./commands/unpublish";
+import { tuiCommand } from "./commands/tui";
+import { startTui } from "./tui/index";
 
 const program = new Command();
 
@@ -36,5 +38,12 @@ program.addCommand(serveCommand);
 program.addCommand(daemonCommand);
 program.addCommand(publishCommand);
 program.addCommand(unpublishCommand);
+program.addCommand(tuiCommand);
 
-await program.parseAsync();
+// If no arguments passed (just "fink"), launch TUI by default
+const args = process.argv.slice(2);
+if (args.length === 0 && process.stdin.isTTY) {
+  await startTui();
+} else {
+  await program.parseAsync();
+}

--- a/packages/cli/src/tui/components/AddCollection.tsx
+++ b/packages/cli/src/tui/components/AddCollection.tsx
@@ -1,0 +1,332 @@
+import React, { useState, useCallback } from "react";
+import { Box, Text, useInput } from "ink";
+import { mkdirSync } from "fs";
+import { join, resolve } from "path";
+import {
+  contextExists,
+  getFrozenInkHome,
+  getCollectionDb,
+  getCollectionDbPath,
+  getCollection,
+  addCollection,
+  isValidCollectionKey,
+} from "@frozenink/core";
+import { createDefaultRegistry } from "@frozenink/crawlers";
+import { SelectInput, type SelectItem } from "./SelectInput.js";
+import { TextInput } from "./TextInput.js";
+
+type Step =
+  | "select-crawler"
+  | "name"
+  | "title"
+  | "github-token"
+  | "github-repo"
+  | "github-open-only"
+  | "github-max-issues"
+  | "github-max-prs"
+  | "obsidian-path"
+  | "git-path"
+  | "git-include-diffs"
+  | "mantisbt-url"
+  | "mantisbt-token"
+  | "mantisbt-project-id"
+  | "mantisbt-max"
+  | "confirm"
+  | "validating"
+  | "done"
+  | "error";
+
+interface FormData {
+  crawlerType: string;
+  name: string;
+  title: string;
+  config: Record<string, unknown>;
+  credentials: Record<string, unknown>;
+}
+
+function getStepsForCrawler(type: string): Step[] {
+  const base: Step[] = ["select-crawler", "name", "title"];
+  switch (type) {
+    case "github":
+      return [...base, "github-token", "github-repo", "github-open-only", "github-max-issues", "github-max-prs", "confirm"];
+    case "obsidian":
+      return [...base, "obsidian-path", "confirm"];
+    case "git":
+      return [...base, "git-path", "git-include-diffs", "confirm"];
+    case "mantisbt":
+      return [...base, "mantisbt-url", "mantisbt-token", "mantisbt-project-id", "mantisbt-max", "confirm"];
+    default:
+      return [...base, "confirm"];
+  }
+}
+
+export function AddCollection({
+  onDone,
+}: {
+  onDone: () => void;
+}): React.ReactElement {
+  const [step, setStep] = useState<Step>("select-crawler");
+  const [data, setData] = useState<FormData>({
+    crawlerType: "",
+    name: "",
+    title: "",
+    config: {},
+    credentials: {},
+  });
+  const [inputValue, setInputValue] = useState("");
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+
+  const registry = createDefaultRegistry();
+  const crawlerTypes = registry.getRegisteredTypes();
+
+  const nextStep = useCallback(() => {
+    if (!data.crawlerType) return;
+    const steps = getStepsForCrawler(data.crawlerType);
+    const currentIdx = steps.indexOf(step);
+    if (currentIdx < steps.length - 1) {
+      setStep(steps[currentIdx + 1]);
+      setInputValue("");
+      setError("");
+    }
+  }, [step, data.crawlerType]);
+
+  const handleCrawlerSelect = useCallback(
+    (item: SelectItem) => {
+      setData((d) => ({ ...d, crawlerType: item.value }));
+      setStep("name");
+      setInputValue("");
+    },
+    [],
+  );
+
+  const handleTextSubmit = useCallback(() => {
+    const val = inputValue.trim();
+
+    switch (step) {
+      case "name": {
+        if (!val) { setError("Name is required"); return; }
+        if (!isValidCollectionKey(val)) { setError("Only letters, numbers, dashes, underscores"); return; }
+        if (getCollection(val)) { setError(`"${val}" already exists`); return; }
+        setData((d) => ({ ...d, name: val }));
+        nextStep();
+        break;
+      }
+      case "title":
+        setData((d) => ({ ...d, title: val }));
+        nextStep();
+        break;
+      case "github-token":
+        if (!val) { setError("Token is required"); return; }
+        setData((d) => ({ ...d, credentials: { ...d.credentials, token: val } }));
+        nextStep();
+        break;
+      case "github-repo": {
+        if (!val) { setError("Repo is required (owner/repo)"); return; }
+        const parts = val.split("/");
+        if (parts.length !== 2 || !parts[0] || !parts[1]) { setError("Format: owner/repo"); return; }
+        setData((d) => ({
+          ...d,
+          config: { ...d.config, owner: parts[0], repo: parts[1] },
+          credentials: { ...d.credentials, owner: parts[0], repo: parts[1] },
+        }));
+        nextStep();
+        break;
+      }
+      case "github-open-only":
+        if (val.toLowerCase() === "y" || val.toLowerCase() === "yes") {
+          setData((d) => ({ ...d, config: { ...d.config, openOnly: true } }));
+        }
+        nextStep();
+        break;
+      case "github-max-issues": {
+        if (val) {
+          const n = parseInt(val, 10);
+          if (isNaN(n) || n < 1) { setError("Enter a positive number or leave blank"); return; }
+          setData((d) => ({ ...d, config: { ...d.config, maxIssues: n } }));
+        }
+        nextStep();
+        break;
+      }
+      case "github-max-prs": {
+        if (val) {
+          const n = parseInt(val, 10);
+          if (isNaN(n) || n < 1) { setError("Enter a positive number or leave blank"); return; }
+          setData((d) => ({ ...d, config: { ...d.config, maxPullRequests: n } }));
+        }
+        nextStep();
+        break;
+      }
+      case "obsidian-path":
+        if (!val) { setError("Path is required"); return; }
+        setData((d) => ({
+          ...d,
+          config: { ...d.config, vaultPath: resolve(val) },
+          credentials: { ...d.credentials, vaultPath: resolve(val) },
+        }));
+        nextStep();
+        break;
+      case "git-path":
+        if (!val) { setError("Path is required"); return; }
+        setData((d) => ({
+          ...d,
+          config: { ...d.config, repoPath: resolve(val) },
+          credentials: { ...d.credentials, repoPath: resolve(val) },
+        }));
+        nextStep();
+        break;
+      case "git-include-diffs":
+        if (val.toLowerCase() === "y" || val.toLowerCase() === "yes") {
+          setData((d) => ({ ...d, config: { ...d.config, includeDiffs: true } }));
+        }
+        nextStep();
+        break;
+      case "mantisbt-url":
+        if (!val) { setError("URL is required"); return; }
+        setData((d) => ({
+          ...d,
+          config: { ...d.config, baseUrl: val },
+          credentials: { ...d.credentials, baseUrl: val },
+        }));
+        nextStep();
+        break;
+      case "mantisbt-token":
+        setData((d) => ({ ...d, credentials: { ...d.credentials, token: val || "" } }));
+        nextStep();
+        break;
+      case "mantisbt-project-id": {
+        if (val) {
+          const n = parseInt(val, 10);
+          if (isNaN(n) || n < 1) { setError("Enter a positive number or leave blank"); return; }
+          setData((d) => ({ ...d, config: { ...d.config, projectId: n } }));
+        }
+        nextStep();
+        break;
+      }
+      case "mantisbt-max": {
+        if (val) {
+          const n = parseInt(val, 10);
+          if (isNaN(n) || n < 1) { setError("Enter a positive number or leave blank"); return; }
+          setData((d) => ({ ...d, config: { ...d.config, maxEntities: n } }));
+        }
+        nextStep();
+        break;
+      }
+    }
+  }, [step, inputValue, nextStep]);
+
+  const handleConfirm = useCallback(async () => {
+    setStep("validating");
+    try {
+      const factory = registry.get(data.crawlerType);
+      if (!factory) { setError("Unknown crawler"); setStep("error"); return; }
+      const crawler = factory();
+      const valid = await crawler.validateCredentials(data.credentials);
+      if (!valid) { setError("Credential validation failed"); setStep("error"); return; }
+
+      const home = getFrozenInkHome();
+      const dir = join(home, "collections", data.name);
+      mkdirSync(dir, { recursive: true });
+      getCollectionDb(getCollectionDbPath(data.name));
+      mkdirSync(join(dir, "markdown"), { recursive: true });
+
+      addCollection(data.name, {
+        title: data.title || undefined,
+        crawler: data.crawlerType,
+        config: data.config,
+        credentials: data.credentials,
+      });
+
+      setMessage(`Collection "${data.name}" created!`);
+      setStep("done");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+      setStep("error");
+    }
+  }, [data, registry]);
+
+  useInput((input, key) => {
+    if (step === "confirm") {
+      if (input === "y") handleConfirm();
+      if (input === "n" || key.escape) onDone();
+    }
+    if (step === "done" || step === "error") {
+      if (key.return || key.escape) onDone();
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      <Text bold>Add Collection</Text>
+      <Box marginTop={1} flexDirection="column">
+        {step === "select-crawler" && (
+          <SelectInput
+            label="Select crawler type"
+            items={crawlerTypes.map((t: string) => ({ label: t, value: t }))}
+            onSelect={handleCrawlerSelect}
+          />
+        )}
+
+        {step === "name" && (
+          <TextInput label="Collection name" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} placeholder="my-collection" />
+        )}
+        {step === "title" && (
+          <TextInput label="Display title (optional)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} placeholder="My Collection" />
+        )}
+        {step === "github-token" && (
+          <TextInput label="GitHub token" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} mask />
+        )}
+        {step === "github-repo" && (
+          <TextInput label="Repository (owner/repo)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} placeholder="owner/repo" />
+        )}
+        {step === "github-open-only" && (
+          <TextInput label="Only sync open issues/PRs? (y/N)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
+        )}
+        {step === "github-max-issues" && (
+          <TextInput label="Max issues (blank for unlimited)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
+        )}
+        {step === "github-max-prs" && (
+          <TextInput label="Max PRs (blank for unlimited)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
+        )}
+        {step === "obsidian-path" && (
+          <TextInput label="Vault path" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} placeholder="/path/to/vault" />
+        )}
+        {step === "git-path" && (
+          <TextInput label="Repository path" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} placeholder="/path/to/repo" />
+        )}
+        {step === "git-include-diffs" && (
+          <TextInput label="Include commit diffs? (y/N)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
+        )}
+        {step === "mantisbt-url" && (
+          <TextInput label="MantisBT base URL" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} placeholder="https://mantis.example.com" />
+        )}
+        {step === "mantisbt-token" && (
+          <TextInput label="API token (optional)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
+        )}
+        {step === "mantisbt-project-id" && (
+          <TextInput label="Project ID (blank for all)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
+        )}
+        {step === "mantisbt-max" && (
+          <TextInput label="Max entities (blank for unlimited)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
+        )}
+
+        {step === "confirm" && (
+          <Box flexDirection="column">
+            <Text bold>Summary</Text>
+            <Text>  Crawler: <Text color="cyan">{data.crawlerType}</Text></Text>
+            <Text>  Name:    <Text color="cyan">{data.name}</Text></Text>
+            {data.title && <Text>  Title:   <Text color="cyan">{data.title}</Text></Text>}
+            <Box marginTop={1}>
+              <Text>Create this collection? (y/n)</Text>
+            </Box>
+          </Box>
+        )}
+
+        {step === "validating" && <Text color="yellow">Validating credentials...</Text>}
+        {step === "done" && <Text color="green">{message} Press Enter to continue.</Text>}
+        {step === "error" && <Text color="red">Error: {error}. Press Enter to go back.</Text>}
+        {error && !["error", "done"].includes(step) && <Text color="red">{error}</Text>}
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/components/App.tsx
+++ b/packages/cli/src/tui/components/App.tsx
@@ -1,0 +1,135 @@
+import React, { useState } from "react";
+import { Box, Text, useApp, useInput } from "ink";
+import {
+  contextExists,
+  listCollections,
+} from "@frozenink/core";
+import { CollectionList } from "./CollectionList.js";
+import { SyncView } from "./SyncView.js";
+import { PublishView } from "./PublishView.js";
+import { SettingsView } from "./SettingsView.js";
+import { SearchView } from "./SearchView.js";
+
+export type Screen =
+  | "home"
+  | "collections"
+  | "sync"
+  | "publish"
+  | "settings"
+  | "search";
+
+interface MenuItem {
+  key: string;
+  label: string;
+  description: string;
+  screen: Screen;
+  requiresCollections?: boolean;
+}
+
+const ALL_MENU_ITEMS: MenuItem[] = [
+  { key: "c", label: "Collections", description: "View, manage, add, export, and sync your data sources", screen: "collections" },
+  { key: "s", label: "Sync", description: "Sync all enabled collections at once", screen: "sync", requiresCollections: true },
+  { key: "f", label: "Search", description: "Full-text search across all synced content", screen: "search", requiresCollections: true },
+  { key: "p", label: "Publish", description: "Publish to Cloudflare and manage deployments", screen: "publish", requiresCollections: true },
+  { key: "g", label: "Settings", description: "Configure sync interval, concurrency, and logging", screen: "settings" },
+];
+
+export function App(): React.ReactElement {
+  const { exit } = useApp();
+  const [screen, setScreen] = useState<Screen>("home");
+  const [menuCursor, setMenuCursor] = useState(0);
+
+  const initialized = contextExists();
+  const hasCollections = initialized && listCollections().length > 0;
+  const menuItems = ALL_MENU_ITEMS.filter(
+    (item) => !item.requiresCollections || hasCollections,
+  );
+
+  useInput((input, key) => {
+    if (input === "q" && screen === "home") {
+      exit();
+      return;
+    }
+    if (key.escape) {
+      if (screen !== "home") {
+        setScreen("home");
+      } else {
+        exit();
+      }
+      return;
+    }
+
+    // Home screen: up/down + enter navigation + shortcuts
+    if (screen === "home") {
+      if (key.upArrow) setMenuCursor((c) => Math.max(0, c - 1));
+      if (key.downArrow) setMenuCursor((c) => Math.min(menuItems.length - 1, c + 1));
+      if (key.return) {
+        setScreen(menuItems[menuCursor].screen);
+        return;
+      }
+      if (input === "d") { setScreen("collections"); return; }
+      const nav = menuItems.find((n) => n.key === input);
+      if (nav) setScreen(nav.screen);
+    }
+    // Sub-screens handle their own key bindings — no global shortcuts
+  });
+
+  if (screen === "home") {
+    return (
+      <Box flexDirection="column">
+        <Box paddingX={1} paddingY={1} gap={1}>
+          <Text> </Text>
+          <Text bold color="cyan">Frozen Ink</Text>
+          <Text dimColor>— Local data replica manager</Text>
+        </Box>
+        {!initialized && (
+          <Box paddingX={2} marginBottom={1}>
+            <Text color="yellow">Not initialized. Select Collections to get started.</Text>
+          </Box>
+        )}
+        {initialized && !hasCollections && (
+          <Box paddingX={2} marginBottom={1}>
+            <Text dimColor>No collections configured. Select Collections to add one.</Text>
+          </Box>
+        )}
+        <Box flexDirection="column" paddingX={1}>
+          {menuItems.map((item, i) => (
+            <Box key={item.key} gap={1}>
+              <Text color={i === menuCursor ? "cyan" : "gray"}>{i === menuCursor ? "❯" : " "}</Text>
+              <Text dimColor>[{item.key}]</Text>
+              <Text bold={i === menuCursor} color={i === menuCursor ? "cyan" : undefined}>
+                {item.label.padEnd(18)}
+              </Text>
+              <Text dimColor>{item.description}</Text>
+            </Box>
+          ))}
+        </Box>
+        <Box paddingX={1} marginTop={1}>
+          <Text dimColor>↑↓ navigate  Enter select  q quit</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  const screenLabel = ALL_MENU_ITEMS.find((m) => m.screen === screen)?.label ?? screen;
+
+  return (
+    <Box flexDirection="column">
+      <Box paddingX={1} gap={1}>
+        <Text bold color="cyan">Frozen Ink</Text>
+        <Text dimColor>›</Text>
+        <Text bold>{screenLabel}</Text>
+      </Box>
+      <Box flexDirection="column" paddingX={1}>
+        {screen === "collections" && <CollectionList onNavigate={setScreen} />}
+        {screen === "sync" && <SyncView />}
+        {screen === "publish" && <PublishView onDone={() => setScreen("home")} />}
+        {screen === "settings" && <SettingsView />}
+        {screen === "search" && <SearchView />}
+      </Box>
+      <Box paddingX={1}>
+        <Text dimColor>ESC back to menu</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/components/CollectionList.tsx
+++ b/packages/cli/src/tui/components/CollectionList.tsx
@@ -1,0 +1,613 @@
+import React, { useState, useCallback } from "react";
+import { Box, Text, useInput } from "ink";
+import { existsSync, renameSync, rmSync } from "fs";
+import { join, basename } from "path";
+import {
+  contextExists,
+  listCollections,
+  listDeployments,
+  getCollection,
+  getCollectionDb,
+  getCollectionDbPath,
+  getFrozenInkHome,
+  updateCollection,
+  removeCollection,
+  renameCollection,
+  isValidCollectionKey,
+  entities,
+  syncRuns,
+  SyncEngine,
+  ThemeEngine,
+  LocalStorageBackend,
+} from "@frozenink/core";
+import {
+  createDefaultRegistry,
+  gitHubTheme,
+  obsidianTheme,
+  gitTheme,
+  mantisBTTheme,
+} from "@frozenink/crawlers";
+import { desc, sql } from "drizzle-orm";
+import { TextInput } from "./TextInput.js";
+import { AddCollection } from "./AddCollection.js";
+import { ExportView } from "./ExportView.js";
+import { SearchView } from "./SearchView.js";
+import type { Screen } from "./App.js";
+
+type Mode =
+  | "list"
+  | "edit"
+  | "add"
+  | "export"
+  | "search"
+  | "confirm-delete"
+  | "syncing";
+
+// Fixed-width columns
+const W_CHECK = 6;
+const W_NAME = 20;
+const W_TITLE = 22;
+const W_TYPE = 12;
+const W_ENTITIES = 10;
+
+function pad(text: string, width: number): string {
+  if (text.length >= width) return text.slice(0, width - 1) + " ";
+  return text + " ".repeat(width - text.length);
+}
+
+function formatRelative(date: Date): string {
+  const diffMs = Date.now() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}
+
+interface RowStats {
+  entityCount: string;
+  lastSync: string;
+}
+
+function getRowStats(name: string): RowStats {
+  const dbPath = getCollectionDbPath(name);
+  if (!existsSync(dbPath)) return { entityCount: "—", lastSync: "—" };
+  try {
+    const colDb = getCollectionDb(dbPath);
+    const [{ total }] = colDb.select({ total: sql<number>`count(*)` }).from(entities).all();
+    const runs = colDb.select().from(syncRuns).orderBy(desc(syncRuns.startedAt)).limit(1).all();
+    let lastSync = "never";
+    if (runs.length > 0 && runs[0].startedAt) {
+      const d = new Date(runs[0].startedAt + "Z");
+      if (!isNaN(d.getTime())) {
+        lastSync = formatRelative(d);
+        if (runs[0].status === "failed") lastSync += " (failed)";
+      }
+    }
+    return { entityCount: String(total), lastSync };
+  } catch {
+    return { entityCount: "err", lastSync: "—" };
+  }
+}
+
+function getSourceDetails(crawler: string, config: Record<string, unknown>): Array<{ label: string; value: string }> {
+  const details: Array<{ label: string; value: string }> = [];
+  switch (crawler) {
+    case "github": {
+      const owner = config.owner as string | undefined;
+      const repo = config.repo as string | undefined;
+      if (owner && repo) details.push({ label: "Repository", value: `${owner}/${repo}` });
+      if (config.openOnly) details.push({ label: "Filter", value: "open issues/PRs only" });
+      if (config.maxIssues) details.push({ label: "Max issues", value: String(config.maxIssues) });
+      if (config.maxPullRequests) details.push({ label: "Max PRs", value: String(config.maxPullRequests) });
+      if (config.syncComments === false) details.push({ label: "Comments", value: "disabled" });
+      break;
+    }
+    case "obsidian": {
+      const vaultPath = config.vaultPath as string | undefined;
+      if (vaultPath) {
+        details.push({ label: "Vault", value: basename(vaultPath) });
+        details.push({ label: "Path", value: vaultPath });
+      }
+      break;
+    }
+    case "git": {
+      const repoPath = config.repoPath as string | undefined;
+      if (repoPath) {
+        details.push({ label: "Repository", value: basename(repoPath) });
+        details.push({ label: "Path", value: repoPath });
+      }
+      if (config.includeDiffs) details.push({ label: "Diffs", value: "included" });
+      break;
+    }
+    case "mantisbt": {
+      const baseUrl = config.baseUrl as string | undefined;
+      if (baseUrl) details.push({ label: "URL", value: baseUrl });
+      if (config.projectId) details.push({ label: "Project ID", value: String(config.projectId) });
+      if (config.maxEntities) details.push({ label: "Max entities", value: String(config.maxEntities) });
+      break;
+    }
+  }
+  return details;
+}
+
+/** Editable fields per crawler type */
+interface EditField {
+  key: string;
+  label: string;
+  type: "number" | "boolean";
+  configKey: string;
+}
+
+function getEditableFields(crawler: string): EditField[] {
+  switch (crawler) {
+    case "github":
+      return [
+        { key: "title", label: "Display title", type: "number" as const, configKey: "" },
+        { key: "openOnly", label: "Open issues/PRs only", type: "boolean", configKey: "openOnly" },
+        { key: "maxIssues", label: "Max issues", type: "number", configKey: "maxIssues" },
+        { key: "maxPrs", label: "Max pull requests", type: "number", configKey: "maxPullRequests" },
+        { key: "syncComments", label: "Sync comments", type: "boolean", configKey: "syncComments" },
+        { key: "syncCheckStatuses", label: "Sync check statuses", type: "boolean", configKey: "syncCheckStatuses" },
+      ];
+    case "git":
+      return [
+        { key: "title", label: "Display title", type: "number" as const, configKey: "" },
+        { key: "includeDiffs", label: "Include commit diffs", type: "boolean", configKey: "includeDiffs" },
+      ];
+    case "mantisbt":
+      return [
+        { key: "title", label: "Display title", type: "number" as const, configKey: "" },
+        { key: "maxEntities", label: "Max entities", type: "number", configKey: "maxEntities" },
+      ];
+    case "obsidian":
+      return [
+        { key: "title", label: "Display title", type: "number" as const, configKey: "" },
+      ];
+    default:
+      return [
+        { key: "title", label: "Display title", type: "number" as const, configKey: "" },
+      ];
+  }
+}
+
+// ── CollectionEdit sub-screen ──────────────────────────────────────────
+
+function CollectionEdit({
+  collectionName,
+  onDone,
+}: {
+  collectionName: string;
+  onDone: () => void;
+}): React.ReactElement {
+  // All hooks must be called before any early return
+  const [editCursor, setEditCursor] = useState(0);
+  const [editing, setEditing] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [saved, setSaved] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const col = getCollection(collectionName);
+  const config = col ? (col.config as Record<string, unknown>) : {};
+  const fields = col ? getEditableFields(col.crawler) : [];
+  const sourceDetails = col ? getSourceDetails(col.crawler, config) : [];
+
+  function getCurrentValue(field: EditField): string {
+    if (!col) return "";
+    if (field.key === "title") return col.title || "";
+    const val = config[field.configKey];
+    if (val === undefined || val === null) return "";
+    return String(val);
+  }
+
+  function getCurrentDisplay(field: EditField): string {
+    if (!col) return "";
+    if (field.key === "title") return col.title || "(none)";
+    const val = config[field.configKey];
+    if (field.type === "boolean") {
+      if (val === true) return "yes";
+      if (val === false) return "no";
+      return "(default)";
+    }
+    if (val === undefined || val === null) return "(default)";
+    return String(val);
+  }
+
+  useInput((input, key) => {
+    if (!col || editing) return;
+
+    if (key.escape) {
+      onDone();
+      return;
+    }
+    if (key.upArrow) setEditCursor((c) => Math.max(0, c - 1));
+    if (key.downArrow) setEditCursor((c) => Math.min(fields.length - 1, c + 1));
+    if (key.return && fields[editCursor]) {
+      const field = fields[editCursor];
+      if (field.type === "boolean" && field.key !== "title") {
+        const current = config[field.configKey];
+        const newVal = current === true ? false : true;
+        const newConfig = { ...config, [field.configKey]: newVal };
+        updateCollection(collectionName, { config: newConfig });
+        setSaved(true);
+        setRefreshKey((k) => k + 1);
+        setTimeout(() => setSaved(false), 1500);
+      } else {
+        setInputValue(getCurrentValue(field));
+        setEditing(true);
+      }
+    }
+  });
+
+  const handleEditSubmit = useCallback(() => {
+    if (!col) return;
+    const field = fields[editCursor];
+    if (!field) { setEditing(false); return; }
+    const val = inputValue.trim();
+
+    if (field.key === "title") {
+      updateCollection(collectionName, { title: val || undefined });
+    } else if (field.type === "number") {
+      const newConfig = { ...config };
+      if (val === "") {
+        delete newConfig[field.configKey];
+      } else {
+        const n = parseInt(val, 10);
+        if (!isNaN(n)) newConfig[field.configKey] = n;
+      }
+      updateCollection(collectionName, { config: newConfig });
+    }
+
+    setEditing(false);
+    setSaved(true);
+    setRefreshKey((k) => k + 1);
+    setTimeout(() => setSaved(false), 1500);
+  }, [editCursor, inputValue, fields, config, collectionName, col]);
+
+  if (!col) return <Text color="red">Collection not found.</Text>;
+
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      <Box gap={2}>
+        <Text bold>{col.title || col.name}</Text>
+        <Text dimColor>({col.crawler})</Text>
+        {saved && <Text color="green">Saved</Text>}
+      </Box>
+
+      {sourceDetails.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          {sourceDetails.map((d) => (
+            <Text key={d.label}>
+              <Text dimColor>{d.label}: </Text>
+              <Text>{d.value}</Text>
+            </Text>
+          ))}
+        </Box>
+      )}
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text bold dimColor>Settings</Text>
+        {fields.map((field, i) => {
+          if (editing && i === editCursor) {
+            return (
+              <Box key={field.key}>
+                <TextInput
+                  label={field.label}
+                  value={inputValue}
+                  onChange={setInputValue}
+                  onSubmit={handleEditSubmit}
+                />
+              </Box>
+            );
+          }
+
+          const display = getCurrentDisplay(field);
+          const isBool = field.type === "boolean" && field.key !== "title";
+          return (
+            <Box key={field.key} gap={1}>
+              <Text color={i === editCursor ? "cyan" : undefined}>
+                {i === editCursor ? "❯" : " "}
+              </Text>
+              <Text>{field.label}:</Text>
+              <Text bold color={isBool ? (display === "yes" ? "green" : "gray") : "cyan"}>
+                {display}
+              </Text>
+              {isBool && i === editCursor && <Text dimColor>(Enter to toggle)</Text>}
+            </Box>
+          );
+        })}
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>↑↓ navigate  Enter edit/toggle  ESC back</Text>
+      </Box>
+    </Box>
+  );
+}
+
+// ── Main CollectionList ────────────────────────────────────────────────
+
+export function CollectionList({
+  onNavigate,
+}: {
+  onNavigate?: (screen: Screen) => void;
+}): React.ReactElement {
+  // ── All hooks MUST be declared before any conditional returns ──
+  const [mode, setMode] = useState<Mode>("list");
+  const [cursor, setCursor] = useState(0);
+  const [message, setMessage] = useState("");
+  const [inputValue, setInputValue] = useState("");
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [syncProgress, setSyncProgress] = useState<string[]>([]);
+  const [editingCollection, setEditingCollection] = useState("");
+
+  const refresh = useCallback(() => setRefreshKey((k) => k + 1), []);
+
+  const initialized = contextExists();
+  const collections = initialized ? listCollections() : [];
+  const allDeployments = initialized ? listDeployments() : [];
+  const current = collections[cursor] ?? null;
+
+  // Detail stats for selected collection
+  let entityCount = 0;
+  let lastRun: {
+    status: string;
+    startedAt: string | null;
+    entitiesCreated: number;
+    entitiesUpdated: number;
+    entitiesDeleted: number;
+  } | null = null;
+  let lastSyncTime = "";
+  if (current && mode === "list") {
+    const dbPath = getCollectionDbPath(current.name);
+    if (existsSync(dbPath)) {
+      try {
+        const colDb = getCollectionDb(dbPath);
+        const [{ total }] = colDb.select({ total: sql<number>`count(*)` }).from(entities).all();
+        entityCount = total;
+        const runs = colDb.select().from(syncRuns).orderBy(desc(syncRuns.startedAt)).limit(1).all();
+        if (runs.length > 0) {
+          lastRun = runs[0];
+          if (runs[0].startedAt) {
+            const d = new Date(runs[0].startedAt + "Z");
+            if (!isNaN(d.getTime())) lastSyncTime = formatRelative(d);
+          }
+        }
+      } catch { /* ignore */ }
+    }
+  }
+
+  const relatedDeployments = current
+    ? allDeployments.filter((d: { collections: string[] }) => d.collections.includes(current.name))
+    : [];
+
+  const sourceDetails = current
+    ? getSourceDetails(current.crawler, current.config as Record<string, unknown>)
+    : [];
+
+  const startSync = useCallback(async () => {
+    if (!current) return;
+    setMode("syncing");
+    setSyncProgress([`Syncing "${current.name}" (${current.crawler})...`]);
+    try {
+      const registry = createDefaultRegistry();
+      const themeEngine = new ThemeEngine();
+      themeEngine.register(gitHubTheme);
+      themeEngine.register(obsidianTheme);
+      themeEngine.register(gitTheme);
+      themeEngine.register(mantisBTTheme);
+      const factory = registry.get(current.crawler);
+      if (!factory) { setSyncProgress((p) => [...p, `No crawler for ${current.crawler}`]); setMode("list"); return; }
+      const crawler = factory();
+      await crawler.initialize(current.config as Record<string, unknown>, current.credentials as Record<string, unknown>);
+      const home = getFrozenInkHome();
+      const dbPath = getCollectionDbPath(current.name);
+      const collectionDir = join(home, "collections", current.name);
+      const storage = new LocalStorageBackend(collectionDir);
+      const engine = new SyncEngine({
+        crawler, dbPath, collectionName: current.name, themeEngine, storage, markdownBasePath: "markdown",
+        onBatchFetched: ({ externalIds }: { externalIds: string[] }) => {
+          if (externalIds.length > 0) setSyncProgress((p) => [...p, `  Fetched ${externalIds.length} entities`]);
+        },
+      });
+      const stats = await engine.run();
+      const colDb = getCollectionDb(dbPath);
+      const [{ total }] = colDb.select({ total: sql<number>`count(*)` }).from(entities).all();
+      setSyncProgress((p) => [...p, `Done: +${stats.created} ~${stats.updated} -${stats.deleted} (${total} total)`]);
+      await crawler.dispose();
+      setMessage(`Sync complete for "${current.name}"`);
+    } catch (err) {
+      setSyncProgress((p) => [...p, `Error: ${err instanceof Error ? err.message : String(err)}`]);
+    }
+    setMode("list");
+    refresh();
+  }, [current, refresh]);
+
+  const handleRenameSubmit = useCallback(() => {
+    if (!current || !inputValue) { setMode("list"); return; }
+    if (!isValidCollectionKey(inputValue)) { setMessage("Invalid key. Use letters, numbers, dashes, underscores."); setMode("list"); return; }
+    if (getCollection(inputValue)) { setMessage(`"${inputValue}" already exists.`); setMode("list"); return; }
+    const home = getFrozenInkHome();
+    const oldDir = join(home, "collections", current.name);
+    const newDir = join(home, "collections", inputValue);
+    if (existsSync(oldDir)) renameSync(oldDir, newDir);
+    renameCollection(current.name, inputValue);
+    setMessage(`Renamed "${current.name}" → "${inputValue}"`);
+    setMode("list");
+    refresh();
+  }, [current, inputValue, refresh, cursor]);
+
+  useInput((input, key) => {
+    // Only handle input in list/confirm-delete modes; sub-screens handle their own input
+    if (mode === "list") {
+      if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
+      if (key.downArrow) setCursor((c) => Math.min(collections.length - 1, c + 1));
+      if (input === " " && current) {
+        updateCollection(current.name, { enabled: !current.enabled });
+        refresh();
+      }
+      if (key.return && current) {
+        setEditingCollection(current.name);
+        setMode("edit");
+      }
+      if (input === "a") setMode("add");
+      if (input === "x" && current) setMode("confirm-delete");
+      if (input === "s" && current) startSync();
+      if (input === "e" && current) { setEditingCollection(current.name); setMode("export"); }
+      if (input === "f" && current) { setEditingCollection(current.name); setMode("search"); }
+    } else if (mode === "confirm-delete") {
+      if (input === "y" && current) {
+        const home = getFrozenInkHome();
+        const dir = join(home, "collections", current.name);
+        if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+        removeCollection(current.name);
+        setMessage(`Deleted "${current.name}"`);
+        setCursor(Math.max(0, cursor - 1));
+        setMode("list");
+        refresh();
+      } else {
+        setMessage("");
+        setMode("list");
+      }
+    }
+  });
+
+  // ── All hooks are above this line ──
+
+  if (!initialized) {
+    return <Text color="yellow">Not initialized. Run `fink init` first.</Text>;
+  }
+
+  if (mode === "add") {
+    return <AddCollection onDone={() => { setMode("list"); refresh(); }} />;
+  }
+
+  if (mode === "edit" && editingCollection) {
+    return <CollectionEdit collectionName={editingCollection} onDone={() => { setMode("list"); refresh(); }} />;
+  }
+
+  if (mode === "export" && editingCollection) {
+    return <ExportView collectionName={editingCollection} onDone={() => { setMode("list"); }} />;
+  }
+
+  if (mode === "search" && editingCollection) {
+    return <SearchView collectionName={editingCollection} onDone={() => { setMode("list"); }} />;
+  }
+
+  if (mode === "syncing") {
+    return (
+      <Box flexDirection="column" paddingY={1}>
+        <Text bold color="yellow">Syncing...</Text>
+        <Box flexDirection="column" marginLeft={1} marginTop={1}>
+          {syncProgress.map((line, i) => <Text key={i} dimColor>{line}</Text>)}
+        </Box>
+      </Box>
+    );
+  }
+
+  if (collections.length === 0) {
+    return (
+      <Box flexDirection="column" paddingY={1}>
+        <Text dimColor>No collections configured.</Text>
+        <Box marginTop={1}><Text dimColor>Press [a] to add one.</Text></Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      <Text bold>Collections</Text>
+
+      {/* Table header */}
+      <Box marginLeft={1} marginTop={1}>
+        <Text dimColor>{pad("", 2)}</Text>
+        <Text dimColor>{pad("", W_CHECK)}</Text>
+        <Text bold dimColor>{pad("Name", W_NAME)}</Text>
+        <Text bold dimColor>{pad("Title", W_TITLE)}</Text>
+        <Text bold dimColor>{pad("Type", W_TYPE)}</Text>
+        <Text bold dimColor>{pad("Entities", W_ENTITIES)}</Text>
+        <Text bold dimColor>Last Sync</Text>
+      </Box>
+
+      {/* Table rows */}
+      <Box flexDirection="column" marginLeft={1}>
+        {collections.map((col: { name: string; title?: string; crawler: string; enabled: boolean }, i: number) => {
+          const stats = getRowStats(col.name);
+          const selected = i === cursor;
+          const checkbox = col.enabled ? "[x] " : "[ ] ";
+          return (
+            <Box key={col.name}>
+              <Text color={selected ? "cyan" : undefined}>{selected ? "❯ " : "  "}</Text>
+              <Text color={col.enabled ? "green" : "gray"}>{pad(checkbox, W_CHECK)}</Text>
+              <Text bold={selected} color={!col.enabled ? "gray" : selected ? "cyan" : undefined}>{pad(col.name, W_NAME)}</Text>
+              <Text dimColor>{pad(col.title || "", W_TITLE)}</Text>
+              <Text dimColor>{pad(col.crawler, W_TYPE)}</Text>
+              <Text color={!col.enabled ? "gray" : undefined}>{pad(stats.entityCount, W_ENTITIES)}</Text>
+              <Text dimColor>{stats.lastSync}</Text>
+            </Box>
+          );
+        })}
+      </Box>
+
+      {/* Detail panel */}
+      {current && (
+        <Box flexDirection="column" marginTop={1} marginLeft={2} borderStyle="single" borderColor="gray" paddingX={1}>
+          <Box gap={2}>
+            <Text bold>{current.title || current.name}</Text>
+            <Text dimColor>({current.crawler})</Text>
+            <Text>Entities: <Text bold>{entityCount}</Text></Text>
+          </Box>
+          {sourceDetails.length > 0 && (
+            <Box flexDirection="column">
+              {sourceDetails.map((d) => (
+                <Text key={d.label}><Text dimColor>{d.label}: </Text><Text>{d.value}</Text></Text>
+              ))}
+            </Box>
+          )}
+          {lastRun ? (
+            <Box gap={2}>
+              <Text>Last sync: <Text dimColor>{lastSyncTime}</Text> <Text color={lastRun.status === "completed" ? "green" : "red"}>({lastRun.status})</Text></Text>
+              <Text><Text color="green">+{lastRun.entitiesCreated}</Text> <Text color="yellow">~{lastRun.entitiesUpdated}</Text> <Text color="red">-{lastRun.entitiesDeleted}</Text></Text>
+            </Box>
+          ) : (
+            <Text dimColor>No sync runs yet</Text>
+          )}
+          {relatedDeployments.length > 0 && (
+            <Box flexDirection="column" marginTop={1}>
+              <Text dimColor bold>Deployments:</Text>
+              {relatedDeployments.map((dep: { name: string; url: string; passwordProtected: boolean }) => (
+                <Box key={dep.name} gap={1} marginLeft={1}>
+                  <Text>{dep.name}</Text>
+                  <Text dimColor>→</Text>
+                  <Text color="blue">{dep.url}</Text>
+                  <Text color={dep.passwordProtected ? "green" : "yellow"}>[{dep.passwordProtected ? "protected" : "public"}]</Text>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {mode === "confirm-delete" && (
+        <Box marginTop={1}>
+          <Text color="red">Delete "{current?.name}" and all its data? (y/N)</Text>
+        </Box>
+      )}
+
+      {message && <Box marginTop={1}><Text color="green">{message}</Text></Box>}
+
+      <Box marginTop={1} gap={2}>
+        <Text dimColor>[Enter] Edit</Text>
+        <Text dimColor>[s] Sync</Text>
+        <Text dimColor>[f] Search</Text>
+        <Text dimColor>[e] Export</Text>
+        <Text dimColor>[Space] Toggle</Text>
+        <Text dimColor>[a] Add</Text>
+        <Text dimColor>[x] Delete</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/components/ExportView.tsx
+++ b/packages/cli/src/tui/components/ExportView.tsx
@@ -1,0 +1,189 @@
+import React, { useState, useCallback } from "react";
+import { Box, Text, useInput } from "ink";
+import {
+  contextExists,
+  listCollections,
+  ThemeEngine,
+} from "@frozenink/core";
+import { exportStaticSite } from "@frozenink/core/export";
+import {
+  gitHubTheme,
+  obsidianTheme,
+  gitTheme,
+  mantisBTTheme,
+} from "@frozenink/crawlers";
+import { TextInput } from "./TextInput.js";
+
+type Step = "format" | "collections" | "output-dir" | "exporting" | "done" | "error";
+
+export function ExportView({
+  collectionName,
+  onDone,
+}: {
+  collectionName?: string;
+  onDone?: () => void;
+}): React.ReactElement {
+  const [step, setStep] = useState<Step>(collectionName ? "format" : "collections");
+  const [format, setFormat] = useState<"markdown" | "html">("markdown");
+  const [formatCursor, setFormatCursor] = useState(0);
+  const [selectedCollections, setSelectedCollections] = useState<Set<string>>(
+    collectionName ? new Set([collectionName]) : new Set(),
+  );
+  const [collCursor, setCollCursor] = useState(0);
+  const [outputDir, setOutputDir] = useState("");
+  const [progress, setProgress] = useState<string[]>([]);
+  const [error, setError] = useState("");
+
+  if (!contextExists()) {
+    return <Text color="yellow">Not initialized.</Text>;
+  }
+
+  const collections = listCollections()
+    .filter((c: { enabled: boolean }) => c.enabled)
+    .map((c: { name: string }) => c.name);
+
+  const formats = [
+    { label: "Markdown", value: "markdown" as const },
+    { label: "HTML", value: "html" as const },
+  ];
+
+  useInput((input, key) => {
+    if (step === "format") {
+      if (key.escape && onDone) { onDone(); return; }
+      if (key.upArrow || key.downArrow) setFormatCursor((c) => (c === 0 ? 1 : 0));
+      if (key.return) {
+        setFormat(formats[formatCursor].value);
+        setStep(collectionName ? "output-dir" : "collections");
+      }
+    }
+    if (step === "collections") {
+      if (key.upArrow) setCollCursor((c) => Math.max(0, c - 1));
+      if (key.downArrow) setCollCursor((c) => Math.min(collections.length - 1, c + 1));
+      if (input === " ") {
+        const name = collections[collCursor];
+        setSelectedCollections((prev) => {
+          const next = new Set(prev);
+          if (next.has(name)) next.delete(name);
+          else next.add(name);
+          return next;
+        });
+      }
+      if (key.return && selectedCollections.size > 0) {
+        setStep("output-dir");
+      }
+    }
+    if (step === "done" || step === "error") {
+      if (key.return || key.escape) {
+        if (onDone) { onDone(); return; }
+        setStep("format");
+        setProgress([]);
+        setError("");
+        setSelectedCollections(new Set());
+        setOutputDir("");
+      }
+    }
+  });
+
+  const handleOutputDirSubmit = useCallback(async () => {
+    const dir = outputDir.trim();
+    if (!dir) return;
+
+    setStep("exporting");
+    setProgress([]);
+
+    try {
+      let themeEngine: ThemeEngine | undefined;
+      if (format === "html") {
+        themeEngine = new ThemeEngine();
+        themeEngine.register(gitHubTheme);
+        themeEngine.register(obsidianTheme);
+        themeEngine.register(gitTheme);
+        themeEngine.register(mantisBTTheme);
+      }
+
+      await exportStaticSite({
+        collections: [...selectedCollections],
+        outputDir: dir,
+        format,
+        themeEngine,
+        onProgress: (stepName: string, current: number, total: number) => {
+          setProgress((p) => [...p, `${stepName}: ${current}/${total}`]);
+        },
+      });
+
+      setStep("done");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+      setStep("error");
+    }
+  }, [outputDir, selectedCollections, format]);
+
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      <Text bold>Export{collectionName ? ` "${collectionName}"` : ""}</Text>
+
+      {step === "format" && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>Select export format:</Text>
+          {formats.map((f, i) => (
+            <Box key={f.value}>
+              <Text color={i === formatCursor ? "cyan" : undefined}>
+                {i === formatCursor ? "❯ " : "  "}{f.label}
+              </Text>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {step === "collections" && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>
+            Format: <Text color="cyan">{format}</Text> — Select collections (space to toggle, enter to continue)
+          </Text>
+          {collections.map((name: string, i: number) => (
+            <Box key={name} gap={1}>
+              <Text color={i === collCursor ? "cyan" : undefined}>
+                {i === collCursor ? "❯" : " "}
+              </Text>
+              <Text>{selectedCollections.has(name) ? "[✓]" : "[ ]"}</Text>
+              <Text>{name}</Text>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {step === "output-dir" && (
+        <Box marginTop={1}>
+          <TextInput
+            label="Output directory"
+            value={outputDir}
+            onChange={setOutputDir}
+            onSubmit={handleOutputDirSubmit}
+            placeholder="/path/to/export"
+          />
+        </Box>
+      )}
+
+      {step === "exporting" && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color="yellow">Exporting...</Text>
+          {progress.slice(-10).map((line, i) => (
+            <Text key={i} dimColor>{line}</Text>
+          ))}
+        </Box>
+      )}
+
+      {step === "done" && (
+        <Box marginTop={1}>
+          <Text color="green">Export complete! Press Enter to continue.</Text>
+        </Box>
+      )}
+
+      {step === "error" && (
+        <Box marginTop={1}>
+          <Text color="red">Export failed: {error}. Press Enter to go back.</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/components/PublishView.tsx
+++ b/packages/cli/src/tui/components/PublishView.tsx
@@ -1,0 +1,460 @@
+import React, { useState, useCallback } from "react";
+import { Box, Text, useInput } from "ink";
+import { existsSync, statSync, readdirSync } from "fs";
+import { join } from "path";
+import { exec } from "child_process";
+import {
+  contextExists,
+  listCollections,
+  listDeployments,
+  getDeployment,
+  getCollectionDb,
+  getCollectionDbPath,
+  getFrozenInkHome,
+  entities,
+  syncRuns,
+} from "@frozenink/core";
+import { sql, desc } from "drizzle-orm";
+import { publishCollections, type PublishOptions } from "../../commands/publish.js";
+import { unpublishDeployment } from "../../commands/unpublish.js";
+import { TextInput } from "./TextInput.js";
+
+type View = "deployments" | "publish-wizard";
+type WizardStep = "select-mode" | "select-collections" | "worker-name" | "password" | "confirm" | "publishing" | "done" | "error";
+type DeploymentMode = "list" | "confirm-delete" | "deleting" | "done-delete" | "error-delete";
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getDirectorySize(dirPath: string): number {
+  if (!existsSync(dirPath)) return 0;
+  let total = 0;
+  try {
+    for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+      const full = join(dirPath, entry.name);
+      if (entry.isDirectory()) total += getDirectorySize(full);
+      else try { total += statSync(full).size; } catch {}
+    }
+  } catch {}
+  return total;
+}
+
+function getCollectionStats(name: string): { entityCount: number; diskSize: number; lastSyncAt: string | null } {
+  const dbPath = getCollectionDbPath(name);
+  let entityCount = 0;
+  let diskSize = 0;
+  let lastSyncAt: string | null = null;
+  if (existsSync(dbPath)) {
+    try {
+      const colDb = getCollectionDb(dbPath);
+      const [{ total }] = colDb.select({ total: sql<number>`count(*)` }).from(entities).all();
+      entityCount = total;
+      // Find last completed sync, fallback to last sync of any status
+      const completedRuns = colDb.select().from(syncRuns)
+        .where(sql`${syncRuns.status} = 'completed'`)
+        .orderBy(desc(syncRuns.startedAt)).limit(1).all();
+      if (completedRuns.length > 0) {
+        lastSyncAt = completedRuns[0].startedAt;
+      } else {
+        const anyRuns = colDb.select().from(syncRuns).orderBy(desc(syncRuns.startedAt)).limit(1).all();
+        if (anyRuns.length > 0) lastSyncAt = anyRuns[0].startedAt;
+      }
+    } catch {}
+    try { diskSize += statSync(dbPath).size; } catch {}
+  }
+  const home = getFrozenInkHome();
+  const colDir = join(home, "collections", name);
+  diskSize += getDirectorySize(join(colDir, "markdown"));
+  diskSize += getDirectorySize(join(colDir, "attachments"));
+  return { entityCount, diskSize, lastSyncAt };
+}
+
+function formatRelative(date: Date): string {
+  const diffMs = Date.now() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}
+
+export function PublishView({
+  onDone,
+}: {
+  onDone: () => void;
+}): React.ReactElement {
+  const [view, setView] = useState<View>("deployments");
+
+  // --- Deployment list state ---
+  const [depCursor, setDepCursor] = useState(0);
+  const [depMode, setDepMode] = useState<DeploymentMode>("list");
+  const [depProgress, setDepProgress] = useState<string[]>([]);
+  const [depError, setDepError] = useState("");
+  const [depMessage, setDepMessage] = useState("");
+  const [depRefresh, setDepRefresh] = useState(0);
+
+  // --- Publish wizard state ---
+  const [wizStep, setWizStep] = useState<WizardStep>("select-mode");
+  const [modeCursor, setModeCursor] = useState(0);
+  const [selectedCollections, setSelectedCollections] = useState<Set<string>>(new Set());
+  const [collCursor, setCollCursor] = useState(0);
+  const [workerName, setWorkerName] = useState("");
+  const [password, setPassword] = useState("");
+  const [workerOnly, setWorkerOnly] = useState(false);
+  const [pubProgress, setPubProgress] = useState<string[]>([]);
+  const [pubError, setPubError] = useState("");
+  const [pubResult, setPubResult] = useState<{ workerUrl: string; mcpUrl: string } | null>(null);
+  const [inputValue, setInputValue] = useState("");
+
+  if (!contextExists()) return <Text color="yellow">Not initialized.</Text>;
+
+  const collections = listCollections().filter((c: { enabled: boolean }) => c.enabled).map((c: { name: string }) => c.name);
+  const deployments = listDeployments();
+  const depNames = deployments.map((d: { name: string }) => d.name);
+  const currentDep = deployments[depCursor];
+
+  // Stats for selected deployment
+  let totalEntities = 0;
+  let totalSize = 0;
+  let isOutdated = false;
+  const collectionDetails: Array<{ name: string; entityCount: number; diskSize: number; lastSyncAt: string | null; syncedAfterPublish: boolean }> = [];
+  if (currentDep && view === "deployments") {
+    const publishedAt = currentDep.publishedAt ? new Date(currentDep.publishedAt) : null;
+    for (const cn of currentDep.collections) {
+      const s = getCollectionStats(cn);
+      const syncDate = s.lastSyncAt ? new Date(s.lastSyncAt + "Z") : null;
+      const syncedAfterPublish = !!(syncDate && publishedAt && syncDate > publishedAt);
+      if (syncedAfterPublish) isOutdated = true;
+      collectionDetails.push({ name: cn, entityCount: s.entityCount, diskSize: s.diskSize, lastSyncAt: s.lastSyncAt, syncedAfterPublish });
+      totalEntities += s.entityCount;
+      totalSize += s.diskSize;
+    }
+  }
+
+  // Publish wizard modes
+  const publishModes = [
+    { label: "New deployment", value: "new" },
+    ...(depNames.length > 0 ? [
+      { label: "Update existing deployment", value: "update" },
+      { label: "Re-deploy worker code only", value: "worker-only" },
+    ] : []),
+  ];
+
+  // --- Unpublish ---
+  const doUnpublish = useCallback(async () => {
+    if (!currentDep) return;
+    setDepMode("deleting");
+    setDepProgress([]);
+    try {
+      const dep = getDeployment(currentDep.name);
+      if (!dep) { setDepError("Deployment not found"); setDepMode("error-delete"); return; }
+      await unpublishDeployment(dep, (step, detail) => setDepProgress((p) => [...p, `[${step}] ${detail}`]));
+      setDepMessage(`Deployment "${currentDep.name}" removed.`);
+      setDepMode("done-delete");
+    } catch (err: unknown) {
+      setDepError(err instanceof Error ? err.message : String(err));
+      setDepMode("error-delete");
+    }
+  }, [currentDep]);
+
+  // --- Publish ---
+  const handleWorkerNameSubmit = useCallback(() => {
+    setWorkerName(inputValue.trim() || workerName);
+    setInputValue("");
+    setWizStep("password");
+  }, [inputValue, workerName]);
+
+  const handlePasswordSubmit = useCallback(() => {
+    setPassword(inputValue.trim());
+    setInputValue("");
+    setWizStep("confirm");
+  }, [inputValue]);
+
+  const doPublish = useCallback(async () => {
+    setWizStep("publishing");
+    setPubProgress([]);
+    try {
+      const opts: PublishOptions = {
+        collectionNames: [...selectedCollections],
+        workerName,
+        password: password || undefined,
+        forcePublic: !password,
+        workerOnly,
+      };
+      const res = await publishCollections(opts, (s, detail) => setPubProgress((p) => [...p, `[${s}] ${detail}`]));
+      setPubResult({ workerUrl: res.workerUrl, mcpUrl: res.mcpUrl });
+      setWizStep("done");
+    } catch (err: unknown) {
+      setPubError(err instanceof Error ? err.message : String(err));
+      setWizStep("error");
+    }
+  }, [selectedCollections, workerName, password, workerOnly]);
+
+  const resetWizard = useCallback(() => {
+    setWizStep("select-mode");
+    setModeCursor(0);
+    setSelectedCollections(new Set());
+    setCollCursor(0);
+    setWorkerName("");
+    setPassword("");
+    setWorkerOnly(false);
+    setPubProgress([]);
+    setPubError("");
+    setPubResult(null);
+    setInputValue("");
+    setView("deployments");
+    setDepRefresh((k) => k + 1);
+  }, []);
+
+  // --- Input ---
+  useInput((input, key) => {
+    // ── Deployment list view ──
+    if (view === "deployments") {
+      if (depMode === "list") {
+        if (key.upArrow && deployments.length > 0) setDepCursor((c) => Math.max(0, c - 1));
+        if (key.downArrow && deployments.length > 0) setDepCursor((c) => Math.min(deployments.length - 1, c + 1));
+        if (input === "d" && currentDep) setDepMode("confirm-delete");
+        if (key.return && currentDep) {
+          // Open deployment URL in default browser
+          const url = currentDep.url;
+          const cmd = process.platform === "darwin" ? `open "${url}"` : process.platform === "win32" ? `start "${url}"` : `xdg-open "${url}"`;
+          exec(cmd);
+        }
+        if (input === "n") {
+          setView("publish-wizard");
+          setWizStep("select-mode");
+        }
+        if (input === "p" && currentDep) {
+          // Republish: update the current deployment with its existing collections
+          setSelectedCollections(new Set(currentDep.collections));
+          setWorkerName(currentDep.name);
+          setWorkerOnly(false);
+          // Preserve existing password hash by not setting a new password
+          setPassword("");
+          setWizStep("confirm");
+          setView("publish-wizard");
+        }
+      }
+      if (depMode === "confirm-delete") {
+        if (input === "y") doUnpublish();
+        else setDepMode("list");
+      }
+      if (depMode === "done-delete" || depMode === "error-delete") {
+        if (key.return || key.escape) {
+          setDepMode("list");
+          setDepProgress([]);
+          setDepError("");
+          setDepMessage("");
+          setDepRefresh((k) => k + 1);
+          setDepCursor(Math.max(0, depCursor - 1));
+        }
+      }
+      return;
+    }
+
+    // ── Publish wizard view ──
+    if (wizStep === "select-mode") {
+      if (key.upArrow) setModeCursor((c) => Math.max(0, c - 1));
+      if (key.downArrow) setModeCursor((c) => Math.min(publishModes.length - 1, c + 1));
+      if (key.escape) { setView("deployments"); return; }
+      if (key.return) {
+        const mode = publishModes[modeCursor].value;
+        setWorkerOnly(mode === "worker-only");
+        if (mode === "worker-only" || mode === "update") {
+          if (depNames.length > 0) {
+            setWorkerName(depNames[0]);
+            if (mode === "worker-only") setWizStep("confirm");
+            else setWizStep("select-collections");
+          }
+        } else {
+          setWizStep("select-collections");
+        }
+      }
+    }
+    if (wizStep === "select-collections") {
+      if (key.upArrow) setCollCursor((c) => Math.max(0, c - 1));
+      if (key.downArrow) setCollCursor((c) => Math.min(collections.length - 1, c + 1));
+      if (key.escape) { setWizStep("select-mode"); return; }
+      if (input === " ") {
+        const name = collections[collCursor];
+        setSelectedCollections((prev) => { const next = new Set(prev); if (next.has(name)) next.delete(name); else next.add(name); return next; });
+      }
+      if (key.return && selectedCollections.size > 0) {
+        if (!workerName) setInputValue(`fink-${[...selectedCollections][0]}-${Math.random().toString(36).slice(2, 8)}`);
+        setWizStep("worker-name");
+      }
+    }
+    if (wizStep === "confirm") {
+      if (input === "y") doPublish();
+      if (input === "n" || key.escape) resetWizard();
+    }
+    if (wizStep === "done" || wizStep === "error") {
+      if (key.return || key.escape) resetWizard();
+    }
+  });
+
+  // ── Render: Deployment list ──
+  if (view === "deployments") {
+    return (
+      <Box flexDirection="column" paddingY={1}>
+        <Text bold>Publish</Text>
+
+        {deployments.length === 0 ? (
+          <Box marginTop={1}><Text dimColor>No deployments yet.</Text></Box>
+        ) : (
+          <>
+            <Box flexDirection="column" marginTop={1}>
+              {deployments.map((dep: { name: string; url: string; collections: string[]; passwordProtected: boolean; publishedAt: string; mcpUrl: string }, i: number) => {
+                let depEntities = 0;
+                let depSize = 0;
+                for (const cn of dep.collections) { const s = getCollectionStats(cn); depEntities += s.entityCount; depSize += s.diskSize; }
+                return (
+                  <Box key={dep.name} gap={1}>
+                    <Text color={i === depCursor ? "cyan" : undefined}>{i === depCursor ? "❯" : " "}</Text>
+                    <Text bold={i === depCursor}>{dep.name}</Text>
+                    <Text color={dep.passwordProtected ? "green" : "yellow"}>[{dep.passwordProtected ? "protected" : "public"}]</Text>
+                    <Text dimColor>{depEntities} entities</Text>
+                    <Text dimColor>{formatSize(depSize)}</Text>
+                  </Box>
+                );
+              })}
+            </Box>
+
+            {currentDep && (depMode === "list" || depMode === "confirm-delete") && (
+              <Box flexDirection="column" marginTop={1} marginLeft={2} borderStyle="single" borderColor="gray" paddingX={1}>
+                <Box gap={2}>
+                  <Text bold>{currentDep.name}</Text>
+                  {isOutdated && <Text color="yellow" bold>outdated</Text>}
+                </Box>
+                <Text>URL: <Text color="blue">{currentDep.url}</Text></Text>
+                <Text>MCP: <Text color="blue">{currentDep.mcpUrl}</Text></Text>
+                <Text>Published: <Text dimColor>{currentDep.publishedAt}</Text></Text>
+                <Text>Total: <Text bold>{totalEntities} entities</Text><Text dimColor> ({formatSize(totalSize)})</Text></Text>
+                <Box flexDirection="column" marginTop={1}>
+                  <Text dimColor bold>Collections:</Text>
+                  {collectionDetails.map((cd) => {
+                    const syncLabel = cd.lastSyncAt
+                      ? formatRelative(new Date(cd.lastSyncAt + "Z"))
+                      : "never";
+                    return (
+                      <Box key={cd.name} gap={1} marginLeft={1}>
+                        <Text>{cd.name}</Text>
+                        <Text dimColor>{cd.entityCount} entities ({formatSize(cd.diskSize)})</Text>
+                        <Text dimColor>synced {syncLabel}</Text>
+                        {cd.syncedAfterPublish && <Text color="yellow">*</Text>}
+                      </Box>
+                    );
+                  })}
+                </Box>
+                {isOutdated && (
+                  <Text color="yellow" dimColor>* synced after publish — press [p] to republish</Text>
+                )}
+              </Box>
+            )}
+          </>
+        )}
+
+        {depMode === "confirm-delete" && (
+          <Box marginTop={1}><Text color="red">Delete "{currentDep?.name}" and its Cloudflare resources (worker, D1, R2)? (y/N)</Text></Box>
+        )}
+        {depMode === "deleting" && (
+          <Box flexDirection="column" marginTop={1}>
+            <Text color="yellow">Deleting...</Text>
+            {depProgress.map((l, i) => <Text key={i} dimColor>{l}</Text>)}
+          </Box>
+        )}
+        {depMode === "done-delete" && <Box marginTop={1}><Text color="green">{depMessage} Press Enter.</Text></Box>}
+        {depMode === "error-delete" && <Box marginTop={1}><Text color="red">Error: {depError}. Press Enter.</Text></Box>}
+
+        <Box marginTop={1} gap={2}>
+          <Text dimColor>[n] New publish</Text>
+          {deployments.length > 0 && <Text dimColor>[p] Republish</Text>}
+          {deployments.length > 0 && <Text dimColor>[Enter] Open</Text>}
+          {deployments.length > 0 && <Text dimColor>[d] Delete</Text>}
+          {deployments.length > 0 && <Text dimColor>[↑↓] Navigate</Text>}
+        </Box>
+      </Box>
+    );
+  }
+
+  // ── Render: Publish wizard ──
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      <Text bold>New Publish</Text>
+
+      {wizStep === "select-mode" && (
+        <Box flexDirection="column" marginTop={1}>
+          {publishModes.map((m, i) => (
+            <Box key={m.value}>
+              <Text color={i === modeCursor ? "cyan" : undefined}>{i === modeCursor ? "❯ " : "  "}{m.label}</Text>
+            </Box>
+          ))}
+          <Box marginTop={1}><Text dimColor>ESC back</Text></Box>
+        </Box>
+      )}
+
+      {wizStep === "select-collections" && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>Select collections (Space toggle, Enter continue, ESC back)</Text>
+          {collections.map((name: string, i: number) => (
+            <Box key={name} gap={1}>
+              <Text color={i === collCursor ? "cyan" : undefined}>{i === collCursor ? "❯" : " "}</Text>
+              <Text>{selectedCollections.has(name) ? "[x]" : "[ ]"}</Text>
+              <Text>{name}</Text>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {wizStep === "worker-name" && (
+        <Box marginTop={1}>
+          <TextInput label="Worker name" value={inputValue} onChange={setInputValue} onSubmit={handleWorkerNameSubmit} placeholder={workerName} />
+        </Box>
+      )}
+
+      {wizStep === "password" && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>Leave blank for public access</Text>
+          <TextInput label="Password" value={inputValue} onChange={setInputValue} onSubmit={handlePasswordSubmit} mask />
+        </Box>
+      )}
+
+      {wizStep === "confirm" && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold>Summary</Text>
+          {!workerOnly && <Text>  Collections: {[...selectedCollections].join(", ")}</Text>}
+          <Text>  Worker: {workerName}</Text>
+          {workerOnly && <Text>  Mode: Worker code only</Text>}
+          {password && <Text>  Protected: Yes</Text>}
+          <Box marginTop={1}><Text>Proceed? (y/n)</Text></Box>
+        </Box>
+      )}
+
+      {wizStep === "publishing" && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color="yellow">Publishing...</Text>
+          {pubProgress.map((l, i) => <Text key={i} dimColor>{l}</Text>)}
+        </Box>
+      )}
+
+      {wizStep === "done" && pubResult && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color="green" bold>Published successfully!</Text>
+          <Text>Website: <Text color="blue">{pubResult.workerUrl}</Text></Text>
+          <Text>MCP URL: <Text color="blue">{pubResult.mcpUrl}</Text></Text>
+          <Box marginTop={1}><Text dimColor>Press Enter to continue</Text></Box>
+        </Box>
+      )}
+
+      {wizStep === "error" && (
+        <Box marginTop={1}><Text color="red">Publish failed: {pubError}. Press Enter.</Text></Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/components/SearchView.tsx
+++ b/packages/cli/src/tui/components/SearchView.tsx
@@ -1,0 +1,183 @@
+import React, { useState, useCallback } from "react";
+import { Box, Text, useInput } from "ink";
+import { existsSync } from "fs";
+import { join } from "path";
+import { exec } from "child_process";
+import {
+  contextExists,
+  listCollections,
+  getCollectionDb,
+  getCollectionDbPath,
+  getFrozenInkHome,
+  SearchIndexer,
+  entities,
+} from "@frozenink/core";
+import { eq } from "drizzle-orm";
+import { TextInput } from "./TextInput.js";
+
+interface SearchResult {
+  collection: string;
+  entityType: string;
+  title: string;
+  externalId: string;
+  rank: number;
+}
+
+type Mode = "input" | "results";
+
+function openFile(filePath: string): void {
+  const cmd =
+    process.platform === "darwin"
+      ? `open "${filePath}"`
+      : process.platform === "win32"
+        ? `start "" "${filePath}"`
+        : `xdg-open "${filePath}"`;
+  exec(cmd);
+}
+
+function getMarkdownPath(result: SearchResult): string | null {
+  const home = getFrozenInkHome();
+  const dbPath = getCollectionDbPath(result.collection);
+  if (!existsSync(dbPath)) return null;
+  try {
+    const colDb = getCollectionDb(dbPath);
+    const rows = colDb
+      .select()
+      .from(entities)
+      .where(eq(entities.externalId, result.externalId))
+      .all();
+    if (rows.length > 0 && rows[0].markdownPath) {
+      const mdPath = join(home, "collections", result.collection, rows[0].markdownPath);
+      if (existsSync(mdPath)) return mdPath;
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+export function SearchView({
+  collectionName,
+  onDone,
+}: {
+  collectionName?: string;
+  onDone?: () => void;
+}): React.ReactElement {
+  // All hooks before any conditional returns
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [searched, setSearched] = useState(false);
+  const [mode, setMode] = useState<Mode>("input");
+  const [resultCursor, setResultCursor] = useState(0);
+
+  const initialized = contextExists();
+
+  const doSearch = useCallback(() => {
+    if (!query.trim()) return;
+
+    const collections = collectionName
+      ? [{ name: collectionName }]
+      : listCollections();
+    const allResults: SearchResult[] = [];
+
+    for (const col of collections) {
+      const dbPath = getCollectionDbPath(col.name);
+      if (!existsSync(dbPath)) continue;
+
+      const indexer = new SearchIndexer(dbPath);
+      try {
+        const hits = indexer.search(query.trim(), { collectionName: col.name });
+        for (const r of hits) {
+          allResults.push({ ...r, collection: col.name });
+        }
+      } finally {
+        indexer.close();
+      }
+    }
+
+    allResults.sort((a, b) => a.rank - b.rank);
+    setResults(allResults.slice(0, 30));
+    setSearched(true);
+    setResultCursor(0);
+    if (allResults.length > 0) {
+      setMode("results");
+    }
+  }, [query, collectionName]);
+
+  useInput((input, key) => {
+    if (mode === "results") {
+      if (key.upArrow) setResultCursor((c) => Math.max(0, c - 1));
+      if (key.downArrow) setResultCursor((c) => Math.min(results.length - 1, c + 1));
+      if (key.return && results[resultCursor]) {
+        const mdPath = getMarkdownPath(results[resultCursor]);
+        if (mdPath) openFile(mdPath);
+      }
+      if (key.escape || key.tab) {
+        if (onDone) { onDone(); return; }
+        setMode("input");
+        setQuery("");
+        setSearched(false);
+      }
+    }
+  });
+
+  // All hooks above — safe to do conditional returns now
+
+  if (!initialized) {
+    return <Text color="yellow">Not initialized.</Text>;
+  }
+
+  const scoped = !!collectionName;
+  const title = scoped ? `Search in "${collectionName}"` : "Search";
+  const description = scoped
+    ? `Search within "${collectionName}". Type a query and press Enter.`
+    : "Full-text search across all collections. Type a query and press Enter.";
+  const inputLabel = scoped ? `Search ${collectionName}` : "Search all";
+
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      <Text bold>{title}</Text>
+      <Text dimColor>{description}</Text>
+
+      {mode === "input" && (
+        <Box marginTop={1}>
+          <TextInput
+            label={inputLabel}
+            value={query}
+            onChange={setQuery}
+            onSubmit={doSearch}
+            placeholder="Enter search terms..."
+          />
+        </Box>
+      )}
+
+      {mode === "results" && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>
+            {results.length} result(s) for "{query}" — ↑↓ navigate, Enter to open, ESC back
+          </Text>
+          <Box flexDirection="column" marginTop={1}>
+            {results.length === 0 ? (
+              <Text dimColor>No results found.</Text>
+            ) : (
+              results.map((r, i) => (
+                <Box key={i} gap={1}>
+                  <Text color={i === resultCursor ? "cyan" : undefined}>
+                    {i === resultCursor ? "❯" : " "}
+                  </Text>
+                  {!scoped && <Text dimColor>[{r.collection}]</Text>}
+                  <Text color="cyan">{r.entityType}:</Text>
+                  <Text bold={i === resultCursor}>{r.title}</Text>
+                </Box>
+              ))
+            )}
+          </Box>
+        </Box>
+      )}
+
+      {mode === "input" && searched && results.length === 0 && (
+        <Box marginTop={1}>
+          <Text dimColor>No results found.</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/components/SelectInput.tsx
+++ b/packages/cli/src/tui/components/SelectInput.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import { Box, Text, useInput } from "ink";
+
+export interface SelectItem {
+  label: string;
+  value: string;
+}
+
+interface Props {
+  items: SelectItem[];
+  onSelect: (item: SelectItem) => void;
+  label?: string;
+}
+
+export function SelectInput({
+  items,
+  onSelect,
+  label,
+}: Props): React.ReactElement {
+  const [index, setIndex] = useState(0);
+
+  useInput((_input, key) => {
+    if (key.upArrow) {
+      setIndex((i) => (i > 0 ? i - 1 : items.length - 1));
+    }
+    if (key.downArrow) {
+      setIndex((i) => (i < items.length - 1 ? i + 1 : 0));
+    }
+    if (key.return) {
+      onSelect(items[index]);
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      {label && (
+        <Text bold color="cyan">
+          {label}
+        </Text>
+      )}
+      {items.map((item, i) => (
+        <Box key={item.value}>
+          <Text color={i === index ? "cyan" : undefined}>
+            {i === index ? "❯ " : "  "}
+            {item.label}
+          </Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/components/SettingsView.tsx
+++ b/packages/cli/src/tui/components/SettingsView.tsx
@@ -1,0 +1,147 @@
+import React, { useState, useCallback } from "react";
+import { Box, Text, useInput } from "ink";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { getFrozenInkHome, loadConfig } from "@frozenink/core";
+import { TextInput } from "./TextInput.js";
+
+interface Settings {
+  syncInterval: number;
+  syncConcurrency: number;
+  syncRetries: number;
+  logLevel: string;
+}
+
+const LOG_LEVELS = ["debug", "info", "warn", "error"];
+
+export function SettingsView(): React.ReactElement {
+  const config = loadConfig();
+  const syncConfig = (config as Record<string, unknown>).sync as Record<string, unknown> | undefined;
+  const loggingConfig = (config as Record<string, unknown>).logging as Record<string, unknown> | undefined;
+
+  const [settings, setSettings] = useState<Settings>({
+    syncInterval: (syncConfig?.interval as number) ?? 900,
+    syncConcurrency: (syncConfig?.concurrency as number) ?? 1,
+    syncRetries: (syncConfig?.retries as number) ?? 3,
+    logLevel: (loggingConfig?.level as string) ?? "info",
+  });
+
+  const [cursor, setCursor] = useState(0);
+  const [editing, setEditing] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [saved, setSaved] = useState(false);
+
+  const fields = [
+    { key: "syncInterval", label: "Sync interval (seconds)", value: String(settings.syncInterval) },
+    { key: "syncConcurrency", label: "Sync concurrency", value: String(settings.syncConcurrency) },
+    { key: "syncRetries", label: "Sync retries", value: String(settings.syncRetries) },
+    { key: "logLevel", label: "Log level", value: settings.logLevel },
+    { key: "save", label: "Save", value: "" },
+  ];
+
+  useInput((input, key) => {
+    if (editing) return; // TextInput handles input
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
+    if (key.downArrow) setCursor((c) => Math.min(fields.length - 1, c + 1));
+    if (key.return) {
+      const field = fields[cursor];
+      if (field.key === "save") {
+        saveSettings();
+      } else if (field.key === "logLevel") {
+        // Cycle through log levels
+        const idx = LOG_LEVELS.indexOf(settings.logLevel);
+        const next = LOG_LEVELS[(idx + 1) % LOG_LEVELS.length];
+        setSettings((s) => ({ ...s, logLevel: next }));
+      } else {
+        setInputValue(field.value);
+        setEditing(true);
+      }
+    }
+  });
+
+  const handleEditSubmit = useCallback(() => {
+    const field = fields[cursor];
+    const val = inputValue.trim();
+
+    if (field.key === "syncInterval") {
+      const n = parseInt(val, 10);
+      if (!isNaN(n) && n > 0) setSettings((s) => ({ ...s, syncInterval: n }));
+    } else if (field.key === "syncConcurrency") {
+      const n = parseInt(val, 10);
+      if (!isNaN(n) && n > 0) setSettings((s) => ({ ...s, syncConcurrency: n }));
+    } else if (field.key === "syncRetries") {
+      const n = parseInt(val, 10);
+      if (!isNaN(n) && n >= 0) setSettings((s) => ({ ...s, syncRetries: n }));
+    }
+    setEditing(false);
+  }, [cursor, inputValue, fields]);
+
+  const saveSettings = useCallback(() => {
+    const configPath = join(getFrozenInkHome(), "config.json");
+    let fileConfig: Record<string, unknown> = {};
+    if (existsSync(configPath)) {
+      fileConfig = JSON.parse(readFileSync(configPath, "utf-8"));
+    }
+
+    if (!fileConfig.sync || typeof fileConfig.sync !== "object") fileConfig.sync = {};
+    const sync = fileConfig.sync as Record<string, unknown>;
+    sync.interval = settings.syncInterval;
+    sync.concurrency = settings.syncConcurrency;
+    sync.retries = settings.syncRetries;
+
+    if (!fileConfig.logging || typeof fileConfig.logging !== "object") fileConfig.logging = {};
+    const logging = fileConfig.logging as Record<string, unknown>;
+    logging.level = settings.logLevel;
+
+    writeFileSync(configPath, JSON.stringify(fileConfig, null, 2));
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  }, [settings]);
+
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      <Text bold>Settings</Text>
+
+      <Box flexDirection="column" marginTop={1}>
+        {fields.map((field, i) => {
+          if (editing && i === cursor) {
+            return (
+              <Box key={field.key}>
+                <TextInput
+                  label={field.label}
+                  value={inputValue}
+                  onChange={setInputValue}
+                  onSubmit={handleEditSubmit}
+                />
+              </Box>
+            );
+          }
+
+          const isSave = field.key === "save";
+          return (
+            <Box key={field.key} gap={1}>
+              <Text color={i === cursor ? "cyan" : undefined}>
+                {i === cursor ? "❯" : " "}
+              </Text>
+              {isSave ? (
+                <Text bold color={i === cursor ? "green" : undefined}>
+                  {saved ? "✓ Saved!" : "Save settings"}
+                </Text>
+              ) : (
+                <>
+                  <Text>{field.label}:</Text>
+                  <Text bold color="cyan">{field.value}</Text>
+                  {field.key === "logLevel" && <Text dimColor>(Enter to cycle)</Text>}
+                </>
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>[↑↓] Navigate [Enter] Edit/Select</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/components/SyncView.tsx
+++ b/packages/cli/src/tui/components/SyncView.tsx
@@ -1,0 +1,325 @@
+import React, { useState, useCallback } from "react";
+import { Box, Text, useInput } from "ink";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  contextExists,
+  listCollections,
+  getCollectionDb,
+  getCollectionDbPath,
+  getFrozenInkHome,
+  entities,
+  entityTags,
+  entityLinks,
+  entityRelations,
+  attachments,
+  syncState,
+  syncRuns,
+  SyncEngine,
+  ThemeEngine,
+  LocalStorageBackend,
+  SearchIndexer,
+} from "@frozenink/core";
+import {
+  createDefaultRegistry,
+  gitHubTheme,
+  obsidianTheme,
+  gitTheme,
+  mantisBTTheme,
+} from "@frozenink/crawlers";
+import { sql, desc } from "drizzle-orm";
+
+type SyncMode = "skip" | "incremental" | "full";
+type ViewMode = "select" | "syncing" | "done";
+
+const W_CHECK = 6;
+const W_NAME = 20;
+const W_TITLE = 22;
+const W_TYPE = 12;
+const W_ENTITIES = 10;
+
+function pad(text: string, width: number): string {
+  if (text.length >= width) return text.slice(0, width - 1) + " ";
+  return text + " ".repeat(width - text.length);
+}
+
+function formatRelative(date: Date): string {
+  const diffMs = Date.now() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}
+
+function getLastSync(name: string): string {
+  const dbPath = getCollectionDbPath(name);
+  if (!existsSync(dbPath)) return "never";
+  try {
+    const colDb = getCollectionDb(dbPath);
+    const runs = colDb.select().from(syncRuns).orderBy(desc(syncRuns.startedAt)).limit(1).all();
+    if (runs.length > 0 && runs[0].startedAt) {
+      const d = new Date(runs[0].startedAt + "Z");
+      if (!isNaN(d.getTime())) return formatRelative(d);
+    }
+  } catch {}
+  return "never";
+}
+
+function getEntityCount(name: string): string {
+  const dbPath = getCollectionDbPath(name);
+  if (!existsSync(dbPath)) return "—";
+  try {
+    const colDb = getCollectionDb(dbPath);
+    const [{ total }] = colDb.select({ total: sql<number>`count(*)` }).from(entities).all();
+    return String(total);
+  } catch {
+    return "err";
+  }
+}
+
+export function SyncView(): React.ReactElement {
+  const [cursor, setCursor] = useState(0);
+  const [viewMode, setViewMode] = useState<ViewMode>("select");
+  const [progress, setProgress] = useState<string[]>([]);
+  const [syncModes, setSyncModes] = useState<Map<string, SyncMode>>(new Map());
+  const [totalStats, setTotalStats] = useState<{ created: number; updated: number; deleted: number; total: number } | null>(null);
+
+  const initialized = contextExists();
+  const collections = initialized
+    ? listCollections().filter((c: { enabled: boolean }) => c.enabled)
+    : [];
+
+  // Initialize sync modes for new collections
+  if (initialized && syncModes.size === 0 && collections.length > 0) {
+    const initial = new Map<string, SyncMode>();
+    for (const col of collections) initial.set(col.name, "skip");
+    setSyncModes(initial);
+  }
+
+  const cycleSyncMode = useCallback((name: string) => {
+    setSyncModes((prev) => {
+      const next = new Map(prev);
+      const current = next.get(name) || "skip";
+      const order: SyncMode[] = ["skip", "incremental", "full"];
+      const idx = order.indexOf(current);
+      next.set(name, order[(idx + 1) % 3]);
+      return next;
+    });
+  }, []);
+
+  const setAllMode = useCallback((mode: SyncMode) => {
+    setSyncModes((prev) => {
+      const next = new Map(prev);
+      for (const [key] of next) next.set(key, mode);
+      return next;
+    });
+  }, []);
+
+  const startSync = useCallback(async () => {
+    const toSync = collections.filter((c: { name: string }) => {
+      const m = syncModes.get(c.name);
+      return m === "incremental" || m === "full";
+    });
+
+    if (toSync.length === 0) return;
+
+    setViewMode("syncing");
+    setProgress([]);
+    setTotalStats(null);
+
+    const home = getFrozenInkHome();
+    const registry = createDefaultRegistry();
+    const themeEngine = new ThemeEngine();
+    themeEngine.register(gitHubTheme);
+    themeEngine.register(obsidianTheme);
+    themeEngine.register(gitTheme);
+    themeEngine.register(mantisBTTheme);
+
+    let totalCreated = 0;
+    let totalUpdated = 0;
+    let totalDeleted = 0;
+    let totalEntities = 0;
+
+    for (const col of toSync) {
+      const isFullSync = syncModes.get(col.name) === "full";
+      const label = isFullSync ? "full sync" : "sync";
+      setProgress((p) => [...p, `${label}: "${col.name}" (${col.crawler})...`]);
+
+      const factory = registry.get(col.crawler);
+      if (!factory) {
+        setProgress((p) => [...p, `  No crawler for ${col.crawler}, skipping`]);
+        continue;
+      }
+
+      const crawler = factory();
+      await crawler.initialize(
+        col.config as Record<string, unknown>,
+        col.credentials as Record<string, unknown>,
+      );
+
+      const dbPath = getCollectionDbPath(col.name);
+
+      if (isFullSync) {
+        const colDb = getCollectionDb(dbPath);
+        colDb.delete(entityLinks).run();
+        colDb.delete(entityRelations).run();
+        colDb.delete(attachments).run();
+        colDb.delete(entityTags).run();
+        colDb.delete(entities).run();
+        colDb.delete(syncState).run();
+        const indexer = new SearchIndexer(dbPath);
+        indexer.clearIndex();
+        indexer.close();
+        setProgress((p) => [...p, "  Cleared data for full re-sync"]);
+      }
+
+      const collectionDir = join(home, "collections", col.name);
+      const storage = new LocalStorageBackend(collectionDir);
+
+      const engine = new SyncEngine({
+        crawler,
+        dbPath,
+        collectionName: col.name,
+        themeEngine,
+        storage,
+        markdownBasePath: "markdown",
+        onBatchFetched: ({ externalIds }: { externalIds: string[] }) => {
+          if (externalIds.length > 0) {
+            setProgress((p) => [...p, `  Fetched ${externalIds.length} entities`]);
+          }
+        },
+      });
+
+      try {
+        const stats = await engine.run();
+        const colDb = getCollectionDb(dbPath);
+        const [{ total }] = colDb.select({ total: sql<number>`count(*)` }).from(entities).all();
+        totalCreated += stats.created;
+        totalUpdated += stats.updated;
+        totalDeleted += stats.deleted;
+        totalEntities += total;
+        setProgress((p) => [...p, `  Done: +${stats.created} ~${stats.updated} -${stats.deleted} (${total} total)`]);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setProgress((p) => [...p, `  Error: ${msg}`]);
+      }
+
+      await crawler.dispose();
+    }
+
+    setTotalStats({ created: totalCreated, updated: totalUpdated, deleted: totalDeleted, total: totalEntities });
+    setViewMode("done");
+  }, [collections, syncModes]);
+
+  useInput((input, key) => {
+    if (viewMode === "select") {
+      if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
+      if (key.downArrow) setCursor((c) => Math.min(collections.length - 1, c + 1));
+      if (input === " " && collections[cursor]) {
+        cycleSyncMode(collections[cursor].name);
+      }
+      if (input === "s") setAllMode("incremental");
+      if (input === "f") setAllMode("full");
+      if (input === "n") setAllMode("skip");
+      if (key.return) startSync();
+    }
+    if (viewMode === "done") {
+      if (key.return || key.escape) {
+        setViewMode("select");
+        setProgress([]);
+        setTotalStats(null);
+        // Reset all to skip
+        setAllMode("skip");
+      }
+    }
+  });
+
+  if (!initialized) {
+    return <Text color="yellow">Not initialized.</Text>;
+  }
+
+  if (collections.length === 0) {
+    return (
+      <Box paddingY={1}>
+        <Text dimColor>No enabled collections to sync.</Text>
+      </Box>
+    );
+  }
+
+  if (viewMode === "syncing" || viewMode === "done") {
+    return (
+      <Box flexDirection="column" paddingY={1}>
+        <Text bold>{viewMode === "syncing" ? "Syncing..." : "Sync Complete"}</Text>
+        <Box flexDirection="column" marginLeft={1} marginTop={1}>
+          {progress.map((line, i) => (
+            <Text key={i} dimColor={viewMode === "done"}>{line}</Text>
+          ))}
+        </Box>
+        {totalStats && (
+          <Box marginTop={1} gap={2}>
+            <Text color="green">+{totalStats.created}</Text>
+            <Text color="yellow">~{totalStats.updated}</Text>
+            <Text color="red">-{totalStats.deleted}</Text>
+            <Text dimColor>({totalStats.total} total)</Text>
+          </Box>
+        )}
+        {viewMode === "done" && (
+          <Box marginTop={1}><Text dimColor>Press Enter to continue</Text></Box>
+        )}
+      </Box>
+    );
+  }
+
+  const selectedCount = [...syncModes.values()].filter((m) => m !== "skip").length;
+
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      <Text bold>Sync Collections</Text>
+      <Text dimColor>Select sync mode per collection: [ ] skip, [s] incremental, [f] full re-sync</Text>
+
+      {/* Table header */}
+      <Box marginLeft={1} marginTop={1}>
+        <Text dimColor>{pad("", 2)}</Text>
+        <Text dimColor>{pad("", W_CHECK)}</Text>
+        <Text bold dimColor>{pad("Name", W_NAME)}</Text>
+        <Text bold dimColor>{pad("Title", W_TITLE)}</Text>
+        <Text bold dimColor>{pad("Type", W_TYPE)}</Text>
+        <Text bold dimColor>{pad("Entities", W_ENTITIES)}</Text>
+        <Text bold dimColor>Last Sync</Text>
+      </Box>
+
+      {/* Table rows */}
+      <Box flexDirection="column" marginLeft={1}>
+        {collections.map((col: { name: string; title?: string; crawler: string; enabled: boolean }, i: number) => {
+          const mode = syncModes.get(col.name) || "skip";
+          const selected = i === cursor;
+          const checkbox = mode === "skip" ? "[ ] " : mode === "incremental" ? "[s] " : "[f] ";
+          const checkColor = mode === "skip" ? "gray" : mode === "incremental" ? "green" : "yellow";
+          return (
+            <Box key={col.name}>
+              <Text color={selected ? "cyan" : undefined}>{selected ? "❯ " : "  "}</Text>
+              <Text color={checkColor}>{pad(checkbox, W_CHECK)}</Text>
+              <Text bold={selected} color={selected ? "cyan" : undefined}>{pad(col.name, W_NAME)}</Text>
+              <Text dimColor>{pad(col.title || "", W_TITLE)}</Text>
+              <Text dimColor>{pad(col.crawler, W_TYPE)}</Text>
+              <Text>{pad(getEntityCount(col.name), W_ENTITIES)}</Text>
+              <Text dimColor>{getLastSync(col.name)}</Text>
+            </Box>
+          );
+        })}
+      </Box>
+
+      <Box marginTop={1} gap={2}>
+        <Text dimColor>[Space] Cycle mode</Text>
+        <Text dimColor>[s] All incremental</Text>
+        <Text dimColor>[f] All full</Text>
+        <Text dimColor>[n] All skip</Text>
+        <Text dimColor>[Enter] Start{selectedCount > 0 ? ` (${selectedCount})` : ""}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/components/TextInput.tsx
+++ b/packages/cli/src/tui/components/TextInput.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import { Box, Text, useInput } from "ink";
+
+interface Props {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  placeholder?: string;
+  mask?: boolean;
+}
+
+export function TextInput({
+  label,
+  value,
+  onChange,
+  onSubmit,
+  placeholder,
+  mask,
+}: Props): React.ReactElement {
+  useInput((input, key) => {
+    if (key.return) {
+      onSubmit();
+      return;
+    }
+    if (key.backspace || key.delete) {
+      onChange(value.slice(0, -1));
+      return;
+    }
+    if (
+      !key.ctrl &&
+      !key.meta &&
+      !key.escape &&
+      !key.upArrow &&
+      !key.downArrow &&
+      !key.leftArrow &&
+      !key.rightArrow &&
+      !key.tab &&
+      input
+    ) {
+      onChange(value + input);
+    }
+  });
+
+  const display = mask ? "*".repeat(value.length) : value;
+  const showPlaceholder = !value && placeholder;
+
+  return (
+    <Box>
+      <Text color="cyan">? </Text>
+      <Text bold>{label}: </Text>
+      {showPlaceholder ? (
+        <Text dimColor>{placeholder}</Text>
+      ) : (
+        <Text>{display}</Text>
+      )}
+      <Text color="cyan">█</Text>
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/index.tsx
+++ b/packages/cli/src/tui/index.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { render } from "ink";
+import { App } from "./components/App.js";
+
+export async function startTui(): Promise<void> {
+  const { waitUntilExit } = render(<App />);
+  await waitUntilExit();
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "types": ["bun-types", "@types/react"]
   },
   "include": ["src"],
   "exclude": ["src/**/__tests__"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,13 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "types": ["bun-types"]
+    "types": ["bun-types"],
+    "paths": {
+      "@frozenink/core": ["./packages/core/src/index.ts"],
+      "@frozenink/core/*": ["./packages/core/src/*/index.ts"],
+      "@frozenink/crawlers": ["./packages/crawlers/src/index.ts"],
+      "@frozenink/mcp": ["./packages/mcp/src/index.ts"]
+    }
   },
   "exclude": ["node_modules", "dist"],
   "references": [


### PR DESCRIPTION
## Summary

- **Interactive TUI**: Ink (React for terminals) based interface launched by default when running `fink` with no arguments. Keyboard-driven access to all CLI features with full desktop app feature parity for collection management.
- **Fix all typecheck errors**: Added tsconfig `paths` mappings for workspace package resolution and JSX support for the CLI package. Typecheck now passes with 0 errors.
- **npm publishing**: esbuild-based build producing a minified 1.7MB ESM bundle, published as `@vboctor/fink`. Includes proper package.json, README for npmjs.com, and `bun run publish:npm` workflow.
- **Standalone executables**: Bun-compiled binaries for macOS (arm64/x64) and Linux (arm64/x64) — zero dependencies, download and run.
- **Documentation**: CLI README, updated root README with install/build/release docs, updated AGENTS.md with TUI architecture.

### TUI Features

| Screen | Key | Description |
|--------|-----|-------------|
| Collections | `c` | Table view with checkbox enable/toggle, edit settings, sync, search, export, add, delete |
| Sync | `s` | Per-collection sync mode: `[ ]` skip, `[s]` incremental, `[f]` full re-sync |
| Search | `f` | Full-text search (scoped per-collection from Collections, or global), open results in system viewer |
| Publish | `p` | New publish, republish outdated deployments, delete, open in browser |
| Settings | `g` | Sync interval, concurrency, retries, log level |

## Test plan

- [ ] Run `fink` — TUI launches with home menu
- [ ] Navigate Collections: add, edit, toggle, sync, search, export, delete
- [ ] Sync page: select per-collection modes, run sync
- [ ] Search: global and scoped from collection, open result
- [ ] Publish: new deployment, republish with outdated detection, delete, open
- [ ] `bun run typecheck` passes with 0 errors
- [ ] `cd packages/cli && bun run build` produces dist/fink.mjs
- [ ] Verify empty state: no collections shows appropriate message, hides inapplicable menu items

🤖 Generated with [Claude Code](https://claude.com/claude-code)