### PR TITLE
Fix MantisBT crawler: attachments, project names, MantisHub mode, TUI improvements

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -10,7 +10,7 @@ import {
   addCollection,
   getCollectionDbPath,
 } from "@frozenink/core";
-import { createDefaultRegistry } from "@frozenink/crawlers";
+import { createDefaultRegistry, MantisBTCrawler } from "@frozenink/crawlers";
 
 export const addCommand = new Command("add")
   .description("Add a new collection")
@@ -22,7 +22,7 @@ export const addCommand = new Command("add")
   .option("--path <path>", "Path to local directory (for obsidian, git)")
   .option("--include-diffs", "Include commit diffs (for git)")
   .option("--url <url>", "Base URL (for mantisbt)")
-  .option("--project-id <id>", "Project ID (for mantisbt)", parseInt)
+  .option("--project-name <name>", "Project name (for mantisbt)")
   .option("--max <count>", "Maximum entities per type to sync (applies to issues and PRs independently)", parseInt)
   .option("--max-issues <count>", "Maximum issues to sync (for github)", parseInt)
   .option("--max-prs <count>", "Maximum pull requests to sync (for github)", parseInt)
@@ -108,8 +108,8 @@ export const addCommand = new Command("add")
       config.baseUrl = opts.url;
       credentials.token = opts.token ?? "";
       credentials.baseUrl = opts.url;
-      if (opts.projectId) {
-        config.projectId = opts.projectId;
+      if (opts.projectName) {
+        config.projectName = opts.projectName;
       }
       if (opts.max) {
         config.maxEntities = opts.max;
@@ -137,6 +137,20 @@ export const addCommand = new Command("add")
     if (!valid) {
       console.error("Credential validation failed. Check your token and access.");
       process.exit(1);
+    }
+
+    // Resolve MantisBT project name → ID and persist both
+    if (crawlerType === "mantisbt" && config.projectName) {
+      try {
+        await crawler.initialize(config, credentials);
+        const resolved = await (crawler as MantisBTCrawler).resolveProjectName(config.projectName as string);
+        config.projectId = resolved.id;
+        config.projectName = resolved.name; // canonical casing from server
+        console.log(`  Resolved project "${resolved.name}" → ID ${resolved.id}`);
+      } catch (err) {
+        console.error(`Failed to resolve project name: ${err instanceof Error ? err.message : err}`);
+        process.exit(1);
+      }
     }
 
     // Create collection directory and database

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -26,6 +26,7 @@ import {
 } from "@frozenink/core";
 import {
   createDefaultRegistry,
+  MantisBTCrawler,
   gitHubTheme,
   obsidianTheme,
   gitTheme,
@@ -172,6 +173,20 @@ export function handleManagementRequest(req: Request): Response | null {
       const credentials = (body.credentials ?? {}) as Record<string, unknown>;
       const title = (body.title as string) ?? name;
       const enabled = body.enabled !== false;
+
+      // Resolve MantisBT project name → ID and persist both
+      if (crawler === "mantisbt" && config.projectName && !config.projectId) {
+        try {
+          const registry = createDefaultRegistry();
+          const crawlerInstance = registry.get("mantisbt")!() as MantisBTCrawler;
+          await crawlerInstance.initialize(config, credentials);
+          const resolved = await crawlerInstance.resolveProjectName(config.projectName as string);
+          config.projectId = resolved.id;
+          config.projectName = resolved.name;
+        } catch {
+          // Resolution failed — save with just projectName; will resolve at sync time
+        }
+      }
 
       addCollection(name, { title, crawler, enabled, config, credentials });
 

--- a/packages/cli/src/tui/components/AddCollection.tsx
+++ b/packages/cli/src/tui/components/AddCollection.tsx
@@ -11,7 +11,7 @@ import {
   addCollection,
   isValidCollectionKey,
 } from "@frozenink/core";
-import { createDefaultRegistry } from "@frozenink/crawlers";
+import { createDefaultRegistry, MantisBTCrawler } from "@frozenink/crawlers";
 import { SelectInput, type SelectItem } from "./SelectInput.js";
 import { TextInput } from "./TextInput.js";
 
@@ -29,7 +29,7 @@ type Step =
   | "git-include-diffs"
   | "mantisbt-url"
   | "mantisbt-token"
-  | "mantisbt-project-id"
+  | "mantisbt-project-name"
   | "mantisbt-max"
   | "confirm"
   | "validating"
@@ -54,7 +54,7 @@ function getStepsForCrawler(type: string): Step[] {
     case "git":
       return [...base, "git-path", "git-include-diffs", "confirm"];
     case "mantisbt":
-      return [...base, "mantisbt-url", "mantisbt-token", "mantisbt-project-id", "mantisbt-max", "confirm"];
+      return [...base, "mantisbt-url", "mantisbt-token", "mantisbt-project-name", "mantisbt-max", "confirm"];
     default:
       return [...base, "confirm"];
   }
@@ -194,11 +194,9 @@ export function AddCollection({
         setData((d) => ({ ...d, credentials: { ...d.credentials, token: val || "" } }));
         nextStep();
         break;
-      case "mantisbt-project-id": {
+      case "mantisbt-project-name": {
         if (val) {
-          const n = parseInt(val, 10);
-          if (isNaN(n) || n < 1) { setError("Enter a positive number or leave blank"); return; }
-          setData((d) => ({ ...d, config: { ...d.config, projectId: n } }));
+          setData((d) => ({ ...d, config: { ...d.config, projectName: val } }));
         }
         nextStep();
         break;
@@ -223,6 +221,14 @@ export function AddCollection({
       const crawler = factory();
       const valid = await crawler.validateCredentials(data.credentials);
       if (!valid) { setError("Credential validation failed"); setStep("error"); return; }
+
+      // Resolve MantisBT project name → ID and persist both
+      if (data.crawlerType === "mantisbt" && data.config.projectName) {
+        await crawler.initialize(data.config, data.credentials);
+        const resolved = await (crawler as MantisBTCrawler).resolveProjectName(data.config.projectName as string);
+        data.config.projectId = resolved.id;
+        data.config.projectName = resolved.name;
+      }
 
       const home = getFrozenInkHome();
       const dir = join(home, "collections", data.name);
@@ -303,8 +309,8 @@ export function AddCollection({
         {step === "mantisbt-token" && (
           <TextInput label="API token (optional)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
         )}
-        {step === "mantisbt-project-id" && (
-          <TextInput label="Project ID (blank for all)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
+        {step === "mantisbt-project-name" && (
+          <TextInput label="Project name (blank for all)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
         )}
         {step === "mantisbt-max" && (
           <TextInput label="Max entities (blank for unlimited)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />

--- a/packages/cli/src/tui/components/CollectionList.tsx
+++ b/packages/cli/src/tui/components/CollectionList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { existsSync, renameSync, rmSync } from "fs";
 import { join, basename } from "path";
@@ -49,6 +49,14 @@ const W_NAME = 20;
 const W_TITLE = 22;
 const W_TYPE = 12;
 const W_ENTITIES = 10;
+
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}m ${sec}s`;
+}
 
 function pad(text: string, width: number): string {
   if (text.length >= width) return text.slice(0, width - 1) + " ";
@@ -342,9 +350,20 @@ export function CollectionList({
   const [inputValue, setInputValue] = useState("");
   const [refreshKey, setRefreshKey] = useState(0);
   const [syncProgress, setSyncProgress] = useState<string[]>([]);
+  const [syncFetchedCount, setSyncFetchedCount] = useState(0);
+  const [syncStartTime, setSyncStartTime] = useState<number | null>(null);
+  const [syncElapsedMs, setSyncElapsedMs] = useState(0);
   const [editingCollection, setEditingCollection] = useState("");
 
   const refresh = useCallback(() => setRefreshKey((k) => k + 1), []);
+
+  useEffect(() => {
+    if (syncStartTime === null) return;
+    const interval = setInterval(() => {
+      setSyncElapsedMs(Date.now() - syncStartTime);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [syncStartTime]);
 
   const initialized = contextExists();
   const collections = initialized ? listCollections() : [];
@@ -392,6 +411,9 @@ export function CollectionList({
     if (!current) return;
     setMode("syncing");
     setSyncProgress([`Syncing "${current.name}" (${current.crawler})...`]);
+    setSyncFetchedCount(0);
+    const syncStart = Date.now();
+    setSyncStartTime(syncStart);
     try {
       const registry = createDefaultRegistry();
       const themeEngine = new ThemeEngine();
@@ -400,7 +422,7 @@ export function CollectionList({
       themeEngine.register(gitTheme);
       themeEngine.register(mantisBTTheme);
       const factory = registry.get(current.crawler);
-      if (!factory) { setSyncProgress((p) => [...p, `No crawler for ${current.crawler}`]); setMode("list"); return; }
+      if (!factory) { setSyncProgress((p) => [...p, `No crawler for ${current.crawler}`]); setSyncStartTime(null); setMode("list"); return; }
       const crawler = factory();
       await crawler.initialize(current.config as Record<string, unknown>, current.credentials as Record<string, unknown>);
       const home = getFrozenInkHome();
@@ -410,18 +432,22 @@ export function CollectionList({
       const engine = new SyncEngine({
         crawler, dbPath, collectionName: current.name, themeEngine, storage, markdownBasePath: "markdown",
         onBatchFetched: ({ externalIds }: { externalIds: string[] }) => {
-          if (externalIds.length > 0) setSyncProgress((p) => [...p, `  Fetched ${externalIds.length} entities`]);
+          if (externalIds.length > 0) setSyncFetchedCount((c) => c + externalIds.length);
         },
       });
       const stats = await engine.run();
+      setSyncFetchedCount(0);
+      const elapsed = formatElapsed(Date.now() - syncStart);
       const colDb = getCollectionDb(dbPath);
       const [{ total }] = colDb.select({ total: sql<number>`count(*)` }).from(entities).all();
-      setSyncProgress((p) => [...p, `Done: +${stats.created} ~${stats.updated} -${stats.deleted} (${total} total)`]);
+      setSyncProgress((p) => [...p, `+${stats.created} ~${stats.updated} -${stats.deleted} (${total} total) in ${elapsed}`]);
       await crawler.dispose();
       setMessage(`Sync complete for "${current.name}"`);
     } catch (err) {
+      setSyncFetchedCount(0);
       setSyncProgress((p) => [...p, `Error: ${err instanceof Error ? err.message : String(err)}`]);
     }
+    setSyncStartTime(null);
     setMode("list");
     refresh();
   }, [current, refresh]);
@@ -503,6 +529,9 @@ export function CollectionList({
         <Text bold color="yellow">Syncing...</Text>
         <Box flexDirection="column" marginLeft={1} marginTop={1}>
           {syncProgress.map((line, i) => <Text key={i} dimColor>{line}</Text>)}
+          {syncFetchedCount > 0 && (
+            <Text dimColor>  Fetched {syncFetchedCount} entities... ({formatElapsed(syncElapsedMs)})</Text>
+          )}
         </Box>
       </Box>
     );

--- a/packages/cli/src/tui/components/SearchView.tsx
+++ b/packages/cli/src/tui/components/SearchView.tsx
@@ -35,6 +35,26 @@ function openFile(filePath: string): void {
   exec(cmd);
 }
 
+/**
+ * Build a compact prefix for a search result line.
+ * - issue/PR: "#00238:" (the type is obvious from the numeric ID)
+ * - note: nothing (Obsidian vaults are all notes, showing "note:" is noise)
+ * - other types: "user:", "project:", etc.
+ */
+function formatResultPrefix(entityType: string, externalId: string): string | null {
+  const colonIdx = externalId.indexOf(":");
+  const rawId = colonIdx !== -1 ? externalId.slice(colonIdx + 1) : "";
+
+  if (entityType === "issue" || entityType === "pull_request") {
+    const num = parseInt(rawId, 10);
+    if (!isNaN(num)) return `#${String(num).padStart(5, "0")}:`;
+  }
+
+  if (entityType === "note") return null;
+
+  return `${entityType}:`;
+}
+
 function getMarkdownPath(result: SearchResult): string | null {
   const home = getFrozenInkHome();
   const dbPath = getCollectionDbPath(result.collection);
@@ -158,16 +178,19 @@ export function SearchView({
             {results.length === 0 ? (
               <Text dimColor>No results found.</Text>
             ) : (
-              results.map((r, i) => (
-                <Box key={i} gap={1}>
-                  <Text color={i === resultCursor ? "cyan" : undefined}>
-                    {i === resultCursor ? "❯" : " "}
-                  </Text>
-                  {!scoped && <Text dimColor>[{r.collection}]</Text>}
-                  <Text color="cyan">{r.entityType}:</Text>
-                  <Text bold={i === resultCursor}>{r.title}</Text>
-                </Box>
-              ))
+              results.map((r, i) => {
+                const prefix = formatResultPrefix(r.entityType, r.externalId);
+                return (
+                  <Box key={i} gap={1}>
+                    <Text color={i === resultCursor ? "cyan" : undefined}>
+                      {i === resultCursor ? "❯" : " "}
+                    </Text>
+                    {!scoped && <Text dimColor>[{r.collection}]</Text>}
+                    {prefix && <Text color="cyan">{prefix}</Text>}
+                    <Text bold={i === resultCursor}>{r.title}</Text>
+                  </Box>
+                );
+              })
             )}
           </Box>
         </Box>

--- a/packages/cli/src/tui/components/SyncView.tsx
+++ b/packages/cli/src/tui/components/SyncView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { existsSync } from "fs";
 import { join } from "path";
@@ -37,6 +37,14 @@ const W_NAME = 20;
 const W_TITLE = 22;
 const W_TYPE = 12;
 const W_ENTITIES = 10;
+
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}m ${sec}s`;
+}
 
 function pad(text: string, width: number): string {
   if (text.length >= width) return text.slice(0, width - 1) + " ";
@@ -87,6 +95,19 @@ export function SyncView(): React.ReactElement {
   const [progress, setProgress] = useState<string[]>([]);
   const [syncModes, setSyncModes] = useState<Map<string, SyncMode>>(new Map());
   const [totalStats, setTotalStats] = useState<{ created: number; updated: number; deleted: number; total: number } | null>(null);
+  const [fetchedCount, setFetchedCount] = useState(0);
+  const [syncingCollection, setSyncingCollection] = useState(false);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [syncStartTime, setSyncStartTime] = useState<number | null>(null);
+
+  // Tick elapsed time every second while syncing
+  useEffect(() => {
+    if (syncStartTime === null) return;
+    const interval = setInterval(() => {
+      setElapsedMs(Date.now() - syncStartTime);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [syncStartTime]);
 
   const initialized = contextExists();
   const collections = initialized
@@ -130,6 +151,9 @@ export function SyncView(): React.ReactElement {
     setViewMode("syncing");
     setProgress([]);
     setTotalStats(null);
+    setFetchedCount(0);
+    const syncStart = Date.now();
+    setSyncStartTime(syncStart);
 
     const home = getFrozenInkHome();
     const registry = createDefaultRegistry();
@@ -148,10 +172,13 @@ export function SyncView(): React.ReactElement {
       const isFullSync = syncModes.get(col.name) === "full";
       const label = isFullSync ? "full sync" : "sync";
       setProgress((p) => [...p, `${label}: "${col.name}" (${col.crawler})...`]);
+      setFetchedCount(0);
+      setSyncingCollection(true);
 
       const factory = registry.get(col.crawler);
       if (!factory) {
         setProgress((p) => [...p, `  No crawler for ${col.crawler}, skipping`]);
+        setSyncingCollection(false);
         continue;
       }
 
@@ -189,21 +216,24 @@ export function SyncView(): React.ReactElement {
         markdownBasePath: "markdown",
         onBatchFetched: ({ externalIds }: { externalIds: string[] }) => {
           if (externalIds.length > 0) {
-            setProgress((p) => [...p, `  Fetched ${externalIds.length} entities`]);
+            setFetchedCount((c) => c + externalIds.length);
           }
         },
       });
 
       try {
         const stats = await engine.run();
+        setSyncingCollection(false);
         const colDb = getCollectionDb(dbPath);
         const [{ total }] = colDb.select({ total: sql<number>`count(*)` }).from(entities).all();
         totalCreated += stats.created;
         totalUpdated += stats.updated;
         totalDeleted += stats.deleted;
         totalEntities += total;
-        setProgress((p) => [...p, `  Done: +${stats.created} ~${stats.updated} -${stats.deleted} (${total} total)`]);
+        const colElapsed = formatElapsed(Date.now() - syncStart);
+        setProgress((p) => [...p, `  +${stats.created} ~${stats.updated} -${stats.deleted} (${total} total) in ${colElapsed}`]);
       } catch (err) {
+        setSyncingCollection(false);
         const msg = err instanceof Error ? err.message : String(err);
         setProgress((p) => [...p, `  Error: ${msg}`]);
       }
@@ -211,7 +241,14 @@ export function SyncView(): React.ReactElement {
       await crawler.dispose();
     }
 
-    setTotalStats({ created: totalCreated, updated: totalUpdated, deleted: totalDeleted, total: totalEntities });
+    const totalElapsed = Date.now() - syncStart;
+    setElapsedMs(totalElapsed);
+    setSyncStartTime(null); // stop the timer
+
+    // Only show combined totals when multiple collections were synced
+    if (toSync.length > 1) {
+      setTotalStats({ created: totalCreated, updated: totalUpdated, deleted: totalDeleted, total: totalEntities });
+    }
     setViewMode("done");
   }, [collections, syncModes]);
 
@@ -222,9 +259,18 @@ export function SyncView(): React.ReactElement {
       if (input === " " && collections[cursor]) {
         cycleSyncMode(collections[cursor].name);
       }
-      if (input === "s") setAllMode("incremental");
-      if (input === "f") setAllMode("full");
-      if (input === "n") setAllMode("skip");
+      if (input === "s" && collections[cursor]) {
+        setSyncModes((prev) => { const next = new Map(prev); next.set(collections[cursor].name, "incremental"); return next; });
+      }
+      if (input === "f" && collections[cursor]) {
+        setSyncModes((prev) => { const next = new Map(prev); next.set(collections[cursor].name, "full"); return next; });
+      }
+      if (input === "n" && collections[cursor]) {
+        setSyncModes((prev) => { const next = new Map(prev); next.set(collections[cursor].name, "skip"); return next; });
+      }
+      if (input === "S") setAllMode("incremental");
+      if (input === "F") setAllMode("full");
+      if (input === "N") setAllMode("skip");
       if (key.return) startSync();
     }
     if (viewMode === "done") {
@@ -258,6 +304,9 @@ export function SyncView(): React.ReactElement {
           {progress.map((line, i) => (
             <Text key={i} dimColor={viewMode === "done"}>{line}</Text>
           ))}
+          {syncingCollection && fetchedCount > 0 && (
+            <Text dimColor>  Fetched {fetchedCount} entities... ({formatElapsed(elapsedMs)})</Text>
+          )}
         </Box>
         {totalStats && (
           <Box marginTop={1} gap={2}>
@@ -314,10 +363,11 @@ export function SyncView(): React.ReactElement {
       </Box>
 
       <Box marginTop={1} gap={2}>
-        <Text dimColor>[Space] Cycle mode</Text>
-        <Text dimColor>[s] All incremental</Text>
-        <Text dimColor>[f] All full</Text>
-        <Text dimColor>[n] All skip</Text>
+        <Text dimColor>[Space] Cycle</Text>
+        <Text dimColor>[s] Sync</Text>
+        <Text dimColor>[f] Full</Text>
+        <Text dimColor>[n] Skip</Text>
+        <Text dimColor>[S/F/N] All</Text>
         <Text dimColor>[Enter] Start{selectedCount > 0 ? ` (${selectedCount})` : ""}</Text>
       </Box>
     </Box>

--- a/packages/crawlers/src/mantisbt/README.md
+++ b/packages/crawlers/src/mantisbt/README.md
@@ -1,0 +1,63 @@
+# MantisBT Crawler
+
+Crawls a MantisBT instance via its REST API, syncing issues (with attachments), users, and projects.
+
+## Configuration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `baseUrl` | string | Yes | Base URL of the MantisBT instance (e.g. `https://mantisbt.org/bugs`) |
+| `projectName` | string | No | Project name to filter issues. Resolved to a project ID via the MantisBT projects API at collection creation time. Both `projectName` and `projectId` are persisted so subsequent syncs skip the lookup. |
+| `projectId` | number | No | Project ID (set automatically when `projectName` is resolved; can also be set directly for backward compatibility). |
+| `maxEntities` | number | No | Maximum number of issues to sync (useful for testing). |
+
+## Credentials
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `token` | string | MantisBT REST API token. Optional for public instances. |
+
+## Sync Behavior
+
+- Fetches issues in pages of 25, sleeping 100ms between pages to avoid overloading the server.
+- Issues are sorted by `updated_at` descending. Incremental syncs use the `updatedSince` cursor to only process issues updated since the last completed sync.
+- After all issue pages are processed, the crawler enters a "users" phase where it fetches full user profiles and emits user and project entities.
+
+## Attachment Downloads
+
+Attachments (both issue-level and note-level) are downloaded using the core MantisBT REST API:
+
+1. **`download_url`** (if provided in the issue response): Downloaded as binary.
+2. **`GET /api/rest/issues/{id}/files/{file_id}`** (operationId: `IssueFileGet`): Returns JSON with base64-encoded file content. This endpoint works for both issue-level files and note-level attachments per the MantisBT OpenAPI spec.
+
+## MantisHub Mode
+
+MantisHub mode is automatically enabled when the `baseUrl` contains `.mantishub.` (e.g. `https://example.mantishub.io`). All core MantisBT APIs work identically on MantisHub, so MantisHub mode only activates as a **fallback** when the core API fails.
+
+### Why MantisHub mode exists
+
+MantisHub instances may store file attachments in cloud storage (S3) rather than locally on the server. In this configuration, the core MantisBT REST API file download endpoint may fail because the file content isn't accessible from the local filesystem. MantisHub mode provides a fallback path to retrieve these files.
+
+### When MantisHub mode activates
+
+The crawler always tries the core MantisBT REST API first for every attachment download. Only if the core API fails to return the file content does MantisHub mode kick in. When it does, it makes one API call per issue (cached across all attachments on that issue) to MantisHub's **ApiX plugin**:
+
+```
+GET /api/rest/plugins/ApiX/issues/{id}/pages/view
+```
+
+This is the IssueViewPage endpoint from the ApiX plugin (`IssueViewPageCommandX`). It returns attachment metadata with:
+
+- `url` - Standard download URL (`file_download.php?file_id={id}&type=bug`)
+- `signed_url` - Pre-authenticated, time-limited URL for direct cloud storage access (MantisHub only)
+
+The crawler prefers `signed_url` over `url` for the binary download.
+
+### What MantisHub mode does NOT change
+
+- Issue listing uses the standard MantisBT REST API (`GET /api/rest/issues`)
+- Project resolution uses the standard MantisBT REST API (`GET /api/rest/projects`)
+- User fetching uses the standard MantisBT REST API (`GET /api/rest/users/{id}`)
+- Attachment downloads try the standard MantisBT REST API first
+
+The ApiX plugin is only used as a last resort for attachment downloads, covering the specific gap where cloud-stored files can't be served by the core MantisBT API.

--- a/packages/crawlers/src/mantisbt/__tests__/crawler.test.ts
+++ b/packages/crawlers/src/mantisbt/__tests__/crawler.test.ts
@@ -15,7 +15,7 @@ function sampleIssue(overrides: Partial<MantisBTIssue> = {}): MantisBTIssue {
     resolution: { id: 10, name: "open", label: "open" },
     priority: { id: 30, name: "normal", label: "normal" },
     severity: { id: 50, name: "minor", label: "minor" },
-    files: [],
+    attachments: [],
     notes: [],
     relationships: [],
     ...overrides,
@@ -27,6 +27,37 @@ function jsonResponse(body: unknown, status = 200): Response {
     status,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+/** Match /api/rest/issues/{id} (single issue fetch, no query string). */
+const SINGLE_ISSUE_RE = /\/api\/rest\/issues\/(\d+)$/;
+
+/**
+ * Wrap a list-level fetch mock so that individual issue fetches
+ * (GET /api/rest/issues/{id}) return the matching issue from the
+ * most recently returned list page.
+ */
+function routingFetch(
+  listFn: (url: string) => Promise<Response>,
+): (input: string | URL | Request) => Promise<Response> {
+  let lastPage: MantisBTIssue[] = [];
+  return async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const singleMatch = url.match(SINGLE_ISSUE_RE);
+    if (singleMatch) {
+      const id = parseInt(singleMatch[1], 10);
+      const issue = lastPage.find((i) => i.id === id) ?? sampleIssue({ id });
+      return jsonResponse({ issues: [issue] });
+    }
+    const res = await listFn(url);
+    // Clone and peek at the body to track the last page
+    const cloned = res.clone();
+    try {
+      const data = (await cloned.json()) as { issues?: MantisBTIssue[] };
+      lastPage = data.issues ?? [];
+    } catch { /* ignore */ }
+    return res;
+  };
 }
 
 describe("MantisBTCrawler", () => {
@@ -42,7 +73,7 @@ describe("MantisBTCrawler", () => {
 
   it("stores updatedSince cursor and filters incremental updates", async () => {
     let call = 0;
-    crawler.setFetch(async () => {
+    crawler.setFetch(routingFetch(async () => {
       call += 1;
       if (call === 1) {
         return jsonResponse({
@@ -56,7 +87,7 @@ describe("MantisBTCrawler", () => {
           sampleIssue({ id: 3, updated_at: "2024-01-01T00:00:00Z" }),
         ],
       });
-    });
+    }));
 
     // Issues phase: syncs 1 issue, then transitions to users phase.
     const first = await crawler.sync(null);
@@ -84,11 +115,11 @@ describe("MantisBTCrawler", () => {
   });
 
   it("includes entities with updated_at equal to updatedSince", async () => {
-    crawler.setFetch(async () =>
+    crawler.setFetch(routingFetch(async () =>
       jsonResponse({
         issues: [sampleIssue({ id: 9, updated_at: "2024-02-01T12:00:00Z" })],
       }),
-    );
+    ));
 
     const result = await crawler.sync({ updatedSince: "2024-02-01T12:00:00Z" });
     expect(result.entities).toHaveLength(1);
@@ -107,14 +138,14 @@ describe("MantisBTCrawler", () => {
   });
 
   it("stops paginating when the API repeats the same page", async () => {
-    const repeatedPage = Array.from({ length: 50 }, (_, i) =>
+    const repeatedPage = Array.from({ length: 25 }, (_, i) =>
       sampleIssue({
         id: i + 1,
         updated_at: "2024-02-01T00:00:00Z",
       }),
     );
 
-    crawler.setFetch(async () => jsonResponse({ issues: repeatedPage }));
+    crawler.setFetch(routingFetch(async () => jsonResponse({ issues: repeatedPage })));
 
     const first = await crawler.sync({ updatedSince: "2024-01-01T00:00:00Z" });
     expect(first.hasMore).toBe(true);
@@ -133,26 +164,25 @@ describe("MantisBTCrawler", () => {
   });
 
   it("advances to page 2 with in-run cursor state", async () => {
-    const requestedUrls: string[] = [];
-    const repeatedPage = Array.from({ length: 50 }, (_, i) =>
+    const listUrls: string[] = [];
+    const repeatedPage = Array.from({ length: 25 }, (_, i) =>
       sampleIssue({
         id: i + 1,
         updated_at: "2024-03-01T00:00:00Z",
       }),
     );
 
-    crawler.setFetch(async (input: string | URL | Request) => {
-      const url = typeof input === "string" ? input : input.toString();
-      requestedUrls.push(url);
+    crawler.setFetch(routingFetch(async (url: string) => {
+      listUrls.push(url);
       return jsonResponse({ issues: repeatedPage });
-    });
+    }));
 
     const first = await crawler.sync(null);
     expect(first.hasMore).toBe(true);
     expect(first.nextCursor).toBeTruthy();
 
     await crawler.sync(first.nextCursor);
-    expect(requestedUrls[0]).toContain("page=1");
-    expect(requestedUrls[1]).toContain("page=2");
+    expect(listUrls[0]).toContain("page=1");
+    expect(listUrls[1]).toContain("page=2");
   });
 });

--- a/packages/crawlers/src/mantisbt/crawler.ts
+++ b/packages/crawlers/src/mantisbt/crawler.ts
@@ -10,6 +10,7 @@ import type {
   MantisBTConfig,
   MantisBTCredentials,
   MantisBTIssue,
+  MantisBTProject,
   MantisBTUser,
 } from "./types";
 
@@ -34,7 +35,8 @@ interface MantisBTSyncCursor extends SyncCursor {
   _projects?: Record<number, { id: number; name: string; categories: string[] }>;
 }
 
-const PAGE_SIZE = 50;
+const PAGE_SIZE = 25;
+const PAGE_DELAY_MS = 100;
 
 function parseTimestamp(value: string | undefined): number | null {
   if (!value) return null;
@@ -72,6 +74,17 @@ function noteAttachmentFilename(issueId: number, noteId: number, filename: strin
   return `${padId(issueId)}-${padId(noteId)}-${hash}${ext}`;
 }
 
+/** Detect MantisHub instances by URL pattern. */
+function isMantisHub(baseUrl: string): boolean {
+  return baseUrl.includes(".mantishub.");
+}
+
+/** Attachment download URL info resolved from the API. */
+interface AttachmentUrlInfo {
+  url?: string;
+  signedUrl?: string;
+}
+
 export class MantisBTCrawler implements Crawler {
   metadata: CrawlerMetadata = {
     type: "mantisbt",
@@ -84,10 +97,10 @@ export class MantisBTCrawler implements Crawler {
         required: true,
         description: "Base URL of the MantisBT instance (e.g. https://mantisbt.org/bugs)",
       },
-      projectId: {
-        type: "number",
+      projectName: {
+        type: "string",
         required: false,
-        description: "Optional project ID to filter issues",
+        description: "Optional project name to filter issues (resolved to ID via API)",
       },
       maxEntities: {
         type: "number",
@@ -102,6 +115,7 @@ export class MantisBTCrawler implements Crawler {
   private token = "";
   private projectId?: number;
   private maxEntities?: number;
+  private mantisHubMode = false;
   private fetchFn: typeof fetch = globalThis.fetch;
 
   // Accumulated during the issues phase; emitted in the users phase.
@@ -116,8 +130,36 @@ export class MantisBTCrawler implements Crawler {
     const creds = credentials as unknown as MantisBTCredentials;
     this.baseUrl = cfg.baseUrl.replace(/\/+$/, "");
     this.token = creds.token ?? "";
-    this.projectId = cfg.projectId;
     this.maxEntities = cfg.maxEntities;
+    this.mantisHubMode = isMantisHub(this.baseUrl);
+
+    // Use stored projectId if available (persisted at creation time);
+    // otherwise resolve projectName to projectId via API.
+    if (cfg.projectId) {
+      this.projectId = cfg.projectId;
+    } else if (cfg.projectName) {
+      this.projectId = await this.resolveProjectId(cfg.projectName);
+    }
+  }
+
+  /**
+   * Resolve a project name to its ID and return both.
+   * Public so that callers (CLI, TUI, management API) can persist both
+   * values at collection creation time.
+   */
+  async resolveProjectName(projectName: string): Promise<{ id: number; name: string }> {
+    const projects = await this.fetchProjects();
+    const allProjects = this.flattenProjects(projects);
+    const match = allProjects.find(
+      (p) => p.name.toLowerCase() === projectName.toLowerCase(),
+    );
+    if (!match) {
+      const available = allProjects.map((p) => p.name).join(", ");
+      throw new Error(
+        `Project "${projectName}" not found. Available projects: ${available}`,
+      );
+    }
+    return { id: match.id, name: match.name };
   }
 
   async sync(cursor: SyncCursor | null): Promise<SyncResult> {
@@ -150,6 +192,11 @@ export class MantisBTCrawler implements Crawler {
     const page = isLegacyPageCursor ? 1 : (c.page ?? 1);
     const fetched = isLegacyPageCursor ? 0 : (c.fetched ?? 0);
     const updatedSinceTs = parseTimestamp(c.updatedSince);
+
+    // Throttle requests: sleep between pages to avoid overloading the server
+    if (page > 1) {
+      await new Promise((resolve) => setTimeout(resolve, PAGE_DELAY_MS));
+    }
 
     let url = `${this.baseUrl}/api/rest/issues?page_size=${PAGE_SIZE}&page=${page}`;
     if (this.projectId) {
@@ -223,9 +270,13 @@ export class MantisBTCrawler implements Crawler {
       this.collectUsersAndProjects(issue);
     }
 
-    const entities: CrawlerEntityData[] = await Promise.all(
-      issuesToProcess.map((issue) => this.buildIssueEntity(issue)),
-    );
+    // Fetch full issue data individually — the list endpoint omits attachments
+    // and note attachments. Sequential to avoid overwhelming the server.
+    const entities: CrawlerEntityData[] = [];
+    for (const issue of issuesToProcess) {
+      const fullIssue = await this.fetchIssue(issue.id);
+      entities.push(await this.buildIssueEntity(fullIssue));
+    }
 
     const newFetched = fetched + issuesToProcess.length;
     const serializedCollected = {
@@ -344,10 +395,40 @@ export class MantisBTCrawler implements Crawler {
     return response;
   }
 
+  private async fetchIssue(issueId: number): Promise<MantisBTIssue> {
+    const url = `${this.baseUrl}/api/rest/issues/${issueId}`;
+    const response = await this.apiFetch(url);
+    const data = (await response.json()) as { issues: MantisBTIssue[] };
+    return data.issues[0];
+  }
+
   private async fetchUser(userId: number): Promise<MantisBTUser> {
     const url = `${this.baseUrl}/api/rest/users/${userId}`;
     const response = await this.apiFetch(url);
     return (await response.json()) as MantisBTUser;
+  }
+
+  private async fetchProjects(): Promise<MantisBTProject[]> {
+    const url = `${this.baseUrl}/api/rest/projects`;
+    const response = await this.apiFetch(url);
+    const data = (await response.json()) as { projects: MantisBTProject[] };
+    return data.projects ?? [];
+  }
+
+  private async resolveProjectId(projectName: string): Promise<number> {
+    const resolved = await this.resolveProjectName(projectName);
+    return resolved.id;
+  }
+
+  private flattenProjects(projects: MantisBTProject[]): MantisBTProject[] {
+    const result: MantisBTProject[] = [];
+    for (const p of projects) {
+      result.push(p);
+      if ((p as any).subProjects?.length) {
+        result.push(...this.flattenProjects((p as any).subProjects));
+      }
+    }
+    return result;
   }
 
   private buildUserEntity(user: MantisBTUser): CrawlerEntityData {
@@ -423,6 +504,54 @@ export class MantisBTCrawler implements Crawler {
     }
   }
 
+  // ── MantisHub ApiX fallback ──────────────────────────────────────
+  //
+  // MantisHub instances (detected by `.mantishub.` in the URL) expose the
+  // ApiX plugin at /api/rest/plugins/ApiX/. When the core MantisBT REST
+  // API fails to download an attachment (e.g. cloud-stored files that
+  // require session auth), we fall back to the ApiX IssueViewPage endpoint
+  // which provides pre-signed download URLs. The ApiX call is only made
+  // if a core API download fails, and only once per issue (cached across
+  // all attachments on that issue).
+
+  /**
+   * For MantisHub: fetch the IssueViewPage via the ApiX plugin to get
+   * signed download URLs for all attachments (issue-level and note-level).
+   * Returns a map of attachment_id → { url, signedUrl }.
+   */
+  private async fetchMantisHubAttachmentUrls(
+    issueId: number,
+  ): Promise<Map<number, AttachmentUrlInfo>> {
+    const urlMap = new Map<number, AttachmentUrlInfo>();
+    const url = `${this.baseUrl}/api/rest/plugins/ApiX/issues/${issueId}/pages/view`;
+    try {
+      const res = await this.apiFetch(url);
+      const data = (await res.json()) as {
+        issue?: {
+          attachments?: Array<{ id: number; url?: string; signed_url?: string }>;
+          notes?: Array<{
+            attachments?: Array<{ id: number; url?: string; signed_url?: string }>;
+          }>;
+        };
+      };
+
+      // Issue-level attachments
+      for (const att of data.issue?.attachments ?? []) {
+        urlMap.set(att.id, { url: att.url, signedUrl: att.signed_url });
+      }
+
+      // Note-level attachments
+      for (const note of data.issue?.notes ?? []) {
+        for (const att of note.attachments ?? []) {
+          urlMap.set(att.id, { url: att.url, signedUrl: att.signed_url });
+        }
+      }
+    } catch (err) {
+      console.warn(`  Warning: MantisHub IssueViewPage failed for issue ${issueId}: ${err}`);
+    }
+    return urlMap;
+  }
+
   private async buildIssueEntity(issue: MantisBTIssue): Promise<CrawlerEntityData> {
     const hasher = createCryptoHasher("sha256");
     hasher.update(JSON.stringify(issue));
@@ -455,13 +584,32 @@ export class MantisBTCrawler implements Crawler {
     }
 
     // Download attachments; track storage paths that were successfully saved.
+    // Uses core MantisBT REST API first. On MantisHub instances, if the core
+    // API fails, falls back to the ApiX IssueViewPage for signed download URLs.
     const attachments: CrawlerEntityData["attachments"] = [];
     const savedPaths = new Set<string>();
+    let mantisHubUrls: Map<number, AttachmentUrlInfo> | null = null;
 
-    for (const file of issue.files ?? []) {
+    for (const file of issue.attachments ?? []) {
       const storedName = attachmentFilename(issue.id, file.filename);
       const storagePath = `attachments/mantisbt/${storedName}`;
-      const content = await this.downloadAttachment(issue.id, file.id, `issue ${issue.id} file "${file.filename}"`);
+      let content = await this.downloadAttachment(
+        issue.id, file.id, file.download_url,
+        `issue ${issue.id} file "${file.filename}"`,
+      );
+
+      // MantisHub fallback: fetch signed URLs if core API failed
+      if (!content && this.mantisHubMode) {
+        if (!mantisHubUrls) {
+          mantisHubUrls = await this.fetchMantisHubAttachmentUrls(issue.id);
+        }
+        const urlInfo = mantisHubUrls.get(file.id);
+        const signedUrl = urlInfo?.signedUrl ?? urlInfo?.url;
+        if (signedUrl) {
+          content = await this.downloadBinary(signedUrl, `issue ${issue.id} file "${file.filename}" (MantisHub)`);
+        }
+      }
+
       if (content) {
         attachments.push({
           filename: storedName,
@@ -477,7 +625,23 @@ export class MantisBTCrawler implements Crawler {
       for (const att of note.attachments ?? []) {
         const storedName = noteAttachmentFilename(issue.id, note.id, att.filename);
         const storagePath = `attachments/mantisbt/${storedName}`;
-        const content = await this.downloadAttachment(issue.id, att.id, `issue ${issue.id} note ${note.id} file "${att.filename}"`);
+        let content = await this.downloadAttachment(
+          issue.id, att.id, att.download_url,
+          `issue ${issue.id} note ${note.id} file "${att.filename}"`,
+        );
+
+        // MantisHub fallback: fetch signed URLs if core API failed
+        if (!content && this.mantisHubMode) {
+          if (!mantisHubUrls) {
+            mantisHubUrls = await this.fetchMantisHubAttachmentUrls(issue.id);
+          }
+          const urlInfo = mantisHubUrls.get(att.id);
+          const signedUrl = urlInfo?.signedUrl ?? urlInfo?.url;
+          if (signedUrl) {
+            content = await this.downloadBinary(signedUrl, `issue ${issue.id} note ${note.id} file "${att.filename}" (MantisHub)`);
+          }
+        }
+
         if (content) {
           attachments.push({
             filename: storedName,
@@ -514,7 +678,7 @@ export class MantisBTCrawler implements Crawler {
         createdAt: issue.created_at,
         updatedAt: issue.updated_at,
         sticky: issue.sticky,
-        files: (issue.files ?? []).map((f) => {
+        attachments: (issue.attachments ?? []).map((f) => {
           const storagePath = `attachments/mantisbt/${attachmentFilename(issue.id, f.filename)}`;
           return {
             filename: f.filename,
@@ -542,12 +706,19 @@ export class MantisBTCrawler implements Crawler {
   }
 
   /**
-   * Download a file using GET /api/rest/issues/:issue_id/files/:file_id.
-   * The response is JSON: { files: [{ content: "<base64>" }] }
+   * Download an attachment via the core MantisBT REST API.
+   *
+   * Uses GET /api/rest/issues/{id}/files/{file_id} (operationId: IssueFileGet)
+   * which returns JSON with base64-encoded content. Works for both issue-level
+   * and note-level attachments per the MantisBT OpenAPI spec.
+   *
+   * If a download_url is available (e.g. from the issue response), tries that
+   * first as a binary download, then falls back to the REST API endpoint.
    */
   private async downloadAttachment(
     issueId: number,
     fileId: number,
+    downloadUrl: string | undefined,
     label: string,
   ): Promise<Buffer | null> {
     const headers: Record<string, string> = {};
@@ -555,9 +726,25 @@ export class MantisBTCrawler implements Crawler {
       headers["Authorization"] = this.token;
     }
 
-    const url = `${this.baseUrl}/api/rest/issues/${issueId}/files/${fileId}`;
+    // Try download_url first if provided (binary response)
+    if (downloadUrl) {
+      try {
+        const res = await this.fetchFn(downloadUrl, { headers });
+        if (res.ok) {
+          const arrayBuffer = await res.arrayBuffer();
+          if (arrayBuffer.byteLength > 0) {
+            return Buffer.from(arrayBuffer);
+          }
+        }
+      } catch {
+        // Fall through to REST API
+      }
+    }
+
+    // Core MantisBT REST API (IssueFileGet - returns base64 JSON)
+    const apiUrl = `${this.baseUrl}/api/rest/issues/${issueId}/files/${fileId}`;
     try {
-      const res = await this.fetchFn(url, { headers });
+      const res = await this.fetchFn(apiUrl, { headers });
       if (!res.ok) {
         console.warn(`  Warning: could not download attachment ${label} (${res.status} ${res.statusText})`);
         return null;
@@ -571,6 +758,26 @@ export class MantisBTCrawler implements Crawler {
       return Buffer.from(content, "base64");
     } catch (err) {
       console.warn(`  Warning: could not download attachment ${label}: ${err}`);
+      return null;
+    }
+  }
+
+  /** Download a file as binary from a URL (used for MantisHub signed URLs). */
+  private async downloadBinary(url: string, label: string): Promise<Buffer | null> {
+    const headers: Record<string, string> = {};
+    if (this.token) {
+      headers["Authorization"] = this.token;
+    }
+    try {
+      const res = await this.fetchFn(url, { headers });
+      if (!res.ok) {
+        console.warn(`  Warning: binary download failed for ${label} (${res.status} ${res.statusText})`);
+        return null;
+      }
+      const arrayBuffer = await res.arrayBuffer();
+      return arrayBuffer.byteLength > 0 ? Buffer.from(arrayBuffer) : null;
+    } catch (err) {
+      console.warn(`  Warning: binary download failed for ${label}: ${err}`);
       return null;
     }
   }

--- a/packages/crawlers/src/mantisbt/theme.ts
+++ b/packages/crawlers/src/mantisbt/theme.ts
@@ -299,7 +299,7 @@ export class MantisBTTheme implements Theme {
     }
 
     // Issue-level attachments
-    const files = d.files as Array<{ filename: string; storagePath?: string; size: number }> | undefined;
+    const files = d.attachments as Array<{ filename: string; storagePath?: string; size: number }> | undefined;
     if (files?.length) {
       parts.push(`<h3 class="mt-subsection-title">Attachments</h3>`);
       parts.push(`<div class="mt-attachments">`);
@@ -604,12 +604,13 @@ export class MantisBTTheme implements Theme {
     rows.push(tableRow("Created", formatDate(d.createdAt as string)));
     rows.push(tableRow("Updated", formatDate(d.updatedAt as string)));
 
-    // Issue-level attachments
-    const files = d.files as Array<{ filename: string; storagePath?: string }>;
+    // Issue-level attachments — standard markdown images with relative paths
+    // from markdown/<type>/<file>.md up to the collection root, then into attachments/
+    const files = d.attachments as Array<{ filename: string; storagePath?: string }>;
     if (files?.length) {
       const embeds = files
         .filter((f) => f.storagePath)
-        .map((f) => `![[${f.storagePath!.replace(/^attachments\//, "")}]]`);
+        .map((f) => `![${f.filename}](../../${f.storagePath})`);
       if (embeds.length) {
         sections.push("### Attachments\n\n" + embeds.join("\n\n"));
       }
@@ -673,10 +674,10 @@ export class MantisBTTheme implements Theme {
 
         const body = linkifyIssueRefs(note.text, lookup);
 
-        // Embed note attachments using stored paths
+        // Embed note attachments using stored paths (relative from markdown/<type>/)
         const embeds = (note.attachments ?? [])
           .filter((att) => att.storagePath)
-          .map((att) => `![[${att.storagePath!.replace(/^attachments\//, "")}]]`);
+          .map((att) => `![${att.filename}](../../${att.storagePath})`);
 
         return [header, body, ...embeds].filter(Boolean).join("\n\n");
       });

--- a/packages/crawlers/src/mantisbt/types.ts
+++ b/packages/crawlers/src/mantisbt/types.ts
@@ -19,6 +19,7 @@ export interface MantisBTProject {
 export interface MantisBTConfig {
   baseUrl: string;
   projectId?: number;
+  projectName?: string;
   maxEntities?: number;
 }
 
@@ -46,8 +47,8 @@ export interface MantisBTIssue {
   severity: { id: number; name: string; label: string };
   reproducibility?: { id: number; name: string; label: string };
   tags?: Array<{ id: number; name: string }>;
-  /** Issue-level file attachments. */
-  files?: Array<{
+  /** Issue-level file attachments (returned as "attachments" by the REST API). */
+  attachments?: Array<{
     id: number;
     filename: string;
     content_type: string;

--- a/packages/ui/src/components/MarkdownView.tsx
+++ b/packages/ui/src/components/MarkdownView.tsx
@@ -30,6 +30,14 @@ function preprocessMarkdown(raw: string, collection: string): string {
       `![${path}](/api/attachments/${encodeURIComponent(collection)}/${path})`,
   );
 
+  // Rewrite relative attachment paths (../../attachments/...) to API URLs
+  // so they resolve in the web viewer where files aren't on the local filesystem.
+  content = content.replace(
+    /!\[([^\]]*)\]\(\.\.\/\.\.\/attachments\/([^)]+)\)/g,
+    (_match, alt: string, path: string) =>
+      `![${alt}](/api/attachments/${encodeURIComponent(collection)}/${path})`,
+  );
+
   // Replace wikilinks: [[target|label]] → [label](#wikilink/encoded-target)
   // and [[target]] → [target](#wikilink/encoded-target)
   // encodeURIComponent ensures spaces and special chars survive the URL round-trip.

--- a/packages/ui/src/components/manage/CollectionForm.tsx
+++ b/packages/ui/src/components/manage/CollectionForm.tsx
@@ -222,8 +222,8 @@ function renderConfigFields(
     case "mantisbt":
       return (
         <>
-          {field("url", "MantisBT URL", "https://mantis.example.com")}
-          {field("projectId", "Project ID", "1", "number")}
+          {field("baseUrl", "MantisBT URL", "https://mantis.example.com")}
+          {field("projectName", "Project Name", "My Project")}
         </>
       );
     default:


### PR DESCRIPTION
## Summary

- **Fix attachment downloads**: MantisBT REST API returns issue-level attachments under `attachments` key (not `files`); list endpoint omits them entirely, so each issue is now fetched individually for full data
- **MantisHub mode**: Auto-detected from `.mantishub.` in URL; falls back to ApiX IssueViewPage signed URLs when core MantisBT attachment download fails (covers cloud-stored files)
- **Project name resolution**: Collection creation now asks for project name instead of ID, resolves via `GET /api/rest/projects`, and persists both name and ID so syncs skip the lookup
- **Sync throttling**: Page size reduced to 25 with 100ms inter-page delay
- **Attachment embeds**: Changed from Obsidian wikilinks (`![[...]]`) to standard markdown images with relative paths so they render in any markdown editor; web UI rewrites paths to API URLs
- **TUI sync progress**: Single updating entity counter with elapsed time; duration in final stats; no redundant totals for single-collection syncs
- **Search results**: Show `#00238:` prefix for issues, hide `note:` for Obsidian entries
- **Sync page keybindings**: `s`/`f`/`n` set current item mode, `S`/`F`/`N` set all; space cycles

## Test plan

- [x] All 162 crawler tests pass
- [x] MantisBT-specific tests pass (5/5) with updated mocks for individual issue fetching
- [x] TypeScript type-checks clean
- [ ] Full sync of MantisHub collection to verify attachment downloads
- [ ] Verify attachments render in both web UI and markdown editors
- [ ] Test project name resolution during collection creation (CLI, TUI, web UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)