### PR TITLE
Collection & site directory restructure, DB schema renames, config cleanup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,10 @@
   "workspaces": {
     "": {
       "name": "frozenink",
+      "dependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "js-yaml": "^4.1.1",
+      },
       "devDependencies": {
         "bun-types": "^1.3.11",
         "drizzle-kit": "^0.31.10",
@@ -25,6 +29,7 @@
         "commander": "^13.0.0",
         "drizzle-orm": "^0.39.0",
         "ink": "^7.0.0",
+        "js-yaml": "^4.1.0",
         "react": "^19.2.5",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,9 @@
     "markdownlint-cli2": "^0.22.0",
     "sharp": "^0.34.5",
     "typescript": "^6.0.2"
+  },
+  "dependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "js-yaml": "^4.1.1"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
     "@frozenink/crawlers": "workspace:*",
     "@frozenink/mcp": "workspace:*",
     "commander": "^13.0.0",
+    "js-yaml": "^4.1.0",
     "drizzle-orm": "^0.39.0",
     "ink": "^7.0.0",
     "react": "^19.2.5"

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 });
 
 describe("CLI: init", () => {
-  it("creates directory structure with config.json and context.yml", async () => {
+  it("creates directory structure with frozenink.yml and collections/", async () => {
     const { initCommand } = await import("../commands/init");
 
     const logs: string[] = [];
@@ -35,18 +35,18 @@ describe("CLI: init", () => {
 
     console.log = origLog;
 
-    expect(existsSync(join(TEST_DIR, "config.json"))).toBe(true);
-    const config = JSON.parse(readFileSync(join(TEST_DIR, "config.json"), "utf-8"));
-    expect(config.db.mode).toBe("local");
+    expect(existsSync(join(TEST_DIR, "frozenink.yml"))).toBe(true);
+    const yaml = require("js-yaml");
+    const config = yaml.load(readFileSync(join(TEST_DIR, "frozenink.yml"), "utf-8"));
     expect(config.sync.interval).toBe(900);
+    expect(config.ui.port).toBe(3000);
 
-    expect(existsSync(join(TEST_DIR, "context.yml"))).toBe(true);
     expect(existsSync(join(TEST_DIR, "collections"))).toBe(true);
     expect(listCollections()).toHaveLength(0);
-    expect(logs.some((l) => l.includes("Initialized Frozen Ink"))).toBe(true);
+    expect(logs.some((l) => l.includes("initialized"))).toBe(true);
   });
 
-  it("skips if already initialized", async () => {
+  it("is idempotent — can be run multiple times", async () => {
     const { initCommand: initCmd1 } = await import("../commands/init");
 
     const logs: string[] = [];
@@ -60,7 +60,8 @@ describe("CLI: init", () => {
 
     console.log = origLog;
 
-    expect(logs.some((l) => l.includes("already initialized"))).toBe(true);
+    // Both calls should succeed
+    expect(logs.filter((l) => l.includes("initialized"))).toHaveLength(2);
   });
 });
 
@@ -72,7 +73,7 @@ describe("CLI: add", () => {
     await initCommand.parseAsync([], { from: "user" });
 
     const collectionDir = join(TEST_DIR, "collections", "test-gh");
-    const dbPath = join(collectionDir, "data.db");
+    const dbPath = join(collectionDir, "db", "data.db");
     mkdirSync(collectionDir, { recursive: true });
     mkdirSync(join(collectionDir, "markdown"), { recursive: true });
     getCollectionDb(dbPath);
@@ -149,7 +150,7 @@ describe("CLI: collections", () => {
     await initCommand.parseAsync([], { from: "user" });
 
     const collectionDir = join(TEST_DIR, "collections", "to-remove");
-    const dbPath = join(collectionDir, "data.db");
+    const dbPath = join(collectionDir, "db", "data.db");
     mkdirSync(collectionDir, { recursive: true });
     getCollectionDb(dbPath);
     addCollection("to-remove", { crawler: "github", config: {}, credentials: {} });
@@ -173,7 +174,7 @@ describe("CLI: status", () => {
     await initCommand.parseAsync([], { from: "user" });
 
     const collectionDir = join(TEST_DIR, "collections", "status-test");
-    const dbPath = join(collectionDir, "data.db");
+    const dbPath = join(collectionDir, "db", "data.db");
     mkdirSync(collectionDir, { recursive: true });
     const colDb = getCollectionDb(dbPath);
 
@@ -207,7 +208,7 @@ describe("CLI: search", () => {
     await initCommand.parseAsync([], { from: "user" });
 
     const collectionDir = join(TEST_DIR, "collections", "search-test");
-    const dbPath = join(collectionDir, "data.db");
+    const dbPath = join(collectionDir, "db", "data.db");
     mkdirSync(collectionDir, { recursive: true });
     const colDb = getCollectionDb(dbPath);
 
@@ -239,7 +240,7 @@ describe("CLI: search", () => {
     await initCommand.parseAsync([], { from: "user" });
 
     const collectionDir = join(TEST_DIR, "collections", "json-test");
-    const dbPath = join(collectionDir, "data.db");
+    const dbPath = join(collectionDir, "db", "data.db");
     mkdirSync(collectionDir, { recursive: true });
     getCollectionDb(dbPath);
 
@@ -283,7 +284,7 @@ describe("CLI: config", () => {
     expect(logs).toContain("900");
   });
 
-  it("set updates config.json", async () => {
+  it("set updates frozenink.yml", async () => {
     const { initCommand } = await import("../commands/init");
     const origLog = console.log;
     console.log = () => {};
@@ -293,7 +294,8 @@ describe("CLI: config", () => {
     const { configCommand: cc1 } = await import("../commands/config");
     await cc1.parseAsync(["set", "sync.interval", "1800"], { from: "user" });
 
-    const config = JSON.parse(readFileSync(join(TEST_DIR, "config.json"), "utf-8"));
+    const yamlLib = require("js-yaml");
+    const config = yamlLib.load(readFileSync(join(TEST_DIR, "frozenink.yml"), "utf-8"));
     expect(config.sync.interval).toBe(1800);
 
     const logs: string[] = [];
@@ -323,9 +325,8 @@ describe("CLI: config", () => {
     console.log = origLog;
 
     const parsed = JSON.parse(logs.join("\n"));
-    expect(parsed.db.mode).toBe("local");
     expect(parsed.sync.interval).toBe(900);
-    expect(parsed.logging.level).toBe("info");
+    expect(parsed.ui.port).toBe(3000);
   });
 });
 
@@ -338,7 +339,7 @@ describe("CLI: sync triggers crawler", () => {
     await initCommand.parseAsync([], { from: "user" });
 
     const collectionDir = join(TEST_DIR, "collections", "sync-test");
-    const dbPath = join(collectionDir, "data.db");
+    const dbPath = join(collectionDir, "db", "data.db");
     mkdirSync(collectionDir, { recursive: true });
     mkdirSync(join(collectionDir, "markdown"), { recursive: true });
     getCollectionDb(dbPath);

--- a/packages/cli/src/__tests__/daemon-serve.test.ts
+++ b/packages/cli/src/__tests__/daemon-serve.test.ts
@@ -10,11 +10,11 @@ import { join } from "path";
 import {
   getCollectionDb,
   entities,
+  tags,
   entityTags,
-  attachments,
+  assets,
   SearchIndexer,
   addCollection,
-  saveContext,
 } from "@frozenink/core";
 
 const TEST_DIR = join(import.meta.dir, ".test-daemon-serve");
@@ -31,18 +31,11 @@ afterEach(() => {
 
 function initTestEnv() {
   writeFileSync(
-    join(TEST_DIR, "config.json"),
-    JSON.stringify({
-      db: { mode: "local" },
-      sync: { interval: 900, concurrency: 2, retries: 3 },
-      ui: { port: 3000 },
-      mcp: { transport: "stdio", port: 3001 },
-      logging: { level: "info" },
-    }),
+    join(TEST_DIR, "frozenink.yml"),
+    "sync:\n  interval: 900\nui:\n  port: 3000\n",
   );
 
-  // Create context.yml (required by contextExists() checks in daemon/serve commands)
-  saveContext({ collections: {}, deployments: {} });
+  // Create collections directory (required by contextExists() checks)
   mkdirSync(join(TEST_DIR, "collections"), { recursive: true });
 }
 
@@ -51,7 +44,7 @@ function addTestCollection(
   opts?: { addEntities?: boolean; addAttachment?: boolean; addFts?: boolean },
 ) {
   const collectionDir = join(TEST_DIR, "collections", name);
-  const dbPath = join(collectionDir, "data.db");
+  const dbPath = join(collectionDir, "db", "data.db");
   mkdirSync(collectionDir, { recursive: true });
   mkdirSync(join(collectionDir, "markdown"), { recursive: true });
 
@@ -89,8 +82,13 @@ function addTestCollection(
       .run();
 
     const entityRows = colDb.select().from(entities).all();
-    colDb.insert(entityTags).values({ entityId: entityRows[0].id, tag: "bug" }).run();
-    colDb.insert(entityTags).values({ entityId: entityRows[0].id, tag: "critical" }).run();
+    colDb.insert(tags).values({ name: "bug" }).run();
+    colDb.insert(tags).values({ name: "critical" }).run();
+    const allTags = colDb.select().from(tags).all();
+    const bugTag = allTags.find((t) => t.name === "bug")!;
+    const criticalTag = allTags.find((t) => t.name === "critical")!;
+    colDb.insert(entityTags).values({ entityId: entityRows[0].id, tagId: bugTag.id }).run();
+    colDb.insert(entityTags).values({ entityId: entityRows[0].id, tagId: criticalTag.id }).run();
 
     mkdirSync(join(collectionDir, "markdown", "issues"), { recursive: true });
     mkdirSync(join(collectionDir, "markdown", "pull-requests"), { recursive: true });
@@ -105,13 +103,12 @@ function addTestCollection(
     if (opts.addEntities) {
       const entityRows = colDb.select().from(entities).all();
       colDb
-        .insert(attachments)
+        .insert(assets)
         .values({
           entityId: entityRows[0].id,
           filename: "screenshot.png",
           mimeType: "image/png",
           storagePath: "attachments/issue-1/screenshot.png",
-          backend: "local",
         })
         .run();
     }

--- a/packages/cli/src/__tests__/management-api-publish.test.ts
+++ b/packages/cli/src/__tests__/management-api-publish.test.ts
@@ -37,6 +37,8 @@ beforeEach(async () => {
     removeCollection: () => {},
     updateCollection: () => {},
     renameCollection: () => {},
+    listSites: () => [],
+    removeSite: () => {},
     listDeployments: () => [],
     removeDeployment: () => {},
     loadConfig: () => ({}),
@@ -45,6 +47,20 @@ beforeEach(async () => {
     LocalStorageBackend: class {},
     syncRuns: {},
     entities: {},
+    tags: {},
+    entityTags: {},
+    assets: {},
+    links: {},
+    SearchIndexer: class { updateIndex() {} clearIndex() {} close() {} removeIndex() {} },
+    isValidCollectionKey: () => true,
+    contextExists: () => true,
+    migrateFromLegacyContext: () => {},
+    getSite: () => null,
+    addSite: () => {},
+    getDeployment: () => null,
+    addDeployment: () => {},
+    configSchema: { parse: (x: any) => x },
+    defaultConfig: {},
   }));
 
   mock.module("@frozenink/crawlers", () => ({
@@ -55,9 +71,14 @@ beforeEach(async () => {
     mantisBTTheme: {},
   }));
 
+  mock.module("js-yaml", () => ({
+    default: { load: () => ({}), dump: () => "" },
+  }));
+
   mock.module("drizzle-orm", () => ({
     desc: () => ({}),
     eq: () => ({}),
+    sql: () => ({}),
   }));
 
   const mod = await import("../commands/management-api");

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -5,7 +5,7 @@ import {
   getFrozenInkHome,
   getCollectionDb,
   isValidCollectionKey,
-  contextExists,
+  ensureInitialized,
   getCollection,
   addCollection,
   getCollectionDbPath,
@@ -27,11 +27,9 @@ export const addCommand = new Command("add")
   .option("--max-issues <count>", "Maximum issues to sync (for github)", parseInt)
   .option("--max-prs <count>", "Maximum pull requests to sync (for github)", parseInt)
   .option("--open-only", "Only sync open issues/PRs, delete closed ones (for github)")
+  .option("--sync-entities <types>", "Comma-separated entity types to sync: issues,pages,users (for mantisbt)")
   .action(async (crawlerType: string, opts: Record<string, string>) => {
-    if (!contextExists()) {
-      console.error("Frozen Ink not initialized. Run: fink init");
-      process.exit(1);
-    }
+    ensureInitialized();
 
     if (!isValidCollectionKey(opts.name)) {
       console.error(
@@ -73,8 +71,6 @@ export const addCommand = new Command("add")
       }
       const [ghOwner, ghRepo] = repoParts;
       credentials.token = opts.token;
-      credentials.owner = ghOwner;
-      credentials.repo = ghRepo;
       config.owner = ghOwner;
       config.repo = ghRepo;
       if (opts.openOnly) {
@@ -105,14 +101,25 @@ export const addCommand = new Command("add")
         console.error("MantisBT crawler requires --url <base-url>");
         process.exit(1);
       }
-      config.baseUrl = opts.url;
+      config.url = opts.url;
       credentials.token = opts.token ?? "";
-      credentials.baseUrl = opts.url;
+      credentials.url = opts.url;
       if (opts.projectName) {
-        config.projectName = opts.projectName;
+        config.project = { name: opts.projectName };
       }
       if (opts.max) {
         config.maxEntities = opts.max;
+      }
+      if (opts.syncEntities) {
+        const isMantisHub = opts.url.includes(".mantishub.");
+        const valid = isMantisHub ? ["issues", "pages", "users"] : ["issues", "users"];
+        const entityTypes = (opts.syncEntities as string).split(",").map((s: string) => s.trim()).filter(Boolean);
+        const invalid = entityTypes.filter((e: string) => !valid.includes(e));
+        if (invalid.length) {
+          console.error(`Invalid entity type(s): ${invalid.join(", ")}. Valid: ${valid.join(", ")}`);
+          process.exit(1);
+        }
+        config.entities = entityTypes;
       }
     } else if (crawlerType === "git") {
       if (!opts.path) {
@@ -140,12 +147,12 @@ export const addCommand = new Command("add")
     }
 
     // Resolve MantisBT project name → ID and persist both
-    if (crawlerType === "mantisbt" && config.projectName) {
+    const project = config.project as { id?: number; name?: string } | undefined;
+    if (crawlerType === "mantisbt" && project?.name) {
       try {
         await crawler.initialize(config, credentials);
-        const resolved = await (crawler as MantisBTCrawler).resolveProjectName(config.projectName as string);
-        config.projectId = resolved.id;
-        config.projectName = resolved.name; // canonical casing from server
+        const resolved = await (crawler as MantisBTCrawler).resolveProjectName(project.name);
+        config.project = { id: resolved.id, name: resolved.name };
         console.log(`  Resolved project "${resolved.name}" → ID ${resolved.id}`);
       } catch (err) {
         console.error(`Failed to resolve project name: ${err instanceof Error ? err.message : err}`);
@@ -161,9 +168,15 @@ export const addCommand = new Command("add")
     getCollectionDb(collectionDbPath);
 
     // Create markdown output directory
-    mkdirSync(join(collectionDir, "markdown"), { recursive: true });
+    mkdirSync(join(collectionDir, "content"), { recursive: true });
 
-    // Save to context.yml
+    // For MantisBT, don't store url in credentials (it's already in config)
+    if (crawlerType === "mantisbt") {
+      delete credentials.url;
+      delete credentials.baseUrl;
+    }
+
+    // Save collection config
     addCollection(opts.name, {
       title: opts.title || undefined,
       crawler: crawlerType,

--- a/packages/cli/src/commands/collections.ts
+++ b/packages/cli/src/commands/collections.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import {
   getFrozenInkHome,
   isValidCollectionKey,
-  contextExists,
+  ensureInitialized,
   listCollections,
   getCollection,
   removeCollection,
@@ -14,10 +14,7 @@ import {
 } from "@frozenink/core";
 
 function requireInit(): void {
-  if (!contextExists()) {
-    console.error("Frozen Ink not initialized. Run: fink init");
-    process.exit(1);
-  }
+  ensureInitialized();
 }
 
 function displayName(col: { name: string; title?: string }): string {

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,10 +1,11 @@
 import { Command } from "commander";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { getFrozenInkHome, loadConfig } from "@frozenink/core";
+import yaml from "js-yaml";
+import { getFrozenInkHome, ensureInitialized, loadConfig } from "@frozenink/core";
 
 function getConfigPath(): string {
-  return join(getFrozenInkHome(), "config.json");
+  return join(getFrozenInkHome(), "frozenink.yml");
 }
 
 function readConfigFile(): Record<string, unknown> {
@@ -12,14 +13,11 @@ function readConfigFile(): Record<string, unknown> {
   if (!existsSync(configPath)) {
     return {};
   }
-  return JSON.parse(readFileSync(configPath, "utf-8")) as Record<
-    string,
-    unknown
-  >;
+  return (yaml.load(readFileSync(configPath, "utf-8")) as Record<string, unknown>) ?? {};
 }
 
 function writeConfigFile(config: Record<string, unknown>): void {
-  writeFileSync(getConfigPath(), JSON.stringify(config, null, 2));
+  writeFileSync(getConfigPath(), yaml.dump(config, { lineWidth: -1, noRefs: true, sortKeys: false }));
 }
 
 function getNestedValue(
@@ -84,12 +82,7 @@ const setCommand = new Command("set")
   .argument("<key>", "Config key (e.g., sync.interval)")
   .argument("<value>", "Config value")
   .action((key: string, value: string) => {
-    const configPath = getConfigPath();
-    if (!existsSync(configPath)) {
-      console.error("Frozen Ink not initialized. Run: fink init");
-      process.exit(1);
-    }
-
+    ensureInitialized();
     const fileConfig = readConfigFile();
     setNestedValue(fileConfig, key, parseValue(value));
     writeConfigFile(fileConfig);

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { fileURLToPath } from "url";
 import {
   getFrozenInkHome,
-  contextExists,
+  ensureInitialized,
   listCollections,
   getCollectionDbPath,
   loadConfig,
@@ -32,7 +32,7 @@ async function runSyncLoop(intervalMs: number): Promise<void> {
   const home = getFrozenInkHome();
 
   const doSync = async () => {
-    if (!contextExists()) return;
+    ensureInitialized();
 
     const collectionRows = listCollections().filter((c) => c.enabled);
 
@@ -64,7 +64,8 @@ async function runSyncLoop(intervalMs: number): Promise<void> {
           collectionName: col.name,
           themeEngine,
           storage,
-          markdownBasePath: "markdown",
+          markdownBasePath: "content",
+          assetConfig: col.assets as { extensions?: string[]; maxSize?: number } | undefined,
         });
 
         await engine.run();
@@ -86,10 +87,7 @@ async function runSyncLoop(intervalMs: number): Promise<void> {
 const startCommand = new Command("start")
   .description("Start the sync daemon in the background")
   .action(async () => {
-    if (!contextExists()) {
-      console.error("Frozen Ink not initialized. Run: fink init");
-      process.exit(1);
-    }
+    ensureInitialized();
 
     const home = getFrozenInkHome();
     const pidPath = getPidPath();

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -4,13 +4,14 @@ import { join } from "path";
 import {
   getFrozenInkHome,
   getCollectionDb,
-  contextExists,
+  ensureInitialized,
   listCollections,
   getCollection,
   getCollectionDbPath,
   entities,
   entityTags,
-  entityLinks,
+  tags,
+  links,
   ThemeEngine,
   LocalStorageBackend,
   SearchIndexer,
@@ -25,10 +26,7 @@ export const generateCommand = new Command("generate")
   )
   .argument("<collection>", 'Collection name or "*" for all collections')
   .action(async (collection: string) => {
-    if (!contextExists()) {
-      console.error("Frozen Ink not initialized. Run: fink init");
-      process.exit(1);
-    }
+    ensureInitialized();
 
     const home = getFrozenInkHome();
     let collectionRows = collection === "*"
@@ -92,19 +90,23 @@ export const generateCommand = new Command("generate")
 
       const indexer = new SearchIndexer(dbPath);
       indexer.clearIndex();
-      colDb.delete(entityLinks).run();
+      colDb.delete(links).run();
 
       const allEntities = colDb.select().from(entities).all();
       let generated = 0;
       let renamed = 0;
 
       for (const entity of allEntities) {
-        const tags = colDb
+        const entityTagNames = colDb
           .select()
           .from(entityTags)
           .where(eq(entityTags.entityId, entity.id))
           .all()
-          .map((t: any) => t.tag);
+          .map((t: any) => {
+            const [tagRow] = colDb.select().from(tags).where(eq(tags.id, t.tagId)).all();
+            return tagRow?.name ?? "";
+          })
+          .filter(Boolean);
 
         const renderCtx = {
           entity: {
@@ -113,7 +115,7 @@ export const generateCommand = new Command("generate")
             title: entity.title,
             data: entity.data as Record<string, unknown>,
             url: entity.url ?? undefined,
-            tags,
+            tags: entityTagNames,
           },
           collectionName: col.name,
           crawlerType: col.crawler,
@@ -155,20 +157,27 @@ export const generateCommand = new Command("generate")
           entityType: entity.entityType,
           title: entity.title,
           content: markdown,
-          tags,
+          tags: entityTagNames,
         });
 
         // Rebuild entity links
         const targets = extractWikilinks(markdown);
         for (const target of targets) {
-          colDb
-            .insert(entityLinks)
-            .values({
-              sourceEntityId: entity.id,
-              sourceMarkdownPath: newPath,
-              targetPath: `${markdownBasePath}/${target}.md`,
-            })
-            .run();
+          const targetPath = `${markdownBasePath}/${target}.md`;
+          const [targetEntity] = colDb
+            .select({ id: entities.id })
+            .from(entities)
+            .where(eq(entities.markdownPath, targetPath))
+            .all();
+          if (targetEntity) {
+            colDb
+              .insert(links)
+              .values({
+                sourceEntityId: entity.id,
+                targetEntityId: targetEntity.id,
+              })
+              .run();
+          }
         }
 
         generated++;

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -4,13 +4,14 @@ import { join } from "path";
 import {
   getFrozenInkHome,
   getCollectionDb,
-  contextExists,
+  ensureInitialized,
   listCollections,
   getCollection,
   getCollectionDbPath,
   entities,
   entityTags,
-  entityLinks,
+  tags,
+  links,
   SearchIndexer,
   extractWikilinks,
 } from "@frozenink/core";
@@ -22,10 +23,7 @@ export const indexCommand = new Command("index")
   )
   .argument("<collection>", 'Collection name or "*" for all collections')
   .action(async (collection: string) => {
-    if (!contextExists()) {
-      console.error("Frozen Ink not initialized. Run: fink init");
-      process.exit(1);
-    }
+    ensureInitialized();
 
     const home = getFrozenInkHome();
     let collectionRows = collection === "*"
@@ -62,7 +60,7 @@ export const indexCommand = new Command("index")
       // Clear existing search index and links
       const indexer = new SearchIndexer(dbPath);
       indexer.clearIndex();
-      colDb.delete(entityLinks).run();
+      colDb.delete(links).run();
 
       const allEntities = colDb.select().from(entities).all();
       let indexed = 0;
@@ -77,12 +75,16 @@ export const indexCommand = new Command("index")
         const markdown = readFileSync(filePath, "utf-8");
 
         // Rebuild FTS index
-        const tags = colDb
+        const entityTagNames = colDb
           .select()
           .from(entityTags)
           .where(eq(entityTags.entityId, entity.id))
           .all()
-          .map((t: any) => t.tag);
+          .map((t: any) => {
+            const [tagRow] = colDb.select().from(tags).where(eq(tags.id, t.tagId)).all();
+            return tagRow?.name ?? "";
+          })
+          .filter(Boolean);
 
         indexer.updateIndex({
           id: entity.id,
@@ -90,22 +92,29 @@ export const indexCommand = new Command("index")
           entityType: entity.entityType,
           title: entity.title,
           content: markdown,
-          tags,
+          tags: entityTagNames,
         });
         indexed++;
 
         // Rebuild links
         const targets = extractWikilinks(markdown);
         for (const target of targets) {
-          colDb
-            .insert(entityLinks)
-            .values({
-              sourceEntityId: entity.id,
-              sourceMarkdownPath: entity.markdownPath,
-              targetPath: `${markdownBasePath}/${target}.md`,
-            })
-            .run();
-          linked++;
+          const targetPath = `${markdownBasePath}/${target}.md`;
+          const [targetEntity] = colDb
+            .select({ id: entities.id })
+            .from(entities)
+            .where(eq(entities.markdownPath, targetPath))
+            .all();
+          if (targetEntity) {
+            colDb
+              .insert(links)
+              .values({
+                sourceEntityId: entity.id,
+                targetEntityId: targetEntity.id,
+              })
+              .run();
+            linked++;
+          }
         }
       }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,35 +1,10 @@
 import { Command } from "commander";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { join } from "path";
-import { getFrozenInkHome, defaultConfig, saveContext } from "@frozenink/core";
+import { getFrozenInkHome, ensureInitialized } from "@frozenink/core";
 
 export const initCommand = new Command("init")
   .description("Initialize Frozen Ink directory and configuration")
   .action(() => {
     const home = getFrozenInkHome();
-
-    if (existsSync(join(home, "context.yml"))) {
-      console.log(`Frozen Ink already initialized at ${home}`);
-      return;
-    }
-
-    // Create home directory
-    mkdirSync(home, { recursive: true });
-
-    // Create config.json with defaults
-    writeFileSync(
-      join(home, "config.json"),
-      JSON.stringify(defaultConfig, null, 2),
-    );
-
-    // Create context.yml with empty collections
-    saveContext({ collections: {}, deployments: {} });
-
-    // Create collections directory
-    mkdirSync(join(home, "collections"), { recursive: true });
-
-    console.log(`Initialized Frozen Ink at ${home}`);
-    console.log(`  config.json  - configuration`);
-    console.log(`  context.yml  - collection registry`);
-    console.log(`  collections/ - collection data`);
+    ensureInitialized();
+    console.log(`Frozen Ink initialized at ${home}`);
   });

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -5,6 +5,7 @@
  */
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
+import yaml from "js-yaml";
 import {
   getFrozenInkHome,
   getCollectionDb,
@@ -15,8 +16,8 @@ import {
   removeCollection,
   updateCollection,
   renameCollection,
-  listDeployments,
-  removeDeployment,
+  listSites,
+  removeSite,
   loadConfig,
   SyncEngine,
   ThemeEngine,
@@ -311,11 +312,11 @@ export function handleManagementRequest(req: Request): Response | null {
     return jsonResponse(runs);
   }
 
-  // --- Deployments ---
+  // --- Sites (deployments) ---
 
   // GET /api/deployments
   if (path === "/api/deployments" && method === "GET") {
-    return jsonResponse(listDeployments());
+    return jsonResponse(listSites());
   }
 
   // DELETE /api/deployments/:name — full Cloudflare teardown
@@ -323,12 +324,12 @@ export function handleManagementRequest(req: Request): Response | null {
   if (deleteDepMatch && method === "DELETE") {
     const name = decodeURIComponent(deleteDepMatch[1]);
     return handleAsync(async () => {
-      const { getDeployment: getDeploymentEntry } = await import("@frozenink/core");
-      const deployment = getDeploymentEntry(name);
-      if (!deployment) return errorResponse("Deployment not found", 404);
+      const { getSite: getSiteEntry } = await import("@frozenink/core");
+      const site = getSiteEntry(name);
+      if (!site) return errorResponse("Site not found", 404);
 
       const { unpublishDeployment } = await import("./unpublish");
-      await unpublishDeployment(deployment, (step, detail) => {
+      await unpublishDeployment(site, (step, detail) => {
         console.log(`  [unpublish:${step}] ${detail}`);
       });
       return jsonResponse({ ok: true });
@@ -386,30 +387,30 @@ export function handleManagementRequest(req: Request): Response | null {
     return handleAsync(async () => {
       const body = await readBody(req);
       const home = getFrozenInkHome();
-      const configPath = join(home, "config.json");
+      const configPath = join(home, "frozenink.yml");
 
       let existing: Record<string, unknown> = {};
       if (existsSync(configPath)) {
-        existing = JSON.parse(readFileSync(configPath, "utf-8"));
+        existing = (yaml.load(readFileSync(configPath, "utf-8")) as Record<string, unknown>) ?? {};
       }
 
       const merged = { ...existing, ...body };
-      writeFileSync(configPath, JSON.stringify(merged, null, 2), "utf-8");
+      writeFileSync(configPath, yaml.dump(merged, { lineWidth: -1, noRefs: true, sortKeys: false }), "utf-8");
       return jsonResponse({ ok: true });
     });
   }
 
-  // --- UI Preferences (stored in config.json so they survive port changes) ---
+  // --- UI Preferences (stored in frozenink.yml so they survive port changes) ---
 
   // GET /api/preferences
   if (path === "/api/preferences" && method === "GET") {
     const home = getFrozenInkHome();
-    const configPath = join(home, "config.json");
+    const configPath = join(home, "frozenink.yml");
     let prefs: Record<string, unknown> = {};
     if (existsSync(configPath)) {
       try {
-        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-        prefs = raw.ui_preferences ?? {};
+        const raw = (yaml.load(readFileSync(configPath, "utf-8")) as Record<string, unknown>) ?? {};
+        prefs = (raw.ui_preferences as Record<string, unknown>) ?? {};
       } catch {}
     }
     return jsonResponse(prefs);
@@ -420,14 +421,14 @@ export function handleManagementRequest(req: Request): Response | null {
     return handleAsync(async () => {
       const body = await readBody(req);
       const home = getFrozenInkHome();
-      const configPath = join(home, "config.json");
+      const configPath = join(home, "frozenink.yml");
 
       let existing: Record<string, unknown> = {};
       if (existsSync(configPath)) {
-        try { existing = JSON.parse(readFileSync(configPath, "utf-8")); } catch {}
+        try { existing = (yaml.load(readFileSync(configPath, "utf-8")) as Record<string, unknown>) ?? {}; } catch {}
       }
       existing.ui_preferences = { ...((existing.ui_preferences as Record<string, unknown>) ?? {}), ...body };
-      writeFileSync(configPath, JSON.stringify(existing, null, 2), "utf-8");
+      writeFileSync(configPath, yaml.dump(existing, { lineWidth: -1, noRefs: true, sortKeys: false }), "utf-8");
       return jsonResponse({ ok: true });
     });
   }
@@ -437,12 +438,12 @@ export function handleManagementRequest(req: Request): Response | null {
   // GET /api/publish-presets
   if (path === "/api/publish-presets" && method === "GET") {
     const home = getFrozenInkHome();
-    const configPath = join(home, "config.json");
+    const configPath = join(home, "frozenink.yml");
     let presets: unknown[] = [];
     if (existsSync(configPath)) {
       try {
-        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-        presets = raw.publish_presets ?? [];
+        const raw = (yaml.load(readFileSync(configPath, "utf-8")) as Record<string, unknown>) ?? {};
+        presets = (raw.publish_presets as unknown[]) ?? [];
       } catch {}
     }
     return jsonResponse(presets);
@@ -454,14 +455,14 @@ export function handleManagementRequest(req: Request): Response | null {
       const body = await readBody(req);
       const presets = body.presets as unknown[];
       const home = getFrozenInkHome();
-      const configPath = join(home, "config.json");
+      const configPath = join(home, "frozenink.yml");
 
       let existing: Record<string, unknown> = {};
       if (existsSync(configPath)) {
-        try { existing = JSON.parse(readFileSync(configPath, "utf-8")); } catch {}
+        try { existing = (yaml.load(readFileSync(configPath, "utf-8")) as Record<string, unknown>) ?? {}; } catch {}
       }
       existing.publish_presets = presets;
-      writeFileSync(configPath, JSON.stringify(existing, null, 2), "utf-8");
+      writeFileSync(configPath, yaml.dump(existing, { lineWidth: -1, noRefs: true, sortKeys: false }), "utf-8");
       return jsonResponse({ ok: true });
     });
   }
@@ -569,7 +570,8 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
           collectionName: name,
           themeEngine,
           storage,
-          markdownBasePath: "markdown",
+          markdownBasePath: "content",
+          assetConfig: col.assets as { extensions?: string[]; maxSize?: number } | undefined,
           onEntityProcessed: (info) => {
             if (info.created) totalCreated++;
             if (info.updated) totalUpdated++;

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -5,15 +5,16 @@ import { createInterface } from "readline";
 import {
   getFrozenInkHome,
   getCollectionDb,
-  contextExists,
+  ensureInitialized,
   getCollection,
   getCollectionDbPath,
-  addDeployment,
-  getDeployment,
+  addSite,
+  getSite,
   entities,
   entityTags,
-  entityLinks,
-  attachments,
+  tags,
+  links,
+  assets,
   getModuleDir,
   resolveWorkerBundle,
   resolveUiDist,
@@ -135,15 +136,15 @@ export async function publishCollections(
   }
   let collectionNames = [...options.collectionNames];
 
-  const existingDeployment = getDeployment(workerName);
-  const isUpdate = !!existingDeployment;
+  const existingSite = getSite(workerName);
+  const isUpdate = !!existingSite;
 
-  if (workerOnly && !existingDeployment) {
-    throw new Error(`Deployment "${workerName}" not found. --worker-only only works for existing deployments.`);
+  if (workerOnly && !existingSite) {
+    throw new Error(`Site "${workerName}" not found. --worker-only only works for existing sites.`);
   }
 
-  if (workerOnly && existingDeployment) {
-    collectionNames = existingDeployment.collections;
+  if (workerOnly && existingSite) {
+    collectionNames = existingSite.collections;
   }
 
   const home = getFrozenInkHome();
@@ -162,10 +163,10 @@ export async function publishCollections(
   let d1DatabaseId: string;
   let r2BucketName: string;
   if (workerOnly) {
-    const deployment = existingDeployment!;
-    d1DatabaseName = deployment.d1DatabaseName || `${workerName}-db`;
-    d1DatabaseId = deployment.d1DatabaseId;
-    r2BucketName = deployment.r2BucketName;
+    const site = existingSite!;
+    d1DatabaseName = site.database.name || `${workerName}-db`;
+    d1DatabaseId = site.database.id;
+    r2BucketName = site.bucket.name;
   } else {
     d1DatabaseName = `${workerName}-db`;
     d1DatabaseId = "";
@@ -181,11 +182,11 @@ export async function publishCollections(
     passwordHash = await hashPassword(password);
   } else if (removePassword) {
     passwordHash = "";
-  } else if (existingDeployment?.passwordHash) {
-    passwordHash = existingDeployment.passwordHash;
-  } else if (isUpdate && existingDeployment?.passwordProtected) {
+  } else if (existingSite?.password?.hash) {
+    passwordHash = existingSite.password.hash;
+  } else if (isUpdate && existingSite?.password?.protected) {
     throw new Error(
-      `Deployment "${workerName}" is password protected but no reusable password hash is stored locally. ` +
+      `Site "${workerName}" is password protected but no reusable password hash is stored locally. ` +
       "Re-publish with --password <new-password> to rotate credentials or --remove-password to disable protection.",
     );
   }
@@ -237,7 +238,7 @@ export async function publishCollections(
     try {
       onProgress("r2-manifest", "Reading existing R2 manifest...");
       const manifestJson = await executeD1Command(
-        existingDeployment!.d1DatabaseName || d1DatabaseName,
+        existingSite!.database.name || d1DatabaseName,
         "SELECT key FROM r2_manifest",
       );
       const parsed = JSON.parse(manifestJson);
@@ -256,9 +257,10 @@ export async function publishCollections(
 
     schemaSql.push("DROP TABLE IF EXISTS entities_fts;");
     schemaSql.push("DROP TABLE IF EXISTS r2_manifest;");
-    schemaSql.push("DROP TABLE IF EXISTS entity_links;");
+    schemaSql.push("DROP TABLE IF EXISTS links;");
     schemaSql.push("DROP TABLE IF EXISTS entity_tags;");
-    schemaSql.push("DROP TABLE IF EXISTS attachments;");
+    schemaSql.push("DROP TABLE IF EXISTS tags;");
+    schemaSql.push("DROP TABLE IF EXISTS assets;");
     schemaSql.push("DROP TABLE IF EXISTS entities;");
     schemaSql.push("DROP TABLE IF EXISTS collections_meta;");
     schemaSql.push("");
@@ -271,18 +273,19 @@ export async function publishCollections(
 );`);
     schemaSql.push("CREATE INDEX idx_entities_collection ON entities(collection_name);");
     schemaSql.push("CREATE INDEX idx_entities_external ON entities(collection_name, external_id);");
+    schemaSql.push("CREATE TABLE tags (id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE);");
     schemaSql.push(`CREATE TABLE entity_tags (
   id INTEGER PRIMARY KEY, collection_name TEXT NOT NULL,
-  entity_id INTEGER NOT NULL, tag TEXT NOT NULL
+  entity_id INTEGER NOT NULL, tag_id INTEGER NOT NULL
 );`);
-    schemaSql.push(`CREATE TABLE entity_links (
+    schemaSql.push(`CREATE TABLE links (
   id INTEGER PRIMARY KEY, collection_name TEXT NOT NULL,
   source_entity_id INTEGER NOT NULL,
-  source_markdown_path TEXT NOT NULL, target_path TEXT NOT NULL
+  target_entity_id INTEGER NOT NULL
 );`);
-    schemaSql.push("CREATE INDEX idx_links_target ON entity_links(target_path);");
-    schemaSql.push("CREATE INDEX idx_links_source ON entity_links(source_markdown_path);");
-    schemaSql.push(`CREATE TABLE attachments (
+    schemaSql.push("CREATE INDEX idx_links_target ON links(target_entity_id);");
+    schemaSql.push("CREATE INDEX idx_links_source ON links(source_entity_id);");
+    schemaSql.push(`CREATE TABLE assets (
   id INTEGER PRIMARY KEY, collection_name TEXT NOT NULL,
   entity_id INTEGER NOT NULL, filename TEXT NOT NULL,
   mime_type TEXT NOT NULL, storage_path TEXT NOT NULL
@@ -313,22 +316,41 @@ export async function publishCollections(
         schemaSql.push(`INSERT INTO entities (id, collection_name, external_id, entity_type, title, data, markdown_path, url, created_at, updated_at) VALUES (${entityIdOffset}, '${escapeSQL(colName)}', '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(data)}', ${entity.markdownPath ? `'${escapeSQL(entity.markdownPath)}'` : "NULL"}, ${entity.url ? `'${escapeSQL(entity.url)}'` : "NULL"}, ${entity.createdAt ? `'${escapeSQL(entity.createdAt)}'` : "NULL"}, ${entity.updatedAt ? `'${escapeSQL(entity.updatedAt)}'` : "NULL"});`);
       }
 
-      for (const tag of colDb.select().from(entityTags).all()) {
-        const remoteId = entityIdMap.get(tag.entityId);
+      // Export tags and entity_tags — resolve tagId to tag name via tags table
+      const tagNameCache: Record<number, string> = {};
+      const remoteTagNameToId: Record<string, number> = {};
+      let remoteTagIdCounter = 0;
+      for (const et of colDb.select().from(entityTags).all()) {
+        const remoteId = entityIdMap.get(et.entityId);
         if (!remoteId) continue;
-        schemaSql.push(`INSERT INTO entity_tags (collection_name, entity_id, tag) VALUES ('${escapeSQL(colName)}', ${remoteId}, '${escapeSQL(tag.tag)}');`);
+        // Resolve tag name from local tags table
+        let tagName = tagNameCache[et.tagId];
+        if (!tagName) {
+          const [tagRow] = colDb.select().from(tags).where(eq(tags.id, et.tagId)).all();
+          tagName = tagRow?.name ?? `tag_${et.tagId}`;
+          tagNameCache[et.tagId] = tagName;
+        }
+        // Insert into remote tags table if not already done
+        if (!remoteTagNameToId[tagName]) {
+          remoteTagIdCounter++;
+          remoteTagNameToId[tagName] = remoteTagIdCounter;
+          schemaSql.push(`INSERT INTO tags (id, name) VALUES (${remoteTagIdCounter}, '${escapeSQL(tagName)}');`);
+        }
+        const remoteTagId = remoteTagNameToId[tagName];
+        schemaSql.push(`INSERT INTO entity_tags (collection_name, entity_id, tag_id) VALUES ('${escapeSQL(colName)}', ${remoteId}, ${remoteTagId});`);
       }
 
-      for (const link of colDb.select().from(entityLinks).all()) {
-        const remoteId = entityIdMap.get(link.sourceEntityId);
-        if (!remoteId) continue;
-        schemaSql.push(`INSERT INTO entity_links (collection_name, source_entity_id, source_markdown_path, target_path) VALUES ('${escapeSQL(colName)}', ${remoteId}, '${escapeSQL(link.sourceMarkdownPath)}', '${escapeSQL(link.targetPath)}');`);
+      for (const link of colDb.select().from(links).all()) {
+        const remoteSourceId = entityIdMap.get(link.sourceEntityId);
+        const remoteTargetId = entityIdMap.get(link.targetEntityId);
+        if (!remoteSourceId || !remoteTargetId) continue;
+        schemaSql.push(`INSERT INTO links (collection_name, source_entity_id, target_entity_id) VALUES ('${escapeSQL(colName)}', ${remoteSourceId}, ${remoteTargetId});`);
       }
 
-      for (const att of colDb.select().from(attachments).all()) {
+      for (const att of colDb.select().from(assets).all()) {
         const remoteId = entityIdMap.get(att.entityId);
         if (!remoteId) continue;
-        schemaSql.push(`INSERT INTO attachments (collection_name, entity_id, filename, mime_type, storage_path) VALUES ('${escapeSQL(colName)}', ${remoteId}, '${escapeSQL(att.filename)}', '${escapeSQL(att.mimeType)}', '${escapeSQL(att.storagePath)}');`);
+        schemaSql.push(`INSERT INTO assets (collection_name, entity_id, filename, mime_type, storage_path) VALUES ('${escapeSQL(colName)}', ${remoteId}, '${escapeSQL(att.filename)}', '${escapeSQL(att.mimeType)}', '${escapeSQL(att.storagePath)}');`);
       }
 
       onProgress("export", `Exported "${colName}": ${allEntities.length} entities`);
@@ -364,13 +386,17 @@ export async function publishCollections(
         if (content.length > MAX_FTS_CONTENT) {
           content = content.slice(0, MAX_FTS_CONTENT);
         }
-        const tags = colDb.select().from(entityTags)
+        const entityTagNames = colDb.select().from(entityTags)
           .where(eq(entityTags.entityId, entity.id))
           .all()
-          .map((t: any) => t.tag)
+          .map((t: any) => {
+            const [tagRow] = colDb.select().from(tags).where(eq(tags.id, t.tagId)).all();
+            return tagRow?.name ?? "";
+          })
+          .filter(Boolean)
           .join(" ");
 
-        ftsSql.push(`INSERT INTO entities_fts (collection_name, entity_id, external_id, entity_type, title, content, tags) VALUES ('${escapeSQL(colName)}', ${entity.id}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(content)}', '${escapeSQL(tags)}');`);
+        ftsSql.push(`INSERT INTO entities_fts (collection_name, entity_id, external_id, entity_type, title, content, tags) VALUES ('${escapeSQL(colName)}', ${entity.id}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(content)}', '${escapeSQL(entityTagNames)}');`);
       }
     }
 
@@ -407,11 +433,8 @@ export async function publishCollections(
     const uploads: Array<{ r2Key: string; fullPath: string }> = [];
     for (const colName of collectionNames) {
       const collectionDir = join(home, "collections", colName);
-      for (const file of collectFiles(join(collectionDir, "markdown"))) {
-        uploads.push({ r2Key: `${colName}/markdown/${file.relativePath}`, fullPath: file.fullPath });
-      }
-      for (const file of collectFiles(join(collectionDir, "attachments"))) {
-        uploads.push({ r2Key: `${colName}/attachments/${file.relativePath}`, fullPath: file.fullPath });
+      for (const file of collectFiles(join(collectionDir, "content"))) {
+        uploads.push({ r2Key: `${colName}/content/${file.relativePath}`, fullPath: file.fullPath });
       }
     }
     if (existsSync(uiDistDir)) {
@@ -459,16 +482,14 @@ export async function publishCollections(
   const mcpUrl = `${workerUrl}/mcp`;
   const passwordProtected = passwordHash.length > 0;
 
-  // Save deployment
-  addDeployment(workerName, {
+  // Save site
+  addSite(workerName, {
     url: workerUrl,
     mcpUrl,
     collections: collectionNames,
-    d1DatabaseId,
-    d1DatabaseName,
-    r2BucketName,
-    passwordProtected,
-    passwordHash: passwordHash || undefined,
+    database: { type: "cloudflare-d1", id: d1DatabaseId, name: d1DatabaseName },
+    bucket: { type: "cloudflare-r2", name: r2BucketName },
+    password: { protected: passwordProtected, hash: passwordHash || undefined },
     publishedAt: new Date().toISOString(),
   });
 
@@ -495,10 +516,7 @@ export const publishCommand = new Command("publish")
     workerOnly?: boolean;
   }) => {
     try {
-      if (!contextExists()) {
-        console.error("Frozen Ink not initialized. Run: fink init");
-        process.exit(1);
-      }
+      ensureInitialized();
 
       const workerOnly = !!opts.workerOnly;
       const collectionNames = collectionNamesArg ?? [];
@@ -516,8 +534,8 @@ export const publishCommand = new Command("publish")
       let forcePublic = !!opts.public;
 
       if (!forcePublic && !opts.password && !workerOnly) {
-        const existingDeployment = getDeployment(workerName);
-        const isInitialPublish = !existingDeployment;
+        const existingSite = getSite(workerName);
+        const isInitialPublish = !existingSite;
         if (isInitialPublish && process.stdin.isTTY && process.stdout.isTTY) {
           console.warn("\nWARNING: No password was provided.");
           console.warn("This initial publish will make collection data publicly accessible.");

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { existsSync } from "fs";
 import {
-  contextExists,
+  ensureInitialized,
   listCollections,
   getCollection,
   getCollectionDbPath,
@@ -26,10 +26,7 @@ export const searchCommand = new Command("search")
         json?: boolean;
       },
     ) => {
-      if (!contextExists()) {
-        console.error("Frozen Ink not initialized. Run: fink init");
-        process.exit(1);
-      }
+      ensureInitialized();
 
       let collectionRows = opts.collection
         ? (() => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -4,13 +4,15 @@ import { join, extname } from "path";
 import {
   getFrozenInkHome,
   getCollectionDb,
-  contextExists,
+  ensureInitialized,
   listCollections,
   getCollection,
   getCollectionDbPath,
   entities,
   entityTags,
-  entityLinks,
+  tags,
+  links,
+  assets,
   SearchIndexer,
   ThemeEngine,
   loadConfig,
@@ -25,7 +27,7 @@ import {
   mantisBTTheme,
 } from "@frozenink/crawlers";
 import { startStdioServer } from "@frozenink/mcp";
-import { eq, desc, like } from "drizzle-orm";
+import { eq, desc } from "drizzle-orm";
 import { handleManagementRequest, setAppMode } from "./management-api";
 
 const __moduleDir = getModuleDir(import.meta.url);
@@ -267,13 +269,17 @@ export function createApiServer(
 
         if (!entity) return errorResponse("Entity not found", 404);
 
-        // Get tags
-        const tags = colDb
+        // Get tags (join entityTags -> tags)
+        const entityTagNames = colDb
           .select()
           .from(entityTags)
           .where(eq(entityTags.entityId, entity.id))
           .all()
-          .map((t: any) => t.tag);
+          .map((t: any) => {
+            const [tagRow] = colDb.select().from(tags).where(eq(tags.id, t.tagId)).all();
+            return tagRow?.name ?? "";
+          })
+          .filter(Boolean);
 
         const data = typeof entity.data === "string"
           ? JSON.parse(entity.data)
@@ -288,7 +294,7 @@ export function createApiServer(
             .all();
           const mdPath = row?.markdownPath;
           if (!mdPath) return undefined;
-          const prefix = "markdown/";
+          const prefix = "content/";
           const relative = mdPath.startsWith(prefix) ? mdPath.slice(prefix.length) : mdPath;
           return relative.endsWith(".md") ? relative.slice(0, -3) : relative;
         };
@@ -300,7 +306,7 @@ export function createApiServer(
             title: entity.title,
             data,
             url: entity.url ?? undefined,
-            tags,
+            tags: entityTagNames,
           },
           collectionName: name,
           crawlerType: col.crawler,
@@ -355,21 +361,25 @@ export function createApiServer(
           .offset(offset)
           .all();
 
-        // Get tags for each entity
+        // Get tags for each entity (join entityTags -> tags)
         const result = rows.map((row: any) => {
-          const tags = colDb
+          const rowTags = colDb
             .select()
             .from(entityTags)
             .where(eq(entityTags.entityId, row.id))
             .all()
-            .map((t: any) => t.tag);
+            .map((t: any) => {
+              const [tagRow] = colDb.select().from(tags).where(eq(tags.id, t.tagId)).all();
+              return tagRow?.name ?? "";
+            })
+            .filter(Boolean);
           return {
             id: row.id,
             externalId: row.externalId,
             entityType: row.entityType,
             title: row.title,
             url: row.url,
-            tags,
+            tags: rowTags,
             createdAt: row.createdAt,
             updatedAt: row.updatedAt,
           };
@@ -462,18 +472,28 @@ export function createApiServer(
 
         const colDb = getCollectionDb(dbPath);
 
+        // Find the target entity by markdown path variants
         const targetVariants = [targetFile, `markdown/${targetFile}`];
-
         if (!targetFile.endsWith(".md")) {
           targetVariants.push(`${targetFile}.md`, `markdown/${targetFile}.md`);
         }
-
         const filename = targetFile.includes("/") ? targetFile.split("/").pop()! : null;
         if (filename) {
           targetVariants.push(filename, `markdown/${filename}`);
           if (!filename.endsWith(".md")) {
             targetVariants.push(`${filename}.md`, `markdown/${filename}.md`);
           }
+        }
+
+        // Resolve target entity IDs from markdown path variants
+        const targetEntityIds = new Set<number>();
+        for (const variant of targetVariants) {
+          const rows = colDb
+            .select({ id: entities.id })
+            .from(entities)
+            .where(eq(entities.markdownPath, variant))
+            .all();
+          for (const row of rows) targetEntityIds.add(row.id);
         }
 
         const seen = new Set<number>();
@@ -485,11 +505,11 @@ export function createApiServer(
           markdownPath: string | null;
         }> = [];
 
-        for (const variant of targetVariants) {
+        for (const targetEntityId of targetEntityIds) {
           const linkRows = colDb
             .select()
-            .from(entityLinks)
-            .where(eq(entityLinks.targetPath, variant))
+            .from(links)
+            .where(eq(links.targetEntityId, targetEntityId))
             .all();
 
           for (const link of linkRows) {
@@ -538,44 +558,42 @@ export function createApiServer(
 
         const colDb = getCollectionDb(dbPath);
 
+        // Find source entity by markdown path variants
         const sourceVariants = [sourceFile, `markdown/${sourceFile}`];
 
-        const seen = new Set<string>();
+        // Resolve source entity IDs
+        const sourceEntityIds = new Set<number>();
+        for (const variant of sourceVariants) {
+          const rows = colDb
+            .select({ id: entities.id })
+            .from(entities)
+            .where(eq(entities.markdownPath, variant))
+            .all();
+          for (const row of rows) sourceEntityIds.add(row.id);
+        }
+
+        const seen = new Set<number>();
         const results: Array<{
           title: string;
           markdownPath: string | null;
         }> = [];
 
-        for (const variant of sourceVariants) {
+        for (const sourceEntityId of sourceEntityIds) {
           const linkRows = colDb
             .select()
-            .from(entityLinks)
-            .where(eq(entityLinks.sourceMarkdownPath, variant))
+            .from(links)
+            .where(eq(links.sourceEntityId, sourceEntityId))
             .all();
 
           for (const link of linkRows) {
-            if (seen.has(link.targetPath)) continue;
-            seen.add(link.targetPath);
+            if (seen.has(link.targetEntityId)) continue;
+            seen.add(link.targetEntityId);
 
-            let entity = null;
-            const [e1] = colDb
+            const [entity] = colDb
               .select()
               .from(entities)
-              .where(eq(entities.markdownPath, link.targetPath))
+              .where(eq(entities.id, link.targetEntityId))
               .all();
-            if (e1) { entity = e1; }
-
-            if (!entity) {
-              const filename = link.targetPath.split("/").pop();
-              if (filename) {
-                const [e2] = colDb
-                  .select()
-                  .from(entities)
-                  .where(like(entities.markdownPath, `%/${filename}`))
-                  .all();
-                if (e2) { entity = e2; }
-              }
-            }
 
             if (entity) {
               const relPath = entity.markdownPath
@@ -720,10 +738,7 @@ export const serveCommand = new Command("serve")
   .action(async (opts: { mcpOnly?: boolean; uiOnly?: boolean; port?: string }) => {
     const home = getFrozenInkHome();
 
-    if (!contextExists()) {
-      console.error("Frozen Ink not initialized. Run: fink init");
-      process.exit(1);
-    }
+    ensureInitialized();
 
     const config = loadConfig();
     const port = opts.port ? parseInt(opts.port, 10) : config.ui.port;

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { existsSync } from "fs";
 import {
-  contextExists,
+  ensureInitialized,
   listCollections,
   getCollectionDb,
   getCollectionDbPath,
@@ -13,10 +13,7 @@ import { desc } from "drizzle-orm";
 export const statusCommand = new Command("status")
   .description("Show sync status for all collections")
   .action(() => {
-    if (!contextExists()) {
-      console.error("Frozen Ink not initialized. Run: fink init");
-      process.exit(1);
-    }
+    ensureInitialized();
 
     const collectionRows = listCollections();
 

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,23 +1,17 @@
 import { Command } from "commander";
-import { existsSync } from "fs";
+import { existsSync, rmSync } from "fs";
 import { join } from "path";
 import {
   getFrozenInkHome,
   getCollectionDb,
-  contextExists,
+  ensureInitialized,
   listCollections,
   getCollection,
   getCollectionDbPath,
   SyncEngine,
   ThemeEngine,
   LocalStorageBackend,
-  SearchIndexer,
-  syncState,
   entities,
-  entityTags,
-  attachments,
-  entityLinks,
-  entityRelations,
 } from "@frozenink/core";
 import { sql } from "drizzle-orm";
 import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme, mantisBTTheme } from "@frozenink/crawlers";
@@ -30,10 +24,7 @@ export const syncCommand = new Command("sync")
   .option("--max-issues <count>", "Maximum issues to sync (overrides collection config)", parseInt)
   .option("--max-prs <count>", "Maximum pull requests to sync (overrides collection config)", parseInt)
   .action(async (collection: string, opts: { full?: boolean; max?: number; maxIssues?: number; maxPrs?: number }) => {
-    if (!contextExists()) {
-      console.error("Frozen Ink not initialized. Run: fink init");
-      process.exit(1);
-    }
+    ensureInitialized();
 
     const home = getFrozenInkHome();
     let collectionRows = collection === "*"
@@ -92,23 +83,16 @@ export const syncCommand = new Command("sync")
       );
 
       const dbPath = getCollectionDbPath(col.name);
+      const collectionDir = join(home, "collections", col.name);
 
-      // Full re-sync: wipe all collection data so the sync starts clean
+      // Full re-sync: nuke content/ and db/ directories so the sync starts clean
       if (opts.full) {
-        const colDb = getCollectionDb(dbPath);
-        colDb.delete(entityLinks).run();
-        colDb.delete(entityRelations).run();
-        colDb.delete(attachments).run();
-        colDb.delete(entityTags).run();
-        colDb.delete(entities).run();
-        colDb.delete(syncState).run();
-        const indexer = new SearchIndexer(dbPath);
-        indexer.clearIndex();
-        indexer.close();
+        const contentDir = join(collectionDir, "content");
+        const dbDir = join(collectionDir, "db");
+        if (existsSync(contentDir)) rmSync(contentDir, { recursive: true, force: true });
+        if (existsSync(dbDir)) rmSync(dbDir, { recursive: true, force: true });
         console.log(`  Cleared all data for full re-sync`);
       }
-
-      const collectionDir = join(home, "collections", col.name);
       const storage = new LocalStorageBackend(collectionDir);
 
       const engine = new SyncEngine({
@@ -117,7 +101,8 @@ export const syncCommand = new Command("sync")
         collectionName: col.name,
         themeEngine,
         storage,
-        markdownBasePath: "markdown",
+        markdownBasePath: "content",
+        assetConfig: col.assets as { extensions?: string[]; maxSize?: number } | undefined,
         onBatchFetched: ({ externalIds }) => {
           if (externalIds.length === 0) return;
           const ids = externalIds.map((externalId) => {

--- a/packages/cli/src/commands/unpublish.ts
+++ b/packages/cli/src/commands/unpublish.ts
@@ -1,10 +1,10 @@
 import { Command } from "commander";
 import { createInterface } from "readline";
 import {
-  contextExists,
-  getDeployment,
-  removeDeployment,
-  type DeploymentEntry,
+  ensureInitialized,
+  getSite,
+  removeSite,
+  type SiteEntry,
 } from "@frozenink/core";
 import {
   checkWranglerAuth,
@@ -34,7 +34,7 @@ export type UnpublishProgressCallback = (step: string, detail: string) => void;
  * Callable from both CLI and management API.
  */
 export async function unpublishDeployment(
-  deployment: DeploymentEntry & { name: string },
+  deployment: SiteEntry & { name: string },
   onProgress: UnpublishProgressCallback = () => {},
 ): Promise<void> {
   await checkWranglerAuth();
@@ -48,14 +48,14 @@ export async function unpublishDeployment(
   }
 
   // 2. Try deleting R2 bucket (may fail if non-empty)
-  const r2BucketName = deployment.r2BucketName;
+  const r2BucketName = deployment.bucket.name;
   onProgress("r2", "Deleting R2 bucket...");
   try {
     await deleteR2Bucket(r2BucketName);
   } catch {
     // Bucket may need to be emptied first — try manifest-based cleanup
     onProgress("r2", "R2 bucket not empty, emptying via manifest...");
-    const d1Name = deployment.d1DatabaseName || `${deployment.name}-db`;
+    const d1Name = deployment.database.name || `${deployment.name}-db`;
     try {
       const manifestJson = await executeD1Command(d1Name, "SELECT key FROM r2_manifest");
       const parsed = JSON.parse(manifestJson);
@@ -73,7 +73,7 @@ export async function unpublishDeployment(
   }
 
   // 3. Delete D1 database
-  const d1Name = deployment.d1DatabaseName || `${deployment.name}-db`;
+  const d1Name = deployment.database.name || `${deployment.name}-db`;
   onProgress("d1", "Deleting D1 database...");
   try {
     await deleteD1(d1Name);
@@ -81,29 +81,26 @@ export async function unpublishDeployment(
     onProgress("d1", `Warning: could not delete D1 database: ${err}`);
   }
 
-  // 4. Remove from context.yml
-  removeDeployment(deployment.name);
-  onProgress("done", `Deployment "${deployment.name}" removed`);
+  // 4. Remove site directory
+  removeSite(deployment.name);
+  onProgress("done", `Site "${deployment.name}" removed`);
 }
 
 // --- CLI command ---
 
 export const unpublishCommand = new Command("unpublish")
   .description("Remove a published deployment from Cloudflare")
-  .argument("<name-or-url>", "Worker name or URL of the deployment")
+  .argument("<name-or-url>", "Worker name or URL of the site")
   .option("--force", "Skip confirmation")
   .action(async (nameOrUrl: string, opts: {
     force?: boolean;
   }) => {
     try {
-      if (!contextExists()) {
-        console.error("Frozen Ink not initialized. Run: fink init");
-        process.exit(1);
-      }
+      ensureInitialized();
 
-      const deployment = getDeployment(nameOrUrl);
+      const deployment = getSite(nameOrUrl);
       if (!deployment) {
-        console.error(`Deployment "${nameOrUrl}" not found`);
+        console.error(`Site "${nameOrUrl}" not found`);
         process.exit(1);
       }
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import {
-  contextExists,
+  ensureInitialized,
   getCollection,
   updateCollection,
 } from "@frozenink/core";
@@ -15,10 +15,7 @@ export const updateCommand = new Command("update")
   .option("--sync-comments [value]", "Sync comments (true/false)")
   .option("--sync-check-statuses [value]", "Sync check statuses (true/false)")
   .action(async (collection: string, opts: Record<string, unknown>) => {
-    if (!contextExists()) {
-      console.error("Frozen Ink not initialized. Run: fink init");
-      process.exit(1);
-    }
+    ensureInitialized();
 
     const col = getCollection(collection);
     if (!col) {

--- a/packages/cli/src/commands/wrangler-api.ts
+++ b/packages/cli/src/commands/wrangler-api.ts
@@ -13,14 +13,15 @@ let cachedWranglerPath: string | null = null;
 async function resolveWranglerBin(): Promise<string> {
   if (cachedWranglerPath) return cachedWranglerPath;
 
-  // Check user-configured path in workspace config.json
+  // Check user-configured path in workspace frozenink.yml
   let configuredPath: string | undefined;
   try {
+    const yaml = require("js-yaml");
     const home = getFrozenInkHome();
-    const configPath = join(home, "config.json");
+    const configPath = join(home, "frozenink.yml");
     if (existsSync(configPath)) {
-      const config = JSON.parse(readFileSync(configPath, "utf-8"));
-      configuredPath = config.wranglerPath;
+      const config = (yaml.load(readFileSync(configPath, "utf-8")) as Record<string, unknown>) ?? {};
+      configuredPath = config.wranglerPath as string | undefined;
     }
   } catch {}
 

--- a/packages/cli/src/tui/components/AddCollection.tsx
+++ b/packages/cli/src/tui/components/AddCollection.tsx
@@ -3,7 +3,7 @@ import { Box, Text, useInput } from "ink";
 import { mkdirSync } from "fs";
 import { join, resolve } from "path";
 import {
-  contextExists,
+  ensureInitialized,
   getFrozenInkHome,
   getCollectionDb,
   getCollectionDbPath,
@@ -14,6 +14,7 @@ import {
 import { createDefaultRegistry, MantisBTCrawler } from "@frozenink/crawlers";
 import { SelectInput, type SelectItem } from "./SelectInput.js";
 import { TextInput } from "./TextInput.js";
+import { MultiSelectInput } from "./MultiSelectInput.js";
 
 type Step =
   | "select-crawler"
@@ -29,10 +30,12 @@ type Step =
   | "git-include-diffs"
   | "mantisbt-url"
   | "mantisbt-token"
+  | "mantisbt-sync-entities"
   | "mantisbt-project-name"
   | "mantisbt-max"
   | "confirm"
   | "validating"
+  | "sync-prompt"
   | "done"
   | "error";
 
@@ -54,7 +57,7 @@ function getStepsForCrawler(type: string): Step[] {
     case "git":
       return [...base, "git-path", "git-include-diffs", "confirm"];
     case "mantisbt":
-      return [...base, "mantisbt-url", "mantisbt-token", "mantisbt-project-name", "mantisbt-max", "confirm"];
+      return [...base, "mantisbt-url", "mantisbt-token", "mantisbt-sync-entities", "mantisbt-project-name", "mantisbt-max", "confirm"];
     default:
       return [...base, "confirm"];
   }
@@ -62,8 +65,10 @@ function getStepsForCrawler(type: string): Step[] {
 
 export function AddCollection({
   onDone,
+  onSync,
 }: {
   onDone: () => void;
+  onSync?: (collectionName: string) => void;
 }): React.ReactElement {
   const [step, setStep] = useState<Step>("select-crawler");
   const [data, setData] = useState<FormData>({
@@ -128,7 +133,6 @@ export function AddCollection({
         setData((d) => ({
           ...d,
           config: { ...d.config, owner: parts[0], repo: parts[1] },
-          credentials: { ...d.credentials, owner: parts[0], repo: parts[1] },
         }));
         nextStep();
         break;
@@ -185,8 +189,8 @@ export function AddCollection({
         if (!val) { setError("URL is required"); return; }
         setData((d) => ({
           ...d,
-          config: { ...d.config, baseUrl: val },
-          credentials: { ...d.credentials, baseUrl: val },
+          config: { ...d.config, url: val },
+          credentials: { ...d.credentials, url: val, token: d.credentials.token ?? "" },
         }));
         nextStep();
         break;
@@ -196,7 +200,7 @@ export function AddCollection({
         break;
       case "mantisbt-project-name": {
         if (val) {
-          setData((d) => ({ ...d, config: { ...d.config, projectName: val } }));
+          setData((d) => ({ ...d, config: { ...d.config, project: { name: val } } }));
         }
         nextStep();
         break;
@@ -213,6 +217,16 @@ export function AddCollection({
     }
   }, [step, inputValue, nextStep]);
 
+  const isMantisHubUrl = (data.config.url as string || "").includes(".mantishub.");
+
+  const handleSyncEntitiesSubmit = useCallback(
+    (selected: string[]) => {
+      setData((d) => ({ ...d, config: { ...d.config, entities: selected } }));
+      nextStep();
+    },
+    [nextStep],
+  );
+
   const handleConfirm = useCallback(async () => {
     setStep("validating");
     try {
@@ -223,28 +237,35 @@ export function AddCollection({
       if (!valid) { setError("Credential validation failed"); setStep("error"); return; }
 
       // Resolve MantisBT project name → ID and persist both
-      if (data.crawlerType === "mantisbt" && data.config.projectName) {
+      const project = data.config.project as { id?: number; name?: string } | undefined;
+      if (data.crawlerType === "mantisbt" && project?.name) {
         await crawler.initialize(data.config, data.credentials);
-        const resolved = await (crawler as MantisBTCrawler).resolveProjectName(data.config.projectName as string);
-        data.config.projectId = resolved.id;
-        data.config.projectName = resolved.name;
+        const resolved = await (crawler as MantisBTCrawler).resolveProjectName(project.name);
+        data.config.project = { id: resolved.id, name: resolved.name };
       }
 
       const home = getFrozenInkHome();
       const dir = join(home, "collections", data.name);
       mkdirSync(dir, { recursive: true });
       getCollectionDb(getCollectionDbPath(data.name));
-      mkdirSync(join(dir, "markdown"), { recursive: true });
+      mkdirSync(join(dir, "content"), { recursive: true });
+
+      // For MantisBT, don't store url in credentials (it's already in config)
+      const creds = { ...data.credentials };
+      if (data.crawlerType === "mantisbt") {
+        delete creds.url;
+        delete creds.baseUrl;
+      }
 
       addCollection(data.name, {
         title: data.title || undefined,
         crawler: data.crawlerType,
         config: data.config,
-        credentials: data.credentials,
+        credentials: creds,
       });
 
       setMessage(`Collection "${data.name}" created!`);
-      setStep("done");
+      setStep("sync-prompt");
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
       setStep("error");
@@ -255,6 +276,15 @@ export function AddCollection({
     if (step === "confirm") {
       if (input === "y") handleConfirm();
       if (input === "n" || key.escape) onDone();
+    }
+    if (step === "sync-prompt") {
+      if (input === "y") {
+        if (onSync) {
+          onSync(data.name);
+        }
+        onDone();
+      }
+      if (input === "n" || key.escape || key.return) onDone();
     }
     if (step === "done" || step === "error") {
       if (key.return || key.escape) onDone();
@@ -309,6 +339,17 @@ export function AddCollection({
         {step === "mantisbt-token" && (
           <TextInput label="API token (optional)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
         )}
+        {step === "mantisbt-sync-entities" && (
+          <MultiSelectInput
+            label="Entity types to sync"
+            items={[
+              { label: "Issues", value: "issues" },
+              { label: "Pages (wiki)", value: "pages", enabled: isMantisHubUrl },
+              { label: "Users", value: "users" },
+            ]}
+            onSubmit={handleSyncEntitiesSubmit}
+          />
+        )}
         {step === "mantisbt-project-name" && (
           <TextInput label="Project name (blank for all)" value={inputValue} onChange={setInputValue} onSubmit={handleTextSubmit} />
         )}
@@ -320,8 +361,14 @@ export function AddCollection({
           <Box flexDirection="column">
             <Text bold>Summary</Text>
             <Text>  Crawler: <Text color="cyan">{data.crawlerType}</Text></Text>
+            {data.crawlerType === "mantisbt" && data.config.url && (
+              <Text>  URL:     <Text color="cyan">{data.config.url as string}</Text></Text>
+            )}
             <Text>  Name:    <Text color="cyan">{data.name}</Text></Text>
             {data.title && <Text>  Title:   <Text color="cyan">{data.title}</Text></Text>}
+            {Array.isArray(data.config.entities) && (
+              <Text>  Sync:    <Text color="cyan">{(data.config.entities as string[]).join(", ")}</Text></Text>
+            )}
             <Box marginTop={1}>
               <Text>Create this collection? (y/n)</Text>
             </Box>
@@ -329,6 +376,14 @@ export function AddCollection({
         )}
 
         {step === "validating" && <Text color="yellow">Validating credentials...</Text>}
+        {step === "sync-prompt" && (
+          <Box flexDirection="column">
+            <Text color="green">{message}</Text>
+            <Box marginTop={1}>
+              <Text>Run initial sync now? (y/n)</Text>
+            </Box>
+          </Box>
+        )}
         {step === "done" && <Text color="green">{message} Press Enter to continue.</Text>}
         {step === "error" && <Text color="red">Error: {error}. Press Enter to go back.</Text>}
         {error && !["error", "done"].includes(step) && <Text color="red">{error}</Text>}

--- a/packages/cli/src/tui/components/AddCollection.tsx
+++ b/packages/cli/src/tui/components/AddCollection.tsx
@@ -361,8 +361,8 @@ export function AddCollection({
           <Box flexDirection="column">
             <Text bold>Summary</Text>
             <Text>  Crawler: <Text color="cyan">{data.crawlerType}</Text></Text>
-            {data.crawlerType === "mantisbt" && data.config.url && (
-              <Text>  URL:     <Text color="cyan">{data.config.url as string}</Text></Text>
+            {data.crawlerType === "mantisbt" && !!data.config.url && (
+              <Text>  URL:     <Text color="cyan">{String(data.config.url)}</Text></Text>
             )}
             <Text>  Name:    <Text color="cyan">{data.name}</Text></Text>
             {data.title && <Text>  Title:   <Text color="cyan">{data.title}</Text></Text>}

--- a/packages/cli/src/tui/components/App.tsx
+++ b/packages/cli/src/tui/components/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Box, Text, useApp, useInput } from "ink";
 import {
-  contextExists,
+  ensureInitialized,
   listCollections,
 } from "@frozenink/core";
 import { CollectionList } from "./CollectionList.js";
@@ -39,8 +39,8 @@ export function App(): React.ReactElement {
   const [screen, setScreen] = useState<Screen>("home");
   const [menuCursor, setMenuCursor] = useState(0);
 
-  const initialized = contextExists();
-  const hasCollections = initialized && listCollections().length > 0;
+  ensureInitialized();
+  const hasCollections = listCollections().length > 0;
   const menuItems = ALL_MENU_ITEMS.filter(
     (item) => !item.requiresCollections || hasCollections,
   );
@@ -82,12 +82,7 @@ export function App(): React.ReactElement {
           <Text bold color="cyan">Frozen Ink</Text>
           <Text dimColor>— Local data replica manager</Text>
         </Box>
-        {!initialized && (
-          <Box paddingX={2} marginBottom={1}>
-            <Text color="yellow">Not initialized. Select Collections to get started.</Text>
-          </Box>
-        )}
-        {initialized && !hasCollections && (
+        {!hasCollections && (
           <Box paddingX={2} marginBottom={1}>
             <Text dimColor>No collections configured. Select Collections to add one.</Text>
           </Box>

--- a/packages/cli/src/tui/components/CollectionList.tsx
+++ b/packages/cli/src/tui/components/CollectionList.tsx
@@ -407,7 +407,7 @@ export function CollectionList({
           .groupBy(entities.entityType)
           .orderBy(sql`count(*) desc`)
           .all();
-        entityTypeCounts = typeCounts.map((r) => ({ type: r.type, count: r.count }));
+        entityTypeCounts = typeCounts.map((r: any) => ({ type: r.type, count: r.count }));
 
         // Collection directory size
         const home = getFrozenInkHome();

--- a/packages/cli/src/tui/components/CollectionList.tsx
+++ b/packages/cli/src/tui/components/CollectionList.tsx
@@ -3,9 +3,9 @@ import { Box, Text, useInput } from "ink";
 import { existsSync, renameSync, rmSync } from "fs";
 import { join, basename } from "path";
 import {
-  contextExists,
+  ensureInitialized,
   listCollections,
-  listDeployments,
+  listSites,
   getCollection,
   getCollectionDb,
   getCollectionDbPath,
@@ -41,6 +41,7 @@ type Mode =
   | "export"
   | "search"
   | "confirm-delete"
+  | "confirm-full-sync"
   | "syncing";
 
 // Fixed-width columns
@@ -132,9 +133,15 @@ function getSourceDetails(crawler: string, config: Record<string, unknown>): Arr
       break;
     }
     case "mantisbt": {
-      const baseUrl = config.baseUrl as string | undefined;
-      if (baseUrl) details.push({ label: "URL", value: baseUrl });
-      if (config.projectId) details.push({ label: "Project ID", value: String(config.projectId) });
+      const url = (config.url ?? config.baseUrl) as string | undefined;
+      if (url) details.push({ label: "URL", value: url });
+      const project = config.project as { id?: number; name?: string } | undefined;
+      const projName = project?.name ?? (config.projectName as string | undefined);
+      const projId = project?.id ?? (config.projectId as number | undefined);
+      if (projName || projId) {
+        const value = projName && projId ? `${projName} (id: ${projId})` : projName ?? String(projId);
+        details.push({ label: "Project", value });
+      }
       if (config.maxEntities) details.push({ label: "Max entities", value: String(config.maxEntities) });
       break;
     }
@@ -350,7 +357,7 @@ export function CollectionList({
   const [inputValue, setInputValue] = useState("");
   const [refreshKey, setRefreshKey] = useState(0);
   const [syncProgress, setSyncProgress] = useState<string[]>([]);
-  const [syncFetchedCount, setSyncFetchedCount] = useState(0);
+  const [syncFetchedCounts, setSyncFetchedCounts] = useState<Record<string, number>>({});
   const [syncStartTime, setSyncStartTime] = useState<number | null>(null);
   const [syncElapsedMs, setSyncElapsedMs] = useState(0);
   const [editingCollection, setEditingCollection] = useState("");
@@ -365,13 +372,15 @@ export function CollectionList({
     return () => clearInterval(interval);
   }, [syncStartTime]);
 
-  const initialized = contextExists();
-  const collections = initialized ? listCollections() : [];
-  const allDeployments = initialized ? listDeployments() : [];
+  ensureInitialized();
+  const collections = listCollections();
+  const allSites = listSites();
   const current = collections[cursor] ?? null;
 
   // Detail stats for selected collection
   let entityCount = 0;
+  let entityTypeCounts: Array<{ type: string; count: number }> = [];
+  let collectionSize = "";
   let lastRun: {
     status: string;
     startedAt: string | null;
@@ -387,6 +396,30 @@ export function CollectionList({
         const colDb = getCollectionDb(dbPath);
         const [{ total }] = colDb.select({ total: sql<number>`count(*)` }).from(entities).all();
         entityCount = total;
+
+        // Per-type breakdown
+        const typeCounts = colDb
+          .select({
+            type: entities.entityType,
+            count: sql<number>`count(*)`,
+          })
+          .from(entities)
+          .groupBy(entities.entityType)
+          .orderBy(sql`count(*) desc`)
+          .all();
+        entityTypeCounts = typeCounts.map((r) => ({ type: r.type, count: r.count }));
+
+        // Collection directory size
+        const home = getFrozenInkHome();
+        const colDir = join(home, "collections", current.name);
+        if (existsSync(colDir)) {
+          try {
+            const { execSync } = require("child_process");
+            const sizeStr = execSync(`du -sh "${colDir}" 2>/dev/null`, { encoding: "utf8" }).trim().split(/\s/)[0];
+            if (sizeStr) collectionSize = sizeStr;
+          } catch { /* ignore */ }
+        }
+
         const runs = colDb.select().from(syncRuns).orderBy(desc(syncRuns.startedAt)).limit(1).all();
         if (runs.length > 0) {
           lastRun = runs[0];
@@ -399,19 +432,22 @@ export function CollectionList({
     }
   }
 
-  const relatedDeployments = current
-    ? allDeployments.filter((d: { collections: string[] }) => d.collections.includes(current.name))
+  const relatedSites = current
+    ? allSites.filter((d: { collections: string[] }) => d.collections.includes(current.name))
     : [];
 
   const sourceDetails = current
     ? getSourceDetails(current.crawler, current.config as Record<string, unknown>)
     : [];
 
-  const startSync = useCallback(async () => {
-    if (!current) return;
+  const startSync = useCallback(async (collectionName?: string, syncType?: "full" | "incremental") => {
+    const col = collectionName ? getCollection(collectionName) : current;
+    const name = collectionName ?? current?.name;
+    if (!col || !name) return;
     setMode("syncing");
-    setSyncProgress([`Syncing "${current.name}" (${current.crawler})...`]);
-    setSyncFetchedCount(0);
+    const syncLabel = syncType === "full" ? "Full sync" : "Syncing";
+    setSyncProgress([`${syncLabel} "${name}" (${col.crawler})...`]);
+    setSyncFetchedCounts({});
     const syncStart = Date.now();
     setSyncStartTime(syncStart);
     try {
@@ -421,30 +457,42 @@ export function CollectionList({
       themeEngine.register(obsidianTheme);
       themeEngine.register(gitTheme);
       themeEngine.register(mantisBTTheme);
-      const factory = registry.get(current.crawler);
-      if (!factory) { setSyncProgress((p) => [...p, `No crawler for ${current.crawler}`]); setSyncStartTime(null); setMode("list"); return; }
+      const factory = registry.get(col.crawler);
+      if (!factory) { setSyncProgress((p) => [...p, `No crawler for ${col.crawler}`]); setSyncStartTime(null); setMode("list"); return; }
       const crawler = factory();
-      await crawler.initialize(current.config as Record<string, unknown>, current.credentials as Record<string, unknown>);
+      await crawler.initialize(col.config as Record<string, unknown>, col.credentials as Record<string, unknown>);
       const home = getFrozenInkHome();
-      const dbPath = getCollectionDbPath(current.name);
-      const collectionDir = join(home, "collections", current.name);
+      const dbPath = getCollectionDbPath(name);
+      const collectionDir = join(home, "collections", name);
       const storage = new LocalStorageBackend(collectionDir);
       const engine = new SyncEngine({
-        crawler, dbPath, collectionName: current.name, themeEngine, storage, markdownBasePath: "markdown",
-        onBatchFetched: ({ externalIds }: { externalIds: string[] }) => {
-          if (externalIds.length > 0) setSyncFetchedCount((c) => c + externalIds.length);
+        crawler, dbPath, collectionName: name, themeEngine, storage, markdownBasePath: "content",
+        assetConfig: col.assets as { extensions?: string[]; maxSize?: number } | undefined,
+        onBatchFetched: ({ externalIds, entityTypes }: { externalIds: string[]; entityTypes: string[] }) => {
+          if (externalIds.length > 0) {
+            setSyncFetchedCounts((prev) => {
+              const next = { ...prev };
+              for (const t of entityTypes) {
+                next[t] = (next[t] ?? 0) + 1;
+              }
+              return next;
+            });
+          }
+        },
+        onVersionUpdate: (version: string) => {
+          updateCollection(name, { version });
         },
       });
-      const stats = await engine.run();
-      setSyncFetchedCount(0);
+      const stats = await engine.run({ syncType: syncType ?? "incremental" });
+      setSyncFetchedCounts({});
       const elapsed = formatElapsed(Date.now() - syncStart);
       const colDb = getCollectionDb(dbPath);
       const [{ total }] = colDb.select({ total: sql<number>`count(*)` }).from(entities).all();
       setSyncProgress((p) => [...p, `+${stats.created} ~${stats.updated} -${stats.deleted} (${total} total) in ${elapsed}`]);
       await crawler.dispose();
-      setMessage(`Sync complete for "${current.name}"`);
+      setMessage(`Sync complete for "${name}"`);
     } catch (err) {
-      setSyncFetchedCount(0);
+      setSyncFetchedCounts({});
       setSyncProgress((p) => [...p, `Error: ${err instanceof Error ? err.message : String(err)}`]);
     }
     setSyncStartTime(null);
@@ -481,9 +529,28 @@ export function CollectionList({
       }
       if (input === "a") setMode("add");
       if (input === "x" && current) setMode("confirm-delete");
-      if (input === "s" && current) startSync();
+      if (input === "s" && current) {
+        const registry = createDefaultRegistry();
+        const factory = registry.get(current.crawler);
+        const crawlerVersion = factory ? factory().metadata.version ?? "1.0" : "1.0";
+        const collectionVersion = current.version ?? "1.0";
+        const compat = SyncEngine.checkVersionCompat(collectionVersion, crawlerVersion);
+        if (compat === "full-sync") {
+          setMessage(`Version mismatch (${collectionVersion} → ${crawlerVersion}). Full sync required.`);
+          setMode("confirm-full-sync");
+        } else {
+          startSync();
+        }
+      }
       if (input === "e" && current) { setEditingCollection(current.name); setMode("export"); }
       if (input === "f" && current) { setEditingCollection(current.name); setMode("search"); }
+    } else if (mode === "confirm-full-sync") {
+      if (input === "y" && current) {
+        startSync(undefined, "full");
+      } else {
+        setMessage("");
+        setMode("list");
+      }
     } else if (mode === "confirm-delete") {
       if (input === "y" && current) {
         const home = getFrozenInkHome();
@@ -503,12 +570,11 @@ export function CollectionList({
 
   // ── All hooks are above this line ──
 
-  if (!initialized) {
-    return <Text color="yellow">Not initialized. Run `fink init` first.</Text>;
-  }
-
   if (mode === "add") {
-    return <AddCollection onDone={() => { setMode("list"); refresh(); }} />;
+    return <AddCollection onDone={() => { setMode("list"); refresh(); }} onSync={(name) => {
+      refresh();
+      startSync(name);
+    }} />;
   }
 
   if (mode === "edit" && editingCollection) {
@@ -523,15 +589,29 @@ export function CollectionList({
     return <SearchView collectionName={editingCollection} onDone={() => { setMode("list"); }} />;
   }
 
+  if (mode === "confirm-full-sync") {
+    return (
+      <Box flexDirection="column" paddingY={1}>
+        <Text color="yellow">{message}</Text>
+        <Text>Run full sync? This will re-download all data. (y/n)</Text>
+      </Box>
+    );
+  }
+
   if (mode === "syncing") {
     return (
       <Box flexDirection="column" paddingY={1}>
         <Text bold color="yellow">Syncing...</Text>
         <Box flexDirection="column" marginLeft={1} marginTop={1}>
           {syncProgress.map((line, i) => <Text key={i} dimColor>{line}</Text>)}
-          {syncFetchedCount > 0 && (
-            <Text dimColor>  Fetched {syncFetchedCount} entities... ({formatElapsed(syncElapsedMs)})</Text>
-          )}
+          {Object.keys(syncFetchedCounts).length > 0 && (() => {
+            const total = Object.values(syncFetchedCounts).reduce((a, b) => a + b, 0);
+            const breakdown = Object.entries(syncFetchedCounts)
+              .sort(([, a], [, b]) => b - a)
+              .map(([type, count]) => `${count} ${type}${count !== 1 ? "s" : ""}`)
+              .join(", ");
+            return <Text dimColor>  Fetched {total} entities: {breakdown}. ({formatElapsed(syncElapsedMs)})</Text>;
+          })()}
         </Box>
       </Box>
     );
@@ -587,7 +667,6 @@ export function CollectionList({
           <Box gap={2}>
             <Text bold>{current.title || current.name}</Text>
             <Text dimColor>({current.crawler})</Text>
-            <Text>Entities: <Text bold>{entityCount}</Text></Text>
           </Box>
           {sourceDetails.length > 0 && (
             <Box flexDirection="column">
@@ -596,6 +675,15 @@ export function CollectionList({
               ))}
             </Box>
           )}
+          <Text>
+            <Text dimColor>Content: </Text>
+            <Text bold>{entityCount}</Text>
+            <Text> entities</Text>
+            {entityTypeCounts.length > 0 && (
+              <Text> - {entityTypeCounts.map((t) => `${t.count} ${t.type}${t.count !== 1 ? "s" : ""}`).join(", ")}</Text>
+            )}
+            {collectionSize ? <Text> - {collectionSize}</Text> : null}
+          </Text>
           {lastRun ? (
             <Box gap={2}>
               <Text>Last sync: <Text dimColor>{lastSyncTime}</Text> <Text color={lastRun.status === "completed" ? "green" : "red"}>({lastRun.status})</Text></Text>
@@ -604,15 +692,15 @@ export function CollectionList({
           ) : (
             <Text dimColor>No sync runs yet</Text>
           )}
-          {relatedDeployments.length > 0 && (
+          {relatedSites.length > 0 && (
             <Box flexDirection="column" marginTop={1}>
-              <Text dimColor bold>Deployments:</Text>
-              {relatedDeployments.map((dep: { name: string; url: string; passwordProtected: boolean }) => (
-                <Box key={dep.name} gap={1} marginLeft={1}>
-                  <Text>{dep.name}</Text>
+              <Text dimColor bold>Sites:</Text>
+              {relatedSites.map((site: { name: string; url: string; password?: { protected: boolean } }) => (
+                <Box key={site.name} gap={1} marginLeft={1}>
+                  <Text>{site.name}</Text>
                   <Text dimColor>→</Text>
-                  <Text color="blue">{dep.url}</Text>
-                  <Text color={dep.passwordProtected ? "green" : "yellow"}>[{dep.passwordProtected ? "protected" : "public"}]</Text>
+                  <Text color="blue">{site.url}</Text>
+                  <Text color={site.password?.protected ? "green" : "yellow"}>[{site.password?.protected ? "protected" : "public"}]</Text>
                 </Box>
               ))}
             </Box>

--- a/packages/cli/src/tui/components/ExportView.tsx
+++ b/packages/cli/src/tui/components/ExportView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { Box, Text, useInput } from "ink";
 import {
-  contextExists,
+  ensureInitialized,
   listCollections,
   ThemeEngine,
 } from "@frozenink/core";
@@ -34,9 +34,7 @@ export function ExportView({
   const [progress, setProgress] = useState<string[]>([]);
   const [error, setError] = useState("");
 
-  if (!contextExists()) {
-    return <Text color="yellow">Not initialized.</Text>;
-  }
+  ensureInitialized();
 
   const collections = listCollections()
     .filter((c: { enabled: boolean }) => c.enabled)

--- a/packages/cli/src/tui/components/MultiSelectInput.tsx
+++ b/packages/cli/src/tui/components/MultiSelectInput.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+import { Box, Text, useInput } from "ink";
+
+export interface MultiSelectItem {
+  label: string;
+  value: string;
+  enabled?: boolean;
+}
+
+interface Props {
+  items: MultiSelectItem[];
+  onSubmit: (selected: string[]) => void;
+  label?: string;
+}
+
+/**
+ * Multi-select input: arrow keys to navigate, space to toggle, enter to confirm.
+ * Items with `enabled: false` are shown but cannot be selected.
+ */
+export function MultiSelectInput({
+  items,
+  onSubmit,
+  label,
+}: Props): React.ReactElement {
+  const [index, setIndex] = useState(0);
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    const initial = new Set<string>();
+    for (const item of items) {
+      if (item.enabled !== false) initial.add(item.value);
+    }
+    return initial;
+  });
+
+  useInput((input, key) => {
+    if (key.upArrow) {
+      setIndex((i) => (i > 0 ? i - 1 : items.length - 1));
+    }
+    if (key.downArrow) {
+      setIndex((i) => (i < items.length - 1 ? i + 1 : 0));
+    }
+    if (input === " ") {
+      const item = items[index];
+      if (item.enabled === false) return;
+      setSelected((prev) => {
+        const next = new Set(prev);
+        if (next.has(item.value)) {
+          next.delete(item.value);
+        } else {
+          next.add(item.value);
+        }
+        return next;
+      });
+    }
+    if (key.return) {
+      onSubmit([...selected]);
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      {label && (
+        <Text bold color="cyan">
+          {label}
+        </Text>
+      )}
+      {items.map((item, i) => {
+        const isSelected = selected.has(item.value);
+        const isDisabled = item.enabled === false;
+        const cursor = i === index ? ">" : " ";
+        const check = isDisabled ? "-" : isSelected ? "x" : " ";
+        const color = isDisabled ? "gray" : i === index ? "cyan" : undefined;
+        return (
+          <Box key={item.value}>
+            <Text color={color}>
+              {cursor} [{check}] {item.label}
+              {isDisabled && " (not available)"}
+            </Text>
+          </Box>
+        );
+      })}
+      <Text dimColor>Space to toggle, Enter to confirm</Text>
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/components/PublishView.tsx
+++ b/packages/cli/src/tui/components/PublishView.tsx
@@ -4,10 +4,10 @@ import { existsSync, statSync, readdirSync } from "fs";
 import { join } from "path";
 import { exec } from "child_process";
 import {
-  contextExists,
+  ensureInitialized,
   listCollections,
-  listDeployments,
-  getDeployment,
+  listSites,
+  getSite,
   getCollectionDb,
   getCollectionDbPath,
   getFrozenInkHome,
@@ -112,10 +112,10 @@ export function PublishView({
   const [pubResult, setPubResult] = useState<{ workerUrl: string; mcpUrl: string } | null>(null);
   const [inputValue, setInputValue] = useState("");
 
-  if (!contextExists()) return <Text color="yellow">Not initialized.</Text>;
+  ensureInitialized();
 
   const collections = listCollections().filter((c: { enabled: boolean }) => c.enabled).map((c: { name: string }) => c.name);
-  const deployments = listDeployments();
+  const deployments = listSites();
   const depNames = deployments.map((d: { name: string }) => d.name);
   const currentDep = deployments[depCursor];
 
@@ -152,7 +152,7 @@ export function PublishView({
     setDepMode("deleting");
     setDepProgress([]);
     try {
-      const dep = getDeployment(currentDep.name);
+      const dep = getSite(currentDep.name);
       if (!dep) { setDepError("Deployment not found"); setDepMode("error-delete"); return; }
       await unpublishDeployment(dep, (step, detail) => setDepProgress((p) => [...p, `[${step}] ${detail}`]));
       setDepMessage(`Deployment "${currentDep.name}" removed.`);
@@ -310,7 +310,7 @@ export function PublishView({
         ) : (
           <>
             <Box flexDirection="column" marginTop={1}>
-              {deployments.map((dep: { name: string; url: string; collections: string[]; passwordProtected: boolean; publishedAt: string; mcpUrl: string }, i: number) => {
+              {deployments.map((dep: { name: string; url: string; collections: string[]; password?: { protected: boolean }; publishedAt: string; mcpUrl: string }, i: number) => {
                 let depEntities = 0;
                 let depSize = 0;
                 for (const cn of dep.collections) { const s = getCollectionStats(cn); depEntities += s.entityCount; depSize += s.diskSize; }
@@ -318,7 +318,7 @@ export function PublishView({
                   <Box key={dep.name} gap={1}>
                     <Text color={i === depCursor ? "cyan" : undefined}>{i === depCursor ? "❯" : " "}</Text>
                     <Text bold={i === depCursor}>{dep.name}</Text>
-                    <Text color={dep.passwordProtected ? "green" : "yellow"}>[{dep.passwordProtected ? "protected" : "public"}]</Text>
+                    <Text color={dep.password?.protected ? "green" : "yellow"}>[{dep.password?.protected ? "protected" : "public"}]</Text>
                     <Text dimColor>{depEntities} entities</Text>
                     <Text dimColor>{formatSize(depSize)}</Text>
                   </Box>

--- a/packages/cli/src/tui/components/SearchView.tsx
+++ b/packages/cli/src/tui/components/SearchView.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { existsSync } from "fs";
 import { join } from "path";
 import { exec } from "child_process";
 import {
-  contextExists,
+  ensureInitialized,
   listCollections,
   getCollectionDb,
   getCollectionDbPath,
@@ -12,8 +12,7 @@ import {
   SearchIndexer,
   entities,
 } from "@frozenink/core";
-import { eq } from "drizzle-orm";
-import { TextInput } from "./TextInput.js";
+import { desc, eq, sql } from "drizzle-orm";
 
 interface SearchResult {
   collection: string;
@@ -22,8 +21,6 @@ interface SearchResult {
   externalId: string;
   rank: number;
 }
-
-type Mode = "input" | "results";
 
 function openFile(filePath: string): void {
   const cmd =
@@ -52,6 +49,13 @@ function formatResultPrefix(entityType: string, externalId: string): string | nu
 
   if (entityType === "note") return null;
 
+  if (entityType === "page") {
+    // externalId is "page:{projectId}:{pageName}"
+    const parts = rawId.split(":");
+    const pageName = parts.length >= 2 ? parts.slice(1).join(":") : rawId;
+    return `[[${pageName}]]:`;
+  }
+
   return `${entityType}:`;
 }
 
@@ -74,6 +78,44 @@ function getMarkdownPath(result: SearchResult): string | null {
   return null;
 }
 
+/** Fetch all entities (most recently updated first) when query is empty. */
+function fetchAllEntities(collectionName?: string): SearchResult[] {
+  const collections = collectionName
+    ? [{ name: collectionName }]
+    : listCollections();
+  const allResults: SearchResult[] = [];
+
+  for (const col of collections) {
+    const dbPath = getCollectionDbPath(col.name);
+    if (!existsSync(dbPath)) continue;
+    try {
+      const colDb = getCollectionDb(dbPath);
+      const rows = colDb
+        .select({
+          externalId: entities.externalId,
+          entityType: entities.entityType,
+          title: entities.title,
+        })
+        .from(entities)
+        .orderBy(desc(entities.updatedAt))
+        .limit(100)
+        .all();
+      for (const r of rows) {
+        allResults.push({
+          collection: col.name,
+          entityType: r.entityType,
+          title: r.title,
+          externalId: r.externalId,
+          rank: 0,
+        });
+      }
+    } catch { /* ignore */ }
+  }
+  return allResults;
+}
+
+const PAGE_SIZE = 10;
+
 export function SearchView({
   collectionName,
   onDone,
@@ -81,17 +123,19 @@ export function SearchView({
   collectionName?: string;
   onDone?: () => void;
 }): React.ReactElement {
-  // All hooks before any conditional returns
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
-  const [searched, setSearched] = useState(false);
-  const [mode, setMode] = useState<Mode>("input");
   const [resultCursor, setResultCursor] = useState(0);
 
-  const initialized = contextExists();
+  ensureInitialized();
+  const initialized = true;
 
-  const doSearch = useCallback(() => {
-    if (!query.trim()) return;
+  const runSearch = useCallback((q: string) => {
+    if (!q.trim()) {
+      setResults(fetchAllEntities(collectionName));
+      setResultCursor(0);
+      return;
+    }
 
     const collections = collectionName
       ? [{ name: collectionName }]
@@ -104,7 +148,7 @@ export function SearchView({
 
       const indexer = new SearchIndexer(dbPath);
       try {
-        const hits = indexer.search(query.trim(), { collectionName: col.name });
+        const hits = indexer.search(q.trim(), { collectionName: col.name });
         for (const r of hits) {
           allResults.push({ ...r, collection: col.name });
         }
@@ -114,93 +158,118 @@ export function SearchView({
     }
 
     allResults.sort((a, b) => a.rank - b.rank);
-    setResults(allResults.slice(0, 30));
-    setSearched(true);
+    setResults(allResults.slice(0, 100));
     setResultCursor(0);
-    if (allResults.length > 0) {
-      setMode("results");
-    }
-  }, [query, collectionName]);
+  }, [collectionName]);
 
+  // Run initial search on mount
+  useEffect(() => {
+    if (initialized) runSearch("");
+  }, [initialized]);
+
+  // Handle all keyboard input in one place
   useInput((input, key) => {
-    if (mode === "results") {
-      if (key.upArrow) setResultCursor((c) => Math.max(0, c - 1));
-      if (key.downArrow) setResultCursor((c) => Math.min(results.length - 1, c + 1));
-      if (key.return && results[resultCursor]) {
+    if (key.escape || key.tab) {
+      if (onDone) { onDone(); return; }
+      return;
+    }
+
+    // Navigation keys work alongside typing
+    if (key.upArrow) {
+      setResultCursor((c) => Math.max(0, c - 1));
+      return;
+    }
+    if (key.downArrow) {
+      setResultCursor((c) => Math.min(results.length - 1, c + 1));
+      return;
+    }
+    if (key.leftArrow) {
+      setResultCursor((c) => {
+        const prevPageStart = Math.floor(c / PAGE_SIZE) * PAGE_SIZE - PAGE_SIZE;
+        return Math.max(0, prevPageStart);
+      });
+      return;
+    }
+    if (key.rightArrow) {
+      setResultCursor((c) => {
+        const nextPageStart = Math.floor(c / PAGE_SIZE) * PAGE_SIZE + PAGE_SIZE;
+        return Math.min(results.length - 1, nextPageStart);
+      });
+      return;
+    }
+
+    if (key.return) {
+      if (results[resultCursor]) {
         const mdPath = getMarkdownPath(results[resultCursor]);
         if (mdPath) openFile(mdPath);
       }
-      if (key.escape || key.tab) {
-        if (onDone) { onDone(); return; }
-        setMode("input");
-        setQuery("");
-        setSearched(false);
-      }
+      return;
+    }
+
+    // Text editing
+    if (key.backspace || key.delete) {
+      const next = query.slice(0, -1);
+      setQuery(next);
+      runSearch(next);
+      return;
+    }
+
+    if (!key.ctrl && !key.meta && input) {
+      const next = query + input;
+      setQuery(next);
+      runSearch(next);
     }
   });
 
-  // All hooks above — safe to do conditional returns now
-
-  if (!initialized) {
-    return <Text color="yellow">Not initialized.</Text>;
-  }
-
   const scoped = !!collectionName;
   const title = scoped ? `Search in "${collectionName}"` : "Search";
-  const description = scoped
-    ? `Search within "${collectionName}". Type a query and press Enter.`
-    : "Full-text search across all collections. Type a query and press Enter.";
-  const inputLabel = scoped ? `Search ${collectionName}` : "Search all";
+
+  const totalPages = Math.max(1, Math.ceil(results.length / PAGE_SIZE));
+  const currentPage = Math.floor(resultCursor / PAGE_SIZE);
+  const pageStart = currentPage * PAGE_SIZE;
+  const pageResults = results.slice(pageStart, pageStart + PAGE_SIZE);
 
   return (
     <Box flexDirection="column" paddingY={1}>
       <Text bold>{title}</Text>
-      <Text dimColor>{description}</Text>
 
-      {mode === "input" && (
-        <Box marginTop={1}>
-          <TextInput
-            label={inputLabel}
-            value={query}
-            onChange={setQuery}
-            onSubmit={doSearch}
-            placeholder="Enter search terms..."
-          />
-        </Box>
-      )}
+      <Box marginTop={1}>
+        <Text color="cyan">? </Text>
+        <Text bold>Find: </Text>
+        <Text>{query}</Text>
+        <Text color="cyan">█</Text>
+      </Box>
 
-      {mode === "results" && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text dimColor>
-            {results.length} result(s) for "{query}" — ↑↓ navigate, Enter to open, ESC back
-          </Text>
-          <Box flexDirection="column" marginTop={1}>
-            {results.length === 0 ? (
-              <Text dimColor>No results found.</Text>
-            ) : (
-              results.map((r, i) => {
+      <Box flexDirection="column" marginTop={1}>
+        {results.length === 0 ? (
+          <Text dimColor>{query ? "No results found." : "No entities yet."}</Text>
+        ) : (
+          <>
+            <Text dimColor>
+              {results.length} result(s){query ? ` for "${query}"` : ""}
+            </Text>
+            <Box flexDirection="column" marginTop={1}>
+              {pageResults.map((r, i) => {
+                const globalIdx = pageStart + i;
                 const prefix = formatResultPrefix(r.entityType, r.externalId);
                 return (
-                  <Box key={i} gap={1}>
-                    <Text color={i === resultCursor ? "cyan" : undefined}>
-                      {i === resultCursor ? "❯" : " "}
+                  <Box key={globalIdx} gap={1}>
+                    <Text color={globalIdx === resultCursor ? "cyan" : undefined}>
+                      {globalIdx === resultCursor ? ">" : " "}
                     </Text>
                     {!scoped && <Text dimColor>[{r.collection}]</Text>}
                     {prefix && <Text color="cyan">{prefix}</Text>}
-                    <Text bold={i === resultCursor}>{r.title}</Text>
+                    <Text bold={globalIdx === resultCursor}>{r.title}</Text>
                   </Box>
                 );
-              })
-            )}
-          </Box>
-        </Box>
-      )}
-
-      {mode === "input" && searched && results.length === 0 && (
-        <Box marginTop={1}>
-          <Text dimColor>No results found.</Text>
-        </Box>
-      )}
+              })}
+            </Box>
+            <Text dimColor>
+              Page {currentPage + 1} of {totalPages} — ↑↓ navigate, ←→ prev/next page, Enter open, ESC back
+            </Text>
+          </>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/packages/cli/src/tui/components/SettingsView.tsx
+++ b/packages/cli/src/tui/components/SettingsView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from "react";
 import { Box, Text, useInput } from "ink";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
+import yaml from "js-yaml";
 import { getFrozenInkHome, loadConfig } from "@frozenink/core";
 import { TextInput } from "./TextInput.js";
 
@@ -77,10 +78,10 @@ export function SettingsView(): React.ReactElement {
   }, [cursor, inputValue, fields]);
 
   const saveSettings = useCallback(() => {
-    const configPath = join(getFrozenInkHome(), "config.json");
+    const configPath = join(getFrozenInkHome(), "frozenink.yml");
     let fileConfig: Record<string, unknown> = {};
     if (existsSync(configPath)) {
-      fileConfig = JSON.parse(readFileSync(configPath, "utf-8"));
+      fileConfig = (yaml.load(readFileSync(configPath, "utf-8")) as Record<string, unknown>) ?? {};
     }
 
     if (!fileConfig.sync || typeof fileConfig.sync !== "object") fileConfig.sync = {};
@@ -93,7 +94,7 @@ export function SettingsView(): React.ReactElement {
     const logging = fileConfig.logging as Record<string, unknown>;
     logging.level = settings.logLevel;
 
-    writeFileSync(configPath, JSON.stringify(fileConfig, null, 2));
+    writeFileSync(configPath, yaml.dump(fileConfig, { lineWidth: -1, noRefs: true, sortKeys: false }));
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
   }, [settings]);

--- a/packages/cli/src/tui/components/SyncView.tsx
+++ b/packages/cli/src/tui/components/SyncView.tsx
@@ -1,24 +1,18 @@
 import React, { useState, useCallback, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
-import { existsSync } from "fs";
+import { existsSync, rmSync } from "fs";
 import { join } from "path";
 import {
-  contextExists,
+  ensureInitialized,
   listCollections,
   getCollectionDb,
   getCollectionDbPath,
   getFrozenInkHome,
   entities,
-  entityTags,
-  entityLinks,
-  entityRelations,
-  attachments,
-  syncState,
   syncRuns,
   SyncEngine,
   ThemeEngine,
   LocalStorageBackend,
-  SearchIndexer,
 } from "@frozenink/core";
 import {
   createDefaultRegistry,
@@ -109,13 +103,11 @@ export function SyncView(): React.ReactElement {
     return () => clearInterval(interval);
   }, [syncStartTime]);
 
-  const initialized = contextExists();
-  const collections = initialized
-    ? listCollections().filter((c: { enabled: boolean }) => c.enabled)
-    : [];
+  ensureInitialized();
+  const collections = listCollections().filter((c: { enabled: boolean }) => c.enabled);
 
   // Initialize sync modes for new collections
-  if (initialized && syncModes.size === 0 && collections.length > 0) {
+  if (syncModes.size === 0 && collections.length > 0) {
     const initial = new Map<string, SyncMode>();
     for (const col of collections) initial.set(col.name, "skip");
     setSyncModes(initial);
@@ -189,22 +181,15 @@ export function SyncView(): React.ReactElement {
       );
 
       const dbPath = getCollectionDbPath(col.name);
+      const collectionDir = join(home, "collections", col.name);
 
       if (isFullSync) {
-        const colDb = getCollectionDb(dbPath);
-        colDb.delete(entityLinks).run();
-        colDb.delete(entityRelations).run();
-        colDb.delete(attachments).run();
-        colDb.delete(entityTags).run();
-        colDb.delete(entities).run();
-        colDb.delete(syncState).run();
-        const indexer = new SearchIndexer(dbPath);
-        indexer.clearIndex();
-        indexer.close();
+        const contentDir = join(collectionDir, "content");
+        const dbDir = join(collectionDir, "db");
+        if (existsSync(contentDir)) rmSync(contentDir, { recursive: true, force: true });
+        if (existsSync(dbDir)) rmSync(dbDir, { recursive: true, force: true });
         setProgress((p) => [...p, "  Cleared data for full re-sync"]);
       }
-
-      const collectionDir = join(home, "collections", col.name);
       const storage = new LocalStorageBackend(collectionDir);
 
       const engine = new SyncEngine({
@@ -213,7 +198,8 @@ export function SyncView(): React.ReactElement {
         collectionName: col.name,
         themeEngine,
         storage,
-        markdownBasePath: "markdown",
+        markdownBasePath: "content",
+        assetConfig: col.assets as { extensions?: string[]; maxSize?: number } | undefined,
         onBatchFetched: ({ externalIds }: { externalIds: string[] }) => {
           if (externalIds.length > 0) {
             setFetchedCount((c) => c + externalIds.length);
@@ -283,10 +269,6 @@ export function SyncView(): React.ReactElement {
       }
     }
   });
-
-  if (!initialized) {
-    return <Text color="yellow">Not initialized.</Text>;
-  }
 
   if (collections.length === 0) {
     return (

--- a/packages/core/src/compat/resources.ts
+++ b/packages/core/src/compat/resources.ts
@@ -79,7 +79,7 @@ const WRANGLER_INSTALL_URL = "https://developers.cloudflare.com/workers/wrangler
  * Resolve the wrangler binary path.
  *
  * Search order:
- * 1. User-configured path (from config.json "wranglerPath")
+ * 1. User-configured path (from frozenink.yml "wranglerPath")
  * 2. Monorepo dev: node_modules/.bin/wrangler
  * 3. System PATH: "wrangler" (via `which`)
  *
@@ -119,6 +119,6 @@ export async function resolveWrangler(moduleDir: string, configuredPath?: string
     `Wrangler CLI not found. Install it to publish to Cloudflare:\n` +
     `  npm install -g wrangler\n` +
     `Or visit: ${WRANGLER_INSTALL_URL}\n\n` +
-    `If wrangler is installed at a custom path, set "wranglerPath" in your workspace config.json.`
+    `If wrangler is installed at a custom path, set "wranglerPath" in your workspace frozenink.yml.`
   );
 }

--- a/packages/core/src/compat/sqlite.ts
+++ b/packages/core/src/compat/sqlite.ts
@@ -9,6 +9,11 @@ import { isBun } from "./runtime";
  * (exec, prepare, close).
  */
 export function openDatabase(dbPath: string): any {
+  // Ensure parent directory exists
+  const { mkdirSync } = require("fs");
+  const { dirname } = require("path");
+  mkdirSync(dirname(dbPath), { recursive: true });
+
   if (isBun) {
     const { Database } = require("bun:sqlite");
     return new Database(dbPath);

--- a/packages/core/src/config/__tests__/config.test.ts
+++ b/packages/core/src/config/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { configSchema } from "../schema";
 import { defaultConfig } from "../defaults";
@@ -29,50 +29,19 @@ afterEach(() => {
 describe("Config Schema", () => {
   it("validates a complete valid config", () => {
     const config = configSchema.parse({
-      db: { mode: "turso", tursoUrl: "https://db.turso.io", tursoToken: "tok" },
-      storage: { mode: "s3", s3Bucket: "my-bucket", s3Region: "us-east-1" },
-      sync: { interval: 600, concurrency: 4, retries: 5 },
+      sync: { interval: 600 },
       ui: { port: 8080 },
-      mcp: { transport: "sse", port: 9090 },
-      logging: { level: "debug", file: "/var/log/frozenink.log" },
     });
 
-    expect(config.db.mode).toBe("turso");
-    expect(config.db.tursoUrl).toBe("https://db.turso.io");
-    expect(config.storage.mode).toBe("s3");
-    expect(config.storage.s3Bucket).toBe("my-bucket");
     expect(config.sync.interval).toBe(600);
-    expect(config.sync.concurrency).toBe(4);
     expect(config.ui.port).toBe(8080);
-    expect(config.mcp.transport).toBe("sse");
-    expect(config.logging.level).toBe("debug");
-    expect(config.logging.file).toBe("/var/log/frozenink.log");
   });
 
   it("applies defaults for empty config", () => {
     const config = configSchema.parse({});
 
-    expect(config.db.mode).toBe("local");
-    expect(config.storage.mode).toBe("local");
     expect(config.sync.interval).toBe(900);
-    expect(config.sync.concurrency).toBe(2);
-    expect(config.sync.retries).toBe(3);
     expect(config.ui.port).toBe(3000);
-    expect(config.mcp.transport).toBe("stdio");
-    expect(config.mcp.port).toBe(3001);
-    expect(config.logging.level).toBe("info");
-  });
-
-  it("rejects invalid db mode", () => {
-    expect(() =>
-      configSchema.parse({ db: { mode: "postgres" } }),
-    ).toThrow();
-  });
-
-  it("rejects invalid logging level", () => {
-    expect(() =>
-      configSchema.parse({ logging: { level: "verbose" } }),
-    ).toThrow();
   });
 
   it("rejects negative sync interval", () => {
@@ -86,12 +55,6 @@ describe("Config Schema", () => {
       configSchema.parse({ ui: { port: 3.5 } }),
     ).toThrow();
   });
-
-  it("rejects invalid turso URL", () => {
-    expect(() =>
-      configSchema.parse({ db: { mode: "turso", tursoUrl: "not-a-url" } }),
-    ).toThrow();
-  });
 });
 
 describe("Default Config", () => {
@@ -101,12 +64,8 @@ describe("Default Config", () => {
   });
 
   it("has sensible default values", () => {
-    expect(defaultConfig.db.mode).toBe("local");
-    expect(defaultConfig.storage.mode).toBe("local");
     expect(defaultConfig.sync.interval).toBe(900);
     expect(defaultConfig.ui.port).toBe(3000);
-    expect(defaultConfig.mcp.transport).toBe("stdio");
-    expect(defaultConfig.logging.level).toBe("info");
   });
 });
 
@@ -130,59 +89,47 @@ describe("Config Loader", () => {
     mkdirSync(join(TEST_DIR, "empty"), { recursive: true });
 
     const config = loadConfig();
-    expect(config.db.mode).toBe("local");
     expect(config.sync.interval).toBe(900);
     expect(config.ui.port).toBe(3000);
   });
 
-  it("reads and merges config.json", () => {
+  it("reads and merges frozenink.yml", () => {
     const configDir = join(TEST_DIR, "with-config");
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
-      join(configDir, "config.json"),
-      JSON.stringify({
-        db: { mode: "turso", tursoUrl: "https://db.turso.io" },
-        sync: { interval: 300 },
-      }),
+      join(configDir, "frozenink.yml"),
+      "sync:\n  interval: 300\n",
     );
 
     process.env.FROZENINK_HOME = configDir;
     const config = loadConfig();
 
     // Overridden values
-    expect(config.db.mode).toBe("turso");
-    expect(config.db.tursoUrl).toBe("https://db.turso.io");
     expect(config.sync.interval).toBe(300);
 
     // Defaults preserved
-    expect(config.storage.mode).toBe("local");
     expect(config.ui.port).toBe(3000);
-    expect(config.sync.concurrency).toBe(2);
   });
 
   it("applies FROZENINK_* env var overrides", () => {
     process.env.FROZENINK_HOME = join(TEST_DIR, "env-test");
     mkdirSync(join(TEST_DIR, "env-test"), { recursive: true });
 
-    process.env.FROZENINK_DB_MODE = "turso";
     process.env.FROZENINK_SYNC_INTERVAL = "60";
     process.env.FROZENINK_UI_PORT = "8080";
-    process.env.FROZENINK_LOGGING_LEVEL = "debug";
 
     const config = loadConfig();
 
-    expect(config.db.mode).toBe("turso");
     expect(config.sync.interval).toBe(60);
     expect(config.ui.port).toBe(8080);
-    expect(config.logging.level).toBe("debug");
   });
 
-  it("env vars override config.json values", () => {
+  it("env vars override frozenink.yml values", () => {
     const configDir = join(TEST_DIR, "env-override");
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
-      join(configDir, "config.json"),
-      JSON.stringify({ ui: { port: 4000 } }),
+      join(configDir, "frozenink.yml"),
+      "ui:\n  port: 4000\n",
     );
 
     process.env.FROZENINK_HOME = configDir;
@@ -192,15 +139,20 @@ describe("Config Loader", () => {
     expect(config.ui.port).toBe(9999);
   });
 
-  it("rejects invalid config.json with clear errors", () => {
-    const configDir = join(TEST_DIR, "invalid");
+  it("migrates legacy config.json to frozenink.yml", () => {
+    const configDir = join(TEST_DIR, "migrate-config");
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
       join(configDir, "config.json"),
-      JSON.stringify({ db: { mode: "postgres" } }),
+      JSON.stringify({ sync: { interval: 500 }, ui: { port: 5000 } }),
     );
 
     process.env.FROZENINK_HOME = configDir;
-    expect(() => loadConfig()).toThrow();
+    const config = loadConfig();
+
+    expect(config.sync.interval).toBe(500);
+    expect(config.ui.port).toBe(5000);
+    // frozenink.yml should now exist
+    expect(existsSync(join(configDir, "frozenink.yml"))).toBe(true);
   });
 });

--- a/packages/core/src/config/context.ts
+++ b/packages/core/src/config/context.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, readdirSync, statSync, unlinkSync } from "fs";
 import { join, dirname } from "path";
 import { randomBytes } from "crypto";
 import { z } from "zod";
@@ -7,16 +7,73 @@ import { getFrozenInkHome } from "./loader";
 
 // --- Zod Schemas ---
 
+const assetsConfigSchema = z.object({
+  /** Allowed file extensions (with dot). Defaults to common image formats. */
+  extensions: z.array(z.string()).optional(),
+  /** Maximum file size in KB. Defaults to 10240 (10 MB). */
+  maxSize: z.number().optional(),
+}).optional();
+
 const collectionEntrySchema = z.object({
   title: z.string().optional(),
   crawler: z.string(),
   enabled: z.boolean().optional().default(true),
+  /** Crawler schema version the collection was last synced with. Defaults to "1.0". */
+  version: z.string().optional().default("1.0"),
   syncInterval: z.number().optional(),
   config: z.record(z.unknown()).default({}),
   credentials: z.record(z.unknown()).default({}),
+  assets: assetsConfigSchema,
 });
 
-const deploymentEntrySchema = z.object({
+/** Site config schema — immutable settings stored in <name>.yml */
+const siteConfigSchema = z.object({
+  url: z.string(),
+  mcpUrl: z.string(),
+  collections: z.array(z.string()),
+  database: z.object({
+    type: z.string(),
+    id: z.string(),
+    name: z.string().optional(),
+  }),
+  bucket: z.object({
+    type: z.string(),
+    name: z.string(),
+  }),
+  password: z.object({
+    protected: z.boolean(),
+    hash: z.string().optional(),
+  }).optional(),
+});
+
+/** Site state schema — mutable state stored in state.yml */
+const siteStateSchema = z.object({
+  publishedAt: z.string(),
+});
+
+/** Combined site entry for backward compatibility */
+const siteEntrySchema = z.object({
+  url: z.string(),
+  mcpUrl: z.string(),
+  collections: z.array(z.string()),
+  database: z.object({
+    type: z.string(),
+    id: z.string(),
+    name: z.string().optional(),
+  }),
+  bucket: z.object({
+    type: z.string(),
+    name: z.string(),
+  }),
+  password: z.object({
+    protected: z.boolean(),
+    hash: z.string().optional(),
+  }).optional(),
+  publishedAt: z.string(),
+});
+
+/** Legacy deployment schema — for migration from publish.yml */
+const legacyDeploymentEntrySchema = z.object({
   url: z.string(),
   mcpUrl: z.string(),
   collections: z.array(z.string()),
@@ -29,130 +86,376 @@ const deploymentEntrySchema = z.object({
   publishedAt: z.string(),
 });
 
+// Legacy context.yml schema (for migration)
 const frozenInkSchema = z.object({
   collections: z.record(collectionEntrySchema).default({}),
-  deployments: z.record(deploymentEntrySchema).default({}),
+  deployments: z.record(legacyDeploymentEntrySchema).default({}),
 });
 
 // --- Types ---
 
 export type CollectionEntry = z.infer<typeof collectionEntrySchema>;
 export type CollectionEntryInput = z.input<typeof collectionEntrySchema>;
-export type DeploymentEntry = z.infer<typeof deploymentEntrySchema>;
+export type SiteEntry = z.infer<typeof siteEntrySchema>;
+/** @deprecated Use SiteEntry */
+export type DeploymentEntry = SiteEntry;
 export type FrozenInkYaml = z.infer<typeof frozenInkSchema>;
 
 // --- Paths ---
 
-function getContextPath(): string {
+function getCollectionsDir(): string {
+  return join(getFrozenInkHome(), "collections");
+}
+
+function getCollectionConfigPath(name: string): string {
+  return join(getCollectionsDir(), name, `${name}.yml`);
+}
+
+function getSitesDir(): string {
+  return join(getFrozenInkHome(), "sites");
+}
+
+function getSiteConfigPath(name: string): string {
+  return join(getSitesDir(), name, `${name}.yml`);
+}
+
+function getSiteStatePath(name: string): string {
+  return join(getSitesDir(), name, "state.yml");
+}
+
+/** Legacy publish.yml path */
+function getLegacyPublishPath(): string {
+  return join(getFrozenInkHome(), "publish.yml");
+}
+
+/** Legacy context.yml path */
+function getLegacyContextPath(): string {
   return join(getFrozenInkHome(), "context.yml");
 }
 
-// --- Load / Save ---
+// --- Atomic YAML write ---
 
-export function loadContext(): FrozenInkYaml {
-  const contextPath = getContextPath();
-  if (!existsSync(contextPath)) {
-    return { collections: {}, deployments: {} };
-  }
-  const raw = readFileSync(contextPath, "utf-8");
-  const parsed = yaml.load(raw) as Record<string, unknown> | null;
-  return frozenInkSchema.parse(parsed ?? {});
+function atomicWriteYaml(filePath: string, data: unknown): void {
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true });
+  const content = yaml.dump(data, { lineWidth: -1, noRefs: true, sortKeys: false });
+  const tmpPath = `${filePath}.${randomBytes(4).toString("hex")}.tmp`;
+  writeFileSync(tmpPath, content, "utf-8");
+  renameSync(tmpPath, filePath);
 }
 
-export function saveContext(ctx: FrozenInkYaml): void {
-  const contextPath = getContextPath();
-  const dir = dirname(contextPath);
-  mkdirSync(dir, { recursive: true });
+function readYaml<T>(filePath: string): T | null {
+  if (!existsSync(filePath)) return null;
+  const raw = readFileSync(filePath, "utf-8");
+  return (yaml.load(raw) as T) ?? null;
+}
 
-  const content = yaml.dump(ctx, { lineWidth: -1, noRefs: true, sortKeys: false });
-  // Atomic write: write to temp file then rename
-  const tmpPath = `${contextPath}.${randomBytes(4).toString("hex")}.tmp`;
-  writeFileSync(tmpPath, content, "utf-8");
-  renameSync(tmpPath, contextPath);
+// --- Migration from legacy context.yml ---
+
+/**
+ * Migrate legacy context.yml to per-collection .config files and publish.yml.
+ * Safe to call multiple times — skips if already migrated.
+ */
+export function migrateFromLegacyContext(): void {
+  const legacyPath = getLegacyContextPath();
+  if (!existsSync(legacyPath)) return;
+
+  const raw = readFileSync(legacyPath, "utf-8");
+  const parsed = yaml.load(raw) as Record<string, unknown> | null;
+  if (!parsed) return;
+
+  const ctx = frozenInkSchema.parse(parsed);
+
+  // Migrate collections to per-collection config files
+  for (const [name, entry] of Object.entries(ctx.collections)) {
+    const configPath = getCollectionConfigPath(name);
+    const colDir = dirname(configPath);
+    if (!existsSync(colDir)) {
+      mkdirSync(colDir, { recursive: true });
+    }
+    // Migrate legacy .config -> <name>.yml
+    const legacyConfigPath = join(colDir, ".config");
+    if (existsSync(legacyConfigPath) && !existsSync(configPath)) {
+      renameSync(legacyConfigPath, configPath);
+    } else if (!existsSync(configPath)) {
+      atomicWriteYaml(configPath, entry);
+    }
+  }
+
+  // Also migrate any existing collections that only have .config files
+  const collectionsDir = getCollectionsDir();
+  if (existsSync(collectionsDir)) {
+    for (const name of readdirSync(collectionsDir)) {
+      const colDir = join(collectionsDir, name);
+      try { if (!statSync(colDir).isDirectory()) continue; } catch { continue; }
+      const legacyConfigPath = join(colDir, ".config");
+      const newConfigPath = join(colDir, `${name}.yml`);
+      if (existsSync(legacyConfigPath) && !existsSync(newConfigPath)) {
+        renameSync(legacyConfigPath, newConfigPath);
+      }
+    }
+  }
+
+  // Migrate deployments from context.yml to sites/ directory
+  for (const [name, dep] of Object.entries(ctx.deployments)) {
+    if (!existsSync(getSiteConfigPath(name))) {
+      addSite(name, {
+        url: dep.url,
+        mcpUrl: dep.mcpUrl,
+        collections: dep.collections,
+        database: { type: "cloudflare-d1", id: dep.d1DatabaseId, name: dep.d1DatabaseName },
+        bucket: { type: "cloudflare-r2", name: dep.r2BucketName },
+        password: { protected: dep.passwordProtected, hash: dep.passwordHash },
+        publishedAt: dep.publishedAt,
+      });
+    }
+  }
+
+  // Remove legacy context.yml
+  try { unlinkSync(legacyPath); } catch { /* ignore */ }
+
+  // Clean up legacy master.db files
+  const home = getFrozenInkHome();
+  for (const f of ["master.db", "master.db-wal", "master.db-shm"]) {
+    try { unlinkSync(join(home, f)); } catch { /* ignore */ }
+  }
+
+  // Migrate legacy publish.yml to sites/ directory
+  migrateLegacyPublishYml();
+}
+
+/** Migrate legacy publish.yml to sites/ directory. Safe to call multiple times. */
+function migrateLegacyPublishYml(): void {
+  const publishPath = getLegacyPublishPath();
+  if (!existsSync(publishPath)) return;
+
+  const data = readYaml<Record<string, unknown>>(publishPath);
+  if (!data) return;
+
+  for (const [name, raw] of Object.entries(data)) {
+    if (existsSync(getSiteConfigPath(name))) continue;
+    try {
+      const dep = legacyDeploymentEntrySchema.parse(raw);
+      addSite(name, {
+        url: dep.url,
+        mcpUrl: dep.mcpUrl,
+        collections: dep.collections,
+        database: { type: "cloudflare-d1", id: dep.d1DatabaseId, name: dep.d1DatabaseName },
+        bucket: { type: "cloudflare-r2", name: dep.r2BucketName },
+        password: { protected: dep.passwordProtected, hash: dep.passwordHash },
+        publishedAt: dep.publishedAt,
+      });
+    } catch { /* skip invalid entries */ }
+  }
+
+  // Remove legacy publish.yml
+  try { unlinkSync(publishPath); } catch { /* ignore */ }
+}
+
+// --- Initialization ---
+
+/**
+ * Ensure the Frozen Ink home directory is initialized.
+ * Creates collections/ and sites/ directories if they don't exist.
+ * Also runs legacy migrations. Safe to call multiple times.
+ */
+export function ensureInitialized(): void {
+  const home = getFrozenInkHome();
+  mkdirSync(home, { recursive: true });
+  mkdirSync(join(home, "collections"), { recursive: true });
+  mkdirSync(join(home, "sites"), { recursive: true });
+  // Create default frozenink.yml if it doesn't exist (and no legacy config.json)
+  const configPath = join(home, "frozenink.yml");
+  const legacyConfigPath = join(home, "config.json");
+  if (!existsSync(configPath) && !existsSync(legacyConfigPath)) {
+    atomicWriteYaml(configPath, { sync: { interval: 900 }, ui: { port: 3000 } });
+  }
+  migrateFromLegacyContext();
 }
 
 export function contextExists(): boolean {
-  return existsSync(getContextPath());
+  const home = getFrozenInkHome();
+  return existsSync(join(home, "collections"));
+}
+
+// --- Legacy compat: loadContext / saveContext ---
+
+export function loadContext(): FrozenInkYaml {
+  return {
+    collections: Object.fromEntries(
+      listCollections().map((c) => {
+        const { name, ...entry } = c;
+        return [name, entry];
+      }),
+    ),
+    deployments: {},
+  };
+}
+
+export function saveContext(_ctx: FrozenInkYaml): void {
+  // No-op: kept for backward compat.
 }
 
 // --- Collection CRUD ---
 
 export function getCollection(name: string): (CollectionEntry & { name: string }) | null {
-  const ctx = loadContext();
-  const entry = ctx.collections[name];
-  if (!entry) return null;
-  return { ...entry, name };
+  const configPath = getCollectionConfigPath(name);
+  if (!existsSync(configPath)) return null;
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    const parsed = yaml.load(raw) as Record<string, unknown> | null;
+    if (!parsed) return null;
+    const entry = collectionEntrySchema.parse(parsed);
+    return { ...entry, name };
+  } catch {
+    return null;
+  }
 }
 
 export function listCollections(): Array<CollectionEntry & { name: string }> {
-  const ctx = loadContext();
-  return Object.entries(ctx.collections).map(([name, entry]) => ({ ...entry, name }));
+  const collectionsDir = getCollectionsDir();
+  if (!existsSync(collectionsDir)) return [];
+
+  const results: Array<CollectionEntry & { name: string }> = [];
+  try {
+    const entries = readdirSync(collectionsDir);
+    for (const name of entries) {
+      const dirPath = join(collectionsDir, name);
+      try {
+        if (!statSync(dirPath).isDirectory()) continue;
+      } catch { continue; }
+
+      const configPath = join(dirPath, `${name}.yml`);
+      if (!existsSync(configPath)) continue;
+
+      try {
+        const raw = readFileSync(configPath, "utf-8");
+        const parsed = yaml.load(raw) as Record<string, unknown> | null;
+        if (!parsed) continue;
+        const entry = collectionEntrySchema.parse(parsed);
+        results.push({ ...entry, name });
+      } catch { /* skip invalid entries */ }
+    }
+  } catch { /* ignore */ }
+
+  return results.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export function getCollectionDbPath(name: string): string {
   const home = getFrozenInkHome();
-  return join(home, "collections", name, "data.db");
+  return join(home, "collections", name, "db", "data.db");
 }
 
 export function addCollection(name: string, entry: CollectionEntryInput): void {
-  const ctx = loadContext();
-  ctx.collections[name] = collectionEntrySchema.parse(entry);
-  saveContext(ctx);
+  const parsed = collectionEntrySchema.parse(entry);
+  const colDir = join(getCollectionsDir(), name);
+  mkdirSync(colDir, { recursive: true });
+  atomicWriteYaml(getCollectionConfigPath(name), parsed);
 }
 
 export function removeCollection(name: string): void {
-  const ctx = loadContext();
-  delete ctx.collections[name];
-  saveContext(ctx);
+  // Only removes the config file; the caller is responsible for deleting the directory.
+  const configPath = getCollectionConfigPath(name);
+  try { unlinkSync(configPath); } catch { /* ignore */ }
 }
 
 export function updateCollection(name: string, updates: Partial<CollectionEntry>): void {
-  const ctx = loadContext();
-  const existing = ctx.collections[name];
+  const existing = getCollection(name);
   if (!existing) return;
-  ctx.collections[name] = { ...existing, ...updates };
-  saveContext(ctx);
+  const { name: _name, ...entry } = existing;
+  const updated = { ...entry, ...updates };
+  atomicWriteYaml(getCollectionConfigPath(name), updated);
 }
 
 export function renameCollection(oldName: string, newName: string): void {
-  const ctx = loadContext();
-  const entry = ctx.collections[oldName];
-  if (!entry) return;
-  delete ctx.collections[oldName];
-  ctx.collections[newName] = entry;
-  saveContext(ctx);
+  const existing = getCollection(oldName);
+  if (!existing) return;
+  const { name: _name, ...entry } = existing;
+  // Write new config, remove old config
+  const newDir = join(getCollectionsDir(), newName);
+  mkdirSync(newDir, { recursive: true });
+  atomicWriteYaml(getCollectionConfigPath(newName), entry);
+  try { unlinkSync(getCollectionConfigPath(oldName)); } catch { /* ignore */ }
 }
 
-// --- Deployment CRUD ---
+// --- Site CRUD (sites/<name>/) ---
 
-export function addDeployment(name: string, entry: DeploymentEntry): void {
-  const ctx = loadContext();
-  ctx.deployments[name] = entry;
-  saveContext(ctx);
+export function addSite(name: string, entry: SiteEntry): void {
+  const { publishedAt, ...config } = entry;
+  const siteDir = join(getSitesDir(), name);
+  mkdirSync(siteDir, { recursive: true });
+  atomicWriteYaml(getSiteConfigPath(name), config);
+  atomicWriteYaml(getSiteStatePath(name), { publishedAt });
 }
 
-export function removeDeployment(name: string): void {
-  const ctx = loadContext();
-  delete ctx.deployments[name];
-  saveContext(ctx);
+export function removeSite(name: string): void {
+  const siteDir = join(getSitesDir(), name);
+  if (existsSync(siteDir)) {
+    const { rmSync } = require("fs");
+    rmSync(siteDir, { recursive: true, force: true });
+  }
 }
 
-export function getDeployment(nameOrUrl: string): (DeploymentEntry & { name: string }) | null {
-  const ctx = loadContext();
+export function getSite(nameOrUrl: string): (SiteEntry & { name: string }) | null {
   // Try by name first
-  if (ctx.deployments[nameOrUrl]) {
-    return { ...ctx.deployments[nameOrUrl], name: nameOrUrl };
+  const configPath = getSiteConfigPath(nameOrUrl);
+  if (existsSync(configPath)) {
+    try {
+      const configRaw = readFileSync(configPath, "utf-8");
+      const config = yaml.load(configRaw) as Record<string, unknown> | null;
+      if (!config) return null;
+      const stateRaw = readYaml<Record<string, unknown>>(getSiteStatePath(nameOrUrl));
+      const publishedAt = (stateRaw?.publishedAt as string) ?? new Date().toISOString();
+      const parsed = siteEntrySchema.parse({ ...config, publishedAt });
+      return { ...parsed, name: nameOrUrl };
+    } catch { return null; }
   }
   // Try by URL
-  for (const [name, entry] of Object.entries(ctx.deployments)) {
-    if (entry.url === nameOrUrl || entry.mcpUrl === nameOrUrl) {
-      return { ...entry, name };
+  for (const site of listSites()) {
+    if (site.url === nameOrUrl || site.mcpUrl === nameOrUrl) {
+      return site;
     }
   }
   return null;
 }
 
-export function listDeployments(): Array<DeploymentEntry & { name: string }> {
-  const ctx = loadContext();
-  return Object.entries(ctx.deployments).map(([name, entry]) => ({ ...entry, name }));
+export function listSites(): Array<SiteEntry & { name: string }> {
+  const sitesDir = getSitesDir();
+  if (!existsSync(sitesDir)) return [];
+
+  const results: Array<SiteEntry & { name: string }> = [];
+  try {
+    for (const name of readdirSync(sitesDir)) {
+      const dirPath = join(sitesDir, name);
+      try { if (!statSync(dirPath).isDirectory()) continue; } catch { continue; }
+      const configPath = join(dirPath, `${name}.yml`);
+      if (!existsSync(configPath)) continue;
+      try {
+        const configRaw = readFileSync(configPath, "utf-8");
+        const config = yaml.load(configRaw) as Record<string, unknown> | null;
+        if (!config) continue;
+        const stateRaw = readYaml<Record<string, unknown>>(join(dirPath, "state.yml"));
+        const publishedAt = (stateRaw?.publishedAt as string) ?? new Date().toISOString();
+        const parsed = siteEntrySchema.parse({ ...config, publishedAt });
+        results.push({ ...parsed, name });
+      } catch { /* skip invalid */ }
+    }
+  } catch { /* ignore */ }
+
+  return results.sort((a, b) => a.name.localeCompare(b.name));
 }
+
+export function updateSiteState(name: string, state: { publishedAt: string }): void {
+  atomicWriteYaml(getSiteStatePath(name), state);
+}
+
+// --- Deprecated aliases for backward compat ---
+
+/** @deprecated Use addSite */
+export const addDeployment = addSite;
+/** @deprecated Use removeSite */
+export const removeDeployment = removeSite;
+/** @deprecated Use getSite */
+export const getDeployment = getSite;
+/** @deprecated Use listSites */
+export const listDeployments = listSites;

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -1,33 +1,10 @@
 import type { FrozenInkConfig } from "./schema";
 
 export const defaultConfig: FrozenInkConfig = {
-  db: {
-    mode: "local",
-    tursoUrl: undefined,
-    tursoToken: undefined,
-  },
-  storage: {
-    mode: "local",
-    s3Bucket: undefined,
-    s3Region: undefined,
-    s3Endpoint: undefined,
-    s3AccessKeyId: undefined,
-    s3SecretAccessKey: undefined,
-  },
   sync: {
     interval: 900,
-    concurrency: 2,
-    retries: 3,
   },
   ui: {
     port: 3000,
-  },
-  mcp: {
-    transport: "stdio",
-    port: 3001,
-  },
-  logging: {
-    level: "info",
-    file: undefined,
   },
 };

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,10 +1,12 @@
-export { configSchema, type FrozenInkConfig, type DbConfig, type StorageConfig, type SyncConfig, type UiConfig, type McpConfig, type LoggingConfig } from "./schema";
+export { configSchema, type FrozenInkConfig, type SyncConfig, type UiConfig } from "./schema";
 export { defaultConfig } from "./defaults";
 export { loadConfig, getFrozenInkHome } from "./loader";
 export {
   loadContext,
   saveContext,
   contextExists,
+  ensureInitialized,
+  migrateFromLegacyContext,
   getCollection,
   listCollections,
   getCollectionDbPath,
@@ -12,12 +14,19 @@ export {
   removeCollection,
   updateCollection,
   renameCollection,
+  addSite,
+  removeSite,
+  getSite,
+  listSites,
+  updateSiteState,
+  // Deprecated aliases
   addDeployment,
   removeDeployment,
   getDeployment,
   listDeployments,
   type CollectionEntry,
   type CollectionEntryInput,
+  type SiteEntry,
   type DeploymentEntry,
   type FrozenInkYaml,
 } from "./context";

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, renameSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+import yaml from "js-yaml";
 import { configSchema, type FrozenInkConfig } from "./schema";
 import { defaultConfig } from "./defaults";
 
@@ -33,29 +34,12 @@ function deepMerge(target: Record<string, unknown>, source: Record<string, unkno
 }
 
 const ENV_MAPPING: Record<string, [keyof FrozenInkConfig, string]> = {
-  FROZENINK_DB_MODE: ["db", "mode"],
-  FROZENINK_DB_TURSO_URL: ["db", "tursoUrl"],
-  FROZENINK_DB_TURSO_TOKEN: ["db", "tursoToken"],
-  FROZENINK_STORAGE_MODE: ["storage", "mode"],
-  FROZENINK_STORAGE_S3_BUCKET: ["storage", "s3Bucket"],
-  FROZENINK_STORAGE_S3_REGION: ["storage", "s3Region"],
-  FROZENINK_STORAGE_S3_ENDPOINT: ["storage", "s3Endpoint"],
-  FROZENINK_STORAGE_S3_ACCESS_KEY_ID: ["storage", "s3AccessKeyId"],
-  FROZENINK_STORAGE_S3_SECRET_ACCESS_KEY: ["storage", "s3SecretAccessKey"],
   FROZENINK_SYNC_INTERVAL: ["sync", "interval"],
-  FROZENINK_SYNC_CONCURRENCY: ["sync", "concurrency"],
-  FROZENINK_SYNC_RETRIES: ["sync", "retries"],
   FROZENINK_UI_PORT: ["ui", "port"],
-  FROZENINK_MCP_TRANSPORT: ["mcp", "transport"],
-  FROZENINK_MCP_PORT: ["mcp", "port"],
-  FROZENINK_LOGGING_LEVEL: ["logging", "level"],
-  FROZENINK_LOGGING_FILE: ["logging", "file"],
 };
 
 const NUMERIC_FIELDS = new Set([
   "interval",
-  "concurrency",
-  "retries",
   "port",
 ]);
 
@@ -79,12 +63,25 @@ function applyEnvOverrides(config: Record<string, unknown>): Record<string, unkn
 
 export function loadConfig(): FrozenInkConfig {
   const home = getFrozenInkHome();
-  const configPath = join(home, "config.json");
+  const ymlPath = join(home, "frozenink.yml");
+  const legacyJsonPath = join(home, "config.json");
+
+  // Migrate legacy config.json → frozenink.yml
+  if (!existsSync(ymlPath) && existsSync(legacyJsonPath)) {
+    try {
+      const raw = readFileSync(legacyJsonPath, "utf-8");
+      const data = JSON.parse(raw);
+      const ymlContent = yaml.dump(data, { lineWidth: -1, noRefs: true, sortKeys: false });
+      const { writeFileSync } = require("fs");
+      writeFileSync(ymlPath, ymlContent, "utf-8");
+      try { renameSync(legacyJsonPath, `${legacyJsonPath}.bak`); } catch { /* ignore */ }
+    } catch { /* ignore migration errors */ }
+  }
 
   let fileConfig: Record<string, unknown> = {};
-  if (existsSync(configPath)) {
-    const raw = readFileSync(configPath, "utf-8");
-    fileConfig = JSON.parse(raw) as Record<string, unknown>;
+  if (existsSync(ymlPath)) {
+    const raw = readFileSync(ymlPath, "utf-8");
+    fileConfig = (yaml.load(raw) as Record<string, unknown>) ?? {};
   }
 
   const merged = deepMerge(

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -1,53 +1,18 @@
 import { z } from "zod";
 
-export const dbConfigSchema = z.object({
-  mode: z.enum(["local", "turso"]).default("local"),
-  tursoUrl: z.string().url().optional(),
-  tursoToken: z.string().optional(),
-});
-
-export const storageConfigSchema = z.object({
-  mode: z.enum(["local", "s3"]).default("local"),
-  s3Bucket: z.string().optional(),
-  s3Region: z.string().optional(),
-  s3Endpoint: z.string().url().optional(),
-  s3AccessKeyId: z.string().optional(),
-  s3SecretAccessKey: z.string().optional(),
-});
-
 export const syncConfigSchema = z.object({
   interval: z.number().int().positive().default(900),
-  concurrency: z.number().int().positive().default(2),
-  retries: z.number().int().nonnegative().default(3),
 });
 
 export const uiConfigSchema = z.object({
   port: z.number().int().positive().default(3000),
 });
 
-export const mcpConfigSchema = z.object({
-  transport: z.enum(["stdio", "sse"]).default("stdio"),
-  port: z.number().int().positive().default(3001),
-});
-
-export const loggingConfigSchema = z.object({
-  level: z.enum(["debug", "info", "warn", "error"]).default("info"),
-  file: z.string().optional(),
-});
-
 export const configSchema = z.object({
-  db: dbConfigSchema.default({}),
-  storage: storageConfigSchema.default({}),
   sync: syncConfigSchema.default({}),
   ui: uiConfigSchema.default({}),
-  mcp: mcpConfigSchema.default({}),
-  logging: loggingConfigSchema.default({}),
 });
 
 export type FrozenInkConfig = z.infer<typeof configSchema>;
-export type DbConfig = z.infer<typeof dbConfigSchema>;
-export type StorageConfig = z.infer<typeof storageConfigSchema>;
 export type SyncConfig = z.infer<typeof syncConfigSchema>;
 export type UiConfig = z.infer<typeof uiConfigSchema>;
-export type McpConfig = z.infer<typeof mcpConfigSchema>;
-export type LoggingConfig = z.infer<typeof loggingConfigSchema>;

--- a/packages/core/src/crawler/__tests__/sync-engine.test.ts
+++ b/packages/core/src/crawler/__tests__/sync-engine.test.ts
@@ -6,9 +6,10 @@ import { SyncEngine } from "../sync-engine";
 import { getCollectionDb } from "../../db/client";
 import {
   entities,
+  tags,
   entityTags,
-  attachments,
-  entityLinks,
+  assets,
+  links,
   syncState,
   syncRuns,
 } from "../../db/collection-schema";
@@ -389,16 +390,16 @@ describe("SyncEngine", () => {
     await engine.run();
 
     // Check attachment was stored
-    const storedContent = await storage.read("attachments/att-1/image.png");
+    const storedContent = await storage.read("content/doc/assets/image.png");
     expect(storedContent).toBe("fake-png-data");
 
     // Check attachment record in DB
     const db = getCollectionDb(dbPath);
-    const atts = db.select().from(attachments).all();
+    const atts = db.select().from(assets).all();
     expect(atts).toHaveLength(1);
     expect(atts[0].filename).toBe("image.png");
     expect(atts[0].mimeType).toBe("image/png");
-    expect(atts[0].storagePath).toBe("attachments/att-1/image.png");
+    expect(atts[0].storagePath).toBe("content/doc/assets/image.png");
   });
 
   it("updates sync_state with latest cursor", async () => {
@@ -548,9 +549,13 @@ describe("SyncEngine", () => {
     await engine.run();
 
     const db = getCollectionDb(dbPath);
-    const tags = db.select().from(entityTags).all();
-    expect(tags).toHaveLength(3);
-    expect(tags.map((t) => t.tag).sort()).toEqual(["bug", "critical", "frontend"]);
+    const entityTagRows = db.select().from(entityTags).all();
+    expect(entityTagRows).toHaveLength(3);
+    const tagRows = db.select().from(tags).all();
+    const tagNames = entityTagRows
+      .map((et) => tagRows.find((t) => t.id === et.tagId)!.name)
+      .sort();
+    expect(tagNames).toEqual(["bug", "critical", "frontend"]);
   });
 
   it("reconcile: deletes orphaned markdown files not in DB", async () => {
@@ -727,8 +732,8 @@ describe("SyncEngine", () => {
     await engine.run();
 
     // Manually create an orphaned attachment file
-    await storage.write("attachments/orphan/stale.png", Buffer.from("orphan-data"));
-    expect(await storage.exists("attachments/orphan/stale.png")).toBe(true);
+    await storage.write("content/doc/assets/stale.png", Buffer.from("orphan-data"));
+    expect(await storage.exists("content/doc/assets/stale.png")).toBe(true);
 
     // Run sync again — reconcile should clean up
     const crawler2 = createMockCrawler([
@@ -764,9 +769,9 @@ describe("SyncEngine", () => {
     await engine2.run();
 
     // Orphaned attachment should be gone
-    expect(await storage.exists("attachments/orphan/stale.png")).toBe(false);
+    expect(await storage.exists("content/doc/assets/stale.png")).toBe(false);
     // Legitimate attachment should still exist
-    expect(await storage.exists("attachments/att-keep/real.png")).toBe(true);
+    expect(await storage.exists("content/doc/assets/real.png")).toBe(true);
   });
 
   it("reconcile: cleans up attachment DB records for missing files", async () => {
@@ -806,10 +811,10 @@ describe("SyncEngine", () => {
     await engine.run();
 
     const db = getCollectionDb(dbPath);
-    expect(db.select().from(attachments).all()).toHaveLength(1);
+    expect(db.select().from(assets).all()).toHaveLength(1);
 
     // Manually delete the attachment file from disk
-    await storage.delete("attachments/att-clean/gone.png");
+    await storage.delete("content/doc/assets/gone.png");
 
     // Run sync again with no attachments (so DB record stays from first sync)
     const crawler2 = createMockCrawler([
@@ -838,7 +843,7 @@ describe("SyncEngine", () => {
     await engine2.run();
 
     // DB attachment record should be cleaned up since file is missing
-    expect(db.select().from(attachments).all()).toHaveLength(0);
+    expect(db.select().from(assets).all()).toHaveLength(0);
   });
 
   it("reconcile: restores user-modified markdown files to expected content", async () => {
@@ -928,17 +933,17 @@ describe("SyncEngine", () => {
 
     // Simulate tool-generated index files inside the output directory
     await storage.write("md/.obsidian/workspace.json", '{"main":true}');
-    await storage.write("attachments/.git/config", "[core]");
+    await storage.write("content/assets/.git/config", "[core]");
 
     await engine.run();
 
     // Tool files must not be touched
     expect(await storage.exists("md/.obsidian/workspace.json")).toBe(true);
-    expect(await storage.exists("attachments/.git/config")).toBe(true);
+    expect(await storage.exists("content/assets/.git/config")).toBe(true);
   });
 
-  it("extracts wikilinks from rendered markdown and stores them as entity_links", async () => {
-    // Create a theme that generates wikilinks
+  it("extracts wikilinks from rendered markdown and stores them as links", async () => {
+    // Create a theme that generates wikilinks to entities that exist
     const linkTheme: Theme = {
       crawlerType: "linktest",
       render(ctx: ThemeRenderContext): string {
@@ -960,6 +965,18 @@ describe("SyncEngine", () => {
             title: "Linker Note",
             data: { text: "links to others" },
           },
+          {
+            externalId: "other-note",
+            entityType: "note",
+            title: "Other Note",
+            data: { text: "target 1" },
+          },
+          {
+            externalId: "another",
+            entityType: "note",
+            title: "Another Note",
+            data: { text: "target 2" },
+          },
         ],
         nextCursor: null,
         hasMore: false,
@@ -979,18 +996,21 @@ describe("SyncEngine", () => {
     await engine.run();
 
     const db = getCollectionDb(dbPath);
-    const links = db.select().from(entityLinks).all();
+    const allEntities = db.select().from(entities).all();
+    const linkerEntity = allEntities.find((e) => e.externalId === "linker-1")!;
+    const otherEntity = allEntities.find((e) => e.externalId === "other-note")!;
+    const anotherEntity = allEntities.find((e) => e.externalId === "another")!;
 
-    // Should have 2 links: note/other-note and note/another
-    expect(links).toHaveLength(2);
-    const targets = links.map((l) => l.targetPath).sort();
-    expect(targets).toEqual(["md/note/another.md", "md/note/other-note.md"]);
+    const linkRows = db.select().from(links).all();
 
-    // Source path should be the entity's markdown path
-    expect(links[0].sourceMarkdownPath).toBe("md/note/linker-1.md");
+    // Should have 2 links from linker-1 to the two target entities
+    const linkerLinks = linkRows.filter((l) => l.sourceEntityId === linkerEntity.id);
+    expect(linkerLinks).toHaveLength(2);
+    const targetIds = linkerLinks.map((l) => l.targetEntityId).sort();
+    expect(targetIds).toEqual([otherEntity.id, anotherEntity.id].sort());
   });
 
-  it("cleans up entity_links when an entity is deleted", async () => {
+  it("cleans up links when an entity is deleted", async () => {
     const linkTheme: Theme = {
       crawlerType: "linktest",
       render(ctx: ThemeRenderContext): string {
@@ -1003,7 +1023,7 @@ describe("SyncEngine", () => {
     const linkEngine = new ThemeEngine();
     linkEngine.register(linkTheme);
 
-    // First sync: create entity with links
+    // First sync: create entity with links (including the target)
     const crawler1 = createMockCrawler([
       {
         entities: [
@@ -1011,6 +1031,12 @@ describe("SyncEngine", () => {
             externalId: "delme-1",
             entityType: "note",
             title: "Delete Me",
+            data: {},
+          },
+          {
+            externalId: "target",
+            entityType: "note",
+            title: "Target",
             data: {},
           },
         ],
@@ -1032,12 +1058,19 @@ describe("SyncEngine", () => {
     await engine1.run();
 
     const db = getCollectionDb(dbPath);
-    expect(db.select().from(entityLinks).all()).toHaveLength(1);
+    expect(db.select().from(links).all()).toHaveLength(1);
 
-    // Second sync: delete the entity
+    // Second sync: delete the source entity
     const crawler2 = createMockCrawler([
       {
-        entities: [],
+        entities: [
+          {
+            externalId: "target",
+            entityType: "note",
+            title: "Target",
+            data: {},
+          },
+        ],
         nextCursor: null,
         hasMore: false,
         deletedExternalIds: ["delme-1"],
@@ -1054,6 +1087,6 @@ describe("SyncEngine", () => {
     await engine2.run();
 
     // Links should be cleaned up
-    expect(db.select().from(entityLinks).all()).toHaveLength(0);
+    expect(db.select().from(links).all()).toHaveLength(0);
   });
 });

--- a/packages/core/src/crawler/interface.ts
+++ b/packages/core/src/crawler/interface.ts
@@ -35,6 +35,8 @@ export interface CrawlerMetadata {
   description: string;
   configSchema: Record<string, unknown>;
   credentialFields: string[];
+  /** Crawler schema version. Major bump = full re-sync required; minor bump = re-render markdown. Defaults to "1.0". */
+  version?: string;
 }
 
 export interface Crawler {

--- a/packages/core/src/crawler/sync-engine.ts
+++ b/packages/core/src/crawler/sync-engine.ts
@@ -3,12 +3,12 @@ import { createCryptoHasher } from "../compat/crypto";
 import { getCollectionDb } from "../db/client";
 import {
   entities,
+  tags,
   entityTags,
-  attachments,
+  assets,
   syncState,
   syncRuns,
-  entityRelations,
-  entityLinks,
+  links,
 } from "../db/collection-schema";
 import { SearchIndexer } from "../search/indexer";
 import type { Crawler, CrawlerEntityData, SyncCursor } from "./interface";
@@ -49,6 +49,21 @@ function computeHash(data: Record<string, unknown>): string {
   return hasher.digest("hex");
 }
 
+/** Default file extensions allowed for asset downloads. */
+const DEFAULT_ASSET_EXTENSIONS = [
+  ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".ico", ".avif", ".pdf",
+];
+
+/** Default max asset size: 10 MB in KB. */
+const DEFAULT_ASSET_MAX_SIZE_KB = 10240;
+
+export interface AssetConfig {
+  /** Allowed file extensions (with dot). */
+  extensions?: string[];
+  /** Maximum file size in KB. */
+  maxSize?: number;
+}
+
 export interface SyncEngineOptions {
   crawler: Crawler;
   dbPath: string;
@@ -56,6 +71,8 @@ export interface SyncEngineOptions {
   themeEngine: ThemeEngine;
   storage: StorageBackend;
   markdownBasePath: string;
+  /** Asset download filtering config. */
+  assetConfig?: AssetConfig;
   onEntityProcessed?: (info: {
     collectionName: string;
     externalId: string;
@@ -65,7 +82,10 @@ export interface SyncEngineOptions {
   onBatchFetched?: (info: {
     collectionName: string;
     externalIds: string[];
+    entityTypes: string[];
   }) => void;
+  /** Called after a successful sync with the crawler version, so callers can update .config. */
+  onVersionUpdate?: (version: string) => void;
 }
 
 export class SyncEngine {
@@ -76,8 +96,23 @@ export class SyncEngine {
   private storage: StorageBackend;
   private markdownBasePath: string;
   private searchIndexer: SearchIndexer;
+  private allowedExtensions: Set<string>;
+  private maxAssetSizeBytes: number;
   private onEntityProcessed?: SyncEngineOptions["onEntityProcessed"];
   private onBatchFetched?: SyncEngineOptions["onBatchFetched"];
+  private onVersionUpdate?: SyncEngineOptions["onVersionUpdate"];
+
+  /**
+   * Check version compatibility between a collection and crawler.
+   * Returns "compatible" (same major), "rerender" (same major, different minor), or "full-sync" (different major).
+   */
+  static checkVersionCompat(collectionVersion: string, crawlerVersion: string): "compatible" | "rerender" | "full-sync" {
+    const [colMajor, colMinor] = (collectionVersion || "1.0").split(".").map(Number);
+    const [crwMajor, crwMinor] = (crawlerVersion || "1.0").split(".").map(Number);
+    if (colMajor !== crwMajor) return "full-sync";
+    if (colMinor !== crwMinor) return "rerender";
+    return "compatible";
+  }
 
   constructor(options: SyncEngineOptions) {
     this.crawler = options.crawler;
@@ -87,8 +122,14 @@ export class SyncEngine {
     this.storage = options.storage;
     this.markdownBasePath = options.markdownBasePath;
     this.searchIndexer = new SearchIndexer(options.dbPath);
+    const ac = options.assetConfig;
+    this.allowedExtensions = new Set(
+      (ac?.extensions ?? DEFAULT_ASSET_EXTENSIONS).map((e) => e.toLowerCase()),
+    );
+    this.maxAssetSizeBytes = (ac?.maxSize ?? DEFAULT_ASSET_MAX_SIZE_KB) * 1024;
     this.onEntityProcessed = options.onEntityProcessed;
     this.onBatchFetched = options.onBatchFetched;
+    this.onVersionUpdate = options.onVersionUpdate;
   }
 
   async run(options?: { syncType?: "full" | "incremental" }): Promise<{ created: number; updated: number; deleted: number }> {
@@ -122,6 +163,20 @@ export class SyncEngine {
         .all();
       let cursor: SyncCursor | null = (stateRow?.cursor as SyncCursor) ?? null;
 
+      // Version check: compare stored version with crawler's current version
+      const currentVersion = this.crawler.metadata.version ?? "1.0";
+      const storedVersion = (stateRow as any)?.crawlerVersion ?? "1.0";
+      const [curMajor, curMinor] = currentVersion.split(".").map(Number);
+      const [stoMajor, stoMinor] = storedVersion.split(".").map(Number);
+
+      if (curMajor !== stoMajor) {
+        // Major version change: force full re-sync (clear cursor)
+        cursor = null;
+      } else if (curMinor !== stoMinor) {
+        // Minor version change: re-render all markdown from stored entity data
+        await this.reRenderAllEntities(crawlerType);
+      }
+
       // Sync loop
       let hasMore = true;
       while (hasMore) {
@@ -129,11 +184,13 @@ export class SyncEngine {
         this.onBatchFetched?.({
           collectionName: this.collectionName,
           externalIds: result.entities.map((e) => e.externalId),
+          entityTypes: result.entities.map((e) => e.entityType),
         });
 
-        // Process entities
+        // Process entities (links are deferred until all entities exist)
+        const deferredLinks: Array<{ entityId: number; markdown: string }> = [];
         for (const entityData of result.entities) {
-          const counts = await this.upsertEntity(entityData, crawlerType);
+          const counts = await this.upsertEntity(entityData, crawlerType, deferredLinks);
           created += counts.created;
           updated += counts.updated;
           this.onEntityProcessed?.({
@@ -142,6 +199,11 @@ export class SyncEngine {
             created: counts.created > 0,
             updated: counts.updated > 0,
           });
+        }
+
+        // Sync links now that all entities in the batch exist
+        for (const { entityId, markdown } of deferredLinks) {
+          this.syncLinks(entityId, markdown);
         }
 
         // Handle deletions
@@ -158,24 +220,35 @@ export class SyncEngine {
         hasMore = result.hasMore;
       }
 
-      // Persist cursor
+      // Persist cursor and version
+      const now = new Date().toISOString().replace("T", " ").replace("Z", "");
       if (cursor) {
         if (stateRow) {
           this.db
             .update(syncState)
-            .set({ cursor: cursor as Record<string, unknown>, updatedAt: new Date().toISOString().replace("T", " ").replace("Z", "") })
+            .set({ cursor: cursor as Record<string, unknown>, crawlerVersion: currentVersion, updatedAt: now })
             .where(eq(syncState.id, stateRow.id))
             .run();
         } else {
           this.db
             .insert(syncState)
-            .values({ crawlerType, cursor: cursor as Record<string, unknown> })
+            .values({ crawlerType, cursor: cursor as Record<string, unknown>, crawlerVersion: currentVersion })
             .run();
         }
+      } else if (stateRow) {
+        // Update version even when cursor is null (e.g. after major version reset)
+        this.db
+          .update(syncState)
+          .set({ crawlerVersion: currentVersion, updatedAt: now })
+          .where(eq(syncState.id, stateRow.id))
+          .run();
       }
 
       // Reconcile filesystem with DB
       await this.reconcile(crawlerType);
+
+      // Notify caller to update collection version in .config
+      this.onVersionUpdate?.(currentVersion);
 
       // Update sync_run as completed
       this.db
@@ -213,6 +286,7 @@ export class SyncEngine {
   private async upsertEntity(
     entityData: CrawlerEntityData,
     crawlerType: string,
+    deferredLinks?: Array<{ entityId: number; markdown: string }>,
   ): Promise<{ created: number; updated: number }> {
     const contentHash = entityData.contentHash ?? computeHash(entityData.data);
 
@@ -235,6 +309,15 @@ export class SyncEngine {
       await this.storage.write(filePath, markdown);
       const writtenStat = await this.storage.stat(filePath);
 
+      // If the file path changed (e.g. title/name rename), delete the old file.
+      if (existing.markdownPath && existing.markdownPath !== filePath) {
+        try {
+          await this.storage.delete(existing.markdownPath);
+        } catch {
+          // Old file may already be gone — ignore.
+        }
+      }
+
       // Update entity
       this.db
         .update(entities)
@@ -253,18 +336,17 @@ export class SyncEngine {
         .run();
 
       // Update tags
-      this.db.delete(entityTags).where(eq(entityTags.entityId, existing.id)).run();
-      if (entityData.tags?.length) {
-        for (const tag of entityData.tags) {
-          this.db.insert(entityTags).values({ entityId: existing.id, tag }).run();
-        }
+      this.syncTags(existing.id, entityData.tags ?? []);
+
+      // Handle assets
+      await this.syncAssets(existing.id, entityData);
+
+      // Defer link syncing until all entities in the batch exist
+      if (deferredLinks) {
+        deferredLinks.push({ entityId: existing.id, markdown });
+      } else {
+        this.syncLinks(existing.id, markdown);
       }
-
-      // Handle attachments
-      await this.syncAttachments(existing.id, entityData);
-
-      // Extract and store outgoing links
-      this.syncLinks(existing.id, filePath, markdown);
 
       // Update search index
       this.searchIndexer.updateIndex({
@@ -308,17 +390,17 @@ export class SyncEngine {
       .all();
 
     // Insert tags
-    if (entityData.tags?.length) {
-      for (const tag of entityData.tags) {
-        this.db.insert(entityTags).values({ entityId: inserted.id, tag }).run();
-      }
+    this.syncTags(inserted.id, entityData.tags ?? []);
+
+    // Handle assets
+    await this.syncAssets(inserted.id, entityData);
+
+    // Defer link syncing until all entities in the batch exist
+    if (deferredLinks) {
+      deferredLinks.push({ entityId: inserted.id, markdown });
+    } else {
+      this.syncLinks(inserted.id, markdown);
     }
-
-    // Handle attachments
-    await this.syncAttachments(inserted.id, entityData);
-
-    // Extract and store outgoing links
-    this.syncLinks(inserted.id, filePath, markdown);
 
     // Add to search index
     this.searchIndexer.updateIndex({
@@ -333,27 +415,78 @@ export class SyncEngine {
     return { created: 1, updated: 0 };
   }
 
-  private async syncAttachments(
+  /** Get tag names for an entity by joining entity_tags → tags. */
+  private getEntityTagNames(entityId: number): string[] {
+    const rows = this.db
+      .select({ name: tags.name })
+      .from(entityTags)
+      .innerJoin(tags, eq(entityTags.tagId, tags.id))
+      .where(eq(entityTags.entityId, entityId))
+      .all();
+    return rows.map((r: any) => r.name);
+  }
+
+  /** Get or create a tag by name, returning its ID. */
+  private getOrCreateTagId(name: string): number {
+    const [existing] = this.db
+      .select()
+      .from(tags)
+      .where(eq(tags.name, name))
+      .all();
+    if (existing) return existing.id;
+    this.db.insert(tags).values({ name }).run();
+    const [created] = this.db
+      .select()
+      .from(tags)
+      .where(eq(tags.name, name))
+      .all();
+    return created.id;
+  }
+
+  private syncTags(entityId: number, tagNames: string[]): void {
+    this.db.delete(entityTags).where(eq(entityTags.entityId, entityId)).run();
+    for (const name of tagNames) {
+      const tagId = this.getOrCreateTagId(name);
+      this.db.insert(entityTags).values({ entityId, tagId }).run();
+    }
+  }
+
+  /** Check if a filename has an allowed image extension. */
+  private isAllowedAsset(filename: string): boolean {
+    const dot = filename.lastIndexOf(".");
+    if (dot === -1) return false;
+    return this.allowedExtensions.has(filename.slice(dot).toLowerCase());
+  }
+
+  private async syncAssets(
     entityId: number,
     entityData: CrawlerEntityData,
   ): Promise<void> {
-    // Remove old attachments
-    this.db.delete(attachments).where(eq(attachments.entityId, entityId)).run();
+    // Remove old asset records
+    this.db.delete(assets).where(eq(assets.entityId, entityId)).run();
 
     if (!entityData.attachments?.length) return;
 
     for (const att of entityData.attachments) {
-      const storagePath = att.storagePath ?? `attachments/${entityData.externalId}/${att.filename}`;
-      await this.storage.write(storagePath, Buffer.from(att.content));
+      const storagePath = att.storagePath ?? `content/${entityData.entityType}/assets/${att.filename}`;
+
+      // Only download files with allowed extensions that are within size limits.
+      // All assets get their metadata stored in the DB regardless.
+      const shouldDownload =
+        this.isAllowedAsset(att.filename) &&
+        att.content.length <= this.maxAssetSizeBytes;
+
+      if (shouldDownload) {
+        await this.storage.write(storagePath, Buffer.from(att.content));
+      }
 
       this.db
-        .insert(attachments)
+        .insert(assets)
         .values({
           entityId,
           filename: att.filename,
           mimeType: att.mimeType,
           storagePath,
-          backend: "local",
         })
         .run();
     }
@@ -361,37 +494,47 @@ export class SyncEngine {
 
   private syncLinks(
     entityId: number,
-    markdownPath: string,
     markdown: string,
   ): void {
-    const newTargets = new Set(
-      extractWikilinks(markdown).map((t) => `${this.markdownBasePath}/${t}.md`),
-    );
+    // Extract wikilink targets and resolve them to entity IDs
+    const wikiTargets = extractWikilinks(markdown);
+    const newTargetIds = new Set<number>();
+    for (const target of wikiTargets) {
+      const targetPath = `${this.markdownBasePath}/${target}.md`;
+      // Look up entity by markdown path
+      const [targetEntity] = this.db
+        .select({ id: entities.id })
+        .from(entities)
+        .where(eq(entities.markdownPath, targetPath))
+        .all();
+      if (targetEntity && targetEntity.id !== entityId) {
+        newTargetIds.add(targetEntity.id);
+      }
+    }
 
     const existingRows = this.db
       .select()
-      .from(entityLinks)
-      .where(eq(entityLinks.sourceEntityId, entityId))
+      .from(links)
+      .where(eq(links.sourceEntityId, entityId))
       .all();
 
-    const existingTargets = new Map(existingRows.map((r: any) => [r.targetPath, r.id]));
+    const existingTargets = new Map(existingRows.map((r: any) => [r.targetEntityId as number, r.id as number]));
 
     // Delete links that are no longer present
-    for (const [target, id] of existingTargets as Map<string, number>) {
-      if (!newTargets.has(target)) {
-        this.db.delete(entityLinks).where(eq(entityLinks.id, id as number)).run();
+    for (const [targetId, id] of existingTargets as Map<number, number>) {
+      if (!newTargetIds.has(targetId)) {
+        this.db.delete(links).where(eq(links.id, id)).run();
       }
     }
 
     // Insert links that are new
-    for (const target of newTargets) {
-      if (!existingTargets.has(target)) {
+    for (const targetId of newTargetIds) {
+      if (!existingTargets.has(targetId)) {
         this.db
-          .insert(entityLinks)
+          .insert(links)
           .values({
             sourceEntityId: entityId,
-            sourceMarkdownPath: markdownPath,
-            targetPath: target,
+            targetEntityId: targetId,
           })
           .run();
       }
@@ -460,6 +603,55 @@ export class SyncEngine {
     return `${this.markdownBasePath}/${entityData.entityType}/${entityData.externalId}.md`;
   }
 
+  /**
+   * Re-render all markdown files from stored entity data (for minor version bumps).
+   * Does not re-download from the API — just re-generates markdown from the JSON in the DB.
+   */
+  private async reRenderAllEntities(crawlerType: string): Promise<void> {
+    const allEntities = this.db.select().from(entities).all();
+    for (const row of allEntities) {
+      const entityData: CrawlerEntityData = {
+        externalId: row.externalId,
+        entityType: row.entityType,
+        title: row.title,
+        data: row.data,
+        url: row.url ?? undefined,
+      };
+      const markdown = this.renderMarkdown(entityData, crawlerType);
+      const filePath = this.getMarkdownPath(entityData, crawlerType);
+      await this.storage.write(filePath, markdown);
+      const stat = await this.storage.stat(filePath);
+
+      // Delete old file if path changed
+      if (row.markdownPath && row.markdownPath !== filePath) {
+        try { await this.storage.delete(row.markdownPath); } catch { /* ignore */ }
+      }
+
+      this.db
+        .update(entities)
+        .set({
+          markdownPath: filePath,
+          markdownMtime: stat?.mtimeMs ?? null,
+          markdownSize: stat?.size ?? null,
+        })
+        .where(eq(entities.id, row.id))
+        .run();
+
+      // Re-sync wikilinks
+      this.syncLinks(row.id, markdown);
+
+      // Update search index
+      this.searchIndexer.updateIndex({
+        id: row.id,
+        externalId: row.externalId,
+        entityType: row.entityType,
+        title: row.title,
+        content: markdown,
+        tags: [],
+      });
+    }
+  }
+
   private async reconcile(crawlerType: string): Promise<void> {
     const allEntities = this.db.select().from(entities).all();
 
@@ -472,12 +664,7 @@ export class SyncEngine {
       if (statMatches(entity, currentStat)) continue;
 
       // File is missing or has been modified — re-render and restore
-      const tags = this.db
-        .select()
-        .from(entityTags)
-        .where(eq(entityTags.entityId, entity.id))
-        .all()
-        .map((t: any) => t.tag);
+      const entityTagNames = this.getEntityTagNames(entity.id);
       const expected = this.themeEngine.render({
         entity: {
           externalId: entity.externalId,
@@ -485,7 +672,7 @@ export class SyncEngine {
           title: entity.title,
           data: entity.data as Record<string, unknown>,
           url: entity.url ?? undefined,
-          tags,
+          tags: entityTagNames,
         },
         collectionName: this.collectionName,
         crawlerType,
@@ -526,32 +713,46 @@ export class SyncEngine {
       // markdown directory may not exist yet
     }
 
-    // 3. Delete orphaned attachment files (on disk but no matching record in DB)
-    const allAttachmentRows = this.db.select().from(attachments).all();
-    const dbAttachmentPaths = new Set(
-      allAttachmentRows.map((a: any) => a.storagePath),
+    // 3. Delete orphaned asset files (on disk but no matching record in DB)
+    const allAssetRows = this.db.select().from(assets).all();
+    const dbAssetPaths = new Set(
+      allAssetRows.map((a: any) => a.storagePath),
     );
-    try {
-      const diskAttachmentFiles = await this.storage.list("attachments");
-      for (const diskPath of diskAttachmentFiles) {
-        if (isToolPath(diskPath)) continue;
-        if (!dbAttachmentPaths.has(diskPath)) {
-          try {
-            await this.storage.delete(diskPath);
-          } catch {
-            // ignore
+    // Derive asset directories from DB paths (handles both old and new layouts)
+    const assetDirs = new Set<string>();
+    for (const att of allAssetRows) {
+      const parts = att.storagePath.split("/");
+      if (parts.length > 1) {
+        assetDirs.add(parts.slice(0, -1).join("/"));
+      }
+    }
+    // Also check legacy directories
+    for (const dir of ["content/assets", "assets", "attachments"]) {
+      assetDirs.add(dir);
+    }
+    for (const assetsDir of assetDirs) {
+      try {
+        const diskAssetFiles = await this.storage.list(assetsDir);
+        for (const diskPath of diskAssetFiles) {
+          if (isToolPath(diskPath)) continue;
+          if (!dbAssetPaths.has(diskPath)) {
+            try {
+              await this.storage.delete(diskPath);
+            } catch {
+              // ignore
+            }
           }
         }
+      } catch {
+        // directory may not exist yet
       }
-    } catch {
-      // attachments directory may not exist yet
     }
 
-    // 4. Clean up attachment DB records whose files are missing from disk
-    for (const att of allAttachmentRows) {
+    // 4. Clean up asset DB records whose files are missing from disk
+    for (const att of allAssetRows) {
       const exists = await this.storage.exists(att.storagePath);
       if (!exists) {
-        this.db.delete(attachments).where(eq(attachments.id, att.id)).run();
+        this.db.delete(assets).where(eq(assets.id, att.id)).run();
       }
     }
   }
@@ -576,16 +777,9 @@ export class SyncEngine {
 
     // Delete related records
     this.db.delete(entityTags).where(eq(entityTags.entityId, existing.id)).run();
-    this.db.delete(attachments).where(eq(attachments.entityId, existing.id)).run();
-    this.db.delete(entityLinks).where(eq(entityLinks.sourceEntityId, existing.id)).run();
-    this.db
-      .delete(entityRelations)
-      .where(eq(entityRelations.sourceEntityId, existing.id))
-      .run();
-    this.db
-      .delete(entityRelations)
-      .where(eq(entityRelations.targetEntityId, existing.id))
-      .run();
+    this.db.delete(assets).where(eq(assets.entityId, existing.id)).run();
+    this.db.delete(links).where(eq(links.sourceEntityId, existing.id)).run();
+    this.db.delete(links).where(eq(links.targetEntityId, existing.id)).run();
     this.db.delete(entities).where(eq(entities.id, existing.id)).run();
 
     // Remove from search index

--- a/packages/core/src/db/__tests__/db.test.ts
+++ b/packages/core/src/db/__tests__/db.test.ts
@@ -5,11 +5,11 @@ import { eq } from "drizzle-orm";
 import { getCollectionDb } from "../client";
 import {
   entities,
+  tags,
   entityTags,
-  attachments,
+  assets,
   syncState,
   syncRuns,
-  entityRelations,
 } from "../collection-schema";
 
 const TEST_DIR = join(import.meta.dir, ".test-dbs");
@@ -32,10 +32,9 @@ describe("Collection Database", () => {
     // Verify all tables exist by querying them
     expect(db.select().from(entities).all()).toEqual([]);
     expect(db.select().from(entityTags).all()).toEqual([]);
-    expect(db.select().from(attachments).all()).toEqual([]);
+    expect(db.select().from(assets).all()).toEqual([]);
     expect(db.select().from(syncState).all()).toEqual([]);
     expect(db.select().from(syncRuns).all()).toEqual([]);
-    expect(db.select().from(entityRelations).all()).toEqual([]);
   });
 
   it("supports CRUD on entities", () => {
@@ -76,7 +75,7 @@ describe("Collection Database", () => {
     expect(db.select().from(entities).all()).toHaveLength(0);
   });
 
-  it("supports entity_tags with foreign key to entities", () => {
+  it("supports entity_tags with foreign key to entities and tags", () => {
     const dbPath = join(TEST_DIR, "collection-tags.db");
     const db = getCollectionDb(dbPath);
 
@@ -91,19 +90,28 @@ describe("Collection Database", () => {
 
     const [entity] = db.select().from(entities).all();
 
-    db.insert(entityTags).values({ entityId: entity.id, tag: "enhancement" }).run();
-    db.insert(entityTags).values({ entityId: entity.id, tag: "frontend" }).run();
+    // Insert into tags table first
+    db.insert(tags).values({ name: "enhancement" }).run();
+    db.insert(tags).values({ name: "frontend" }).run();
+    const allTags = db.select().from(tags).all();
+    const enhancementTag = allTags.find((t) => t.name === "enhancement")!;
+    const frontendTag = allTags.find((t) => t.name === "frontend")!;
 
-    const tags = db
+    db.insert(entityTags).values({ entityId: entity.id, tagId: enhancementTag.id }).run();
+    db.insert(entityTags).values({ entityId: entity.id, tagId: frontendTag.id }).run();
+
+    const entityTagRows = db
       .select()
       .from(entityTags)
       .where(eq(entityTags.entityId, entity.id))
       .all();
-    expect(tags).toHaveLength(2);
-    expect(tags.map((t) => t.tag).sort()).toEqual(["enhancement", "frontend"]);
+    expect(entityTagRows).toHaveLength(2);
+    expect(entityTagRows.map((t) => t.tagId).sort()).toEqual(
+      [enhancementTag.id, frontendTag.id].sort(),
+    );
   });
 
-  it("supports attachments", () => {
+  it("supports assets", () => {
     const dbPath = join(TEST_DIR, "collection-attach.db");
     const db = getCollectionDb(dbPath);
 
@@ -118,24 +126,35 @@ describe("Collection Database", () => {
 
     const [entity] = db.select().from(entities).all();
 
-    db.insert(attachments)
+    db.insert(assets)
       .values({
         entityId: entity.id,
         filename: "screenshot.png",
         mimeType: "image/png",
         storagePath: "/attachments/screenshot.png",
-        backend: "local",
       })
       .run();
 
     const rows = db
       .select()
-      .from(attachments)
-      .where(eq(attachments.entityId, entity.id))
+      .from(assets)
+      .where(eq(assets.entityId, entity.id))
       .all();
     expect(rows).toHaveLength(1);
     expect(rows[0].filename).toBe("screenshot.png");
-    expect(rows[0].backend).toBe("local");
+  });
+
+  it("supports tags table with unique name", () => {
+    const dbPath = join(TEST_DIR, "collection-tags-table.db");
+    const db = getCollectionDb(dbPath);
+
+    db.insert(tags).values({ name: "bug" }).run();
+    db.insert(tags).values({ name: "feature" }).run();
+
+    const allTags = db.select().from(tags).all();
+    expect(allTags).toHaveLength(2);
+    expect(allTags.map((t) => t.name).sort()).toEqual(["bug", "feature"]);
+    expect(allTags[0].id).toBeTruthy();
   });
 
   it("supports sync_state and sync_runs", () => {
@@ -171,34 +190,4 @@ describe("Collection Database", () => {
     expect(runs[0].entitiesCreated).toBe(10);
   });
 
-  it("supports entity_relations", () => {
-    const dbPath = join(TEST_DIR, "collection-relations.db");
-    const db = getCollectionDb(dbPath);
-
-    // Create two entities
-    db.insert(entities)
-      .values([
-        { externalId: "issue-1", entityType: "issue", title: "Bug report", data: {} },
-        { externalId: "pr-1", entityType: "pull_request", title: "Fix for bug", data: {} },
-      ])
-      .run();
-
-    const allEntities = db.select().from(entities).all();
-    expect(allEntities).toHaveLength(2);
-
-    // Create a relation
-    db.insert(entityRelations)
-      .values({
-        sourceEntityId: allEntities[0].id,
-        targetEntityId: allEntities[1].id,
-        relationType: "fixes",
-      })
-      .run();
-
-    const relations = db.select().from(entityRelations).all();
-    expect(relations).toHaveLength(1);
-    expect(relations[0].relationType).toBe("fixes");
-    expect(relations[0].sourceEntityId).toBe(allEntities[0].id);
-    expect(relations[0].targetEntityId).toBe(allEntities[1].id);
-  });
 });

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -42,25 +42,30 @@ export function getCollectionDb(dbPath: string) {
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
+    CREATE TABLE IF NOT EXISTS tags (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE
+    );
+
     CREATE TABLE IF NOT EXISTS entity_tags (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       entity_id INTEGER NOT NULL REFERENCES entities(id),
-      tag TEXT NOT NULL
+      tag_id INTEGER NOT NULL REFERENCES tags(id)
     );
 
-    CREATE TABLE IF NOT EXISTS attachments (
+    CREATE TABLE IF NOT EXISTS assets (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       entity_id INTEGER NOT NULL REFERENCES entities(id),
       filename TEXT NOT NULL,
       mime_type TEXT NOT NULL,
-      storage_path TEXT NOT NULL,
-      backend TEXT NOT NULL
+      storage_path TEXT NOT NULL
     );
 
     CREATE TABLE IF NOT EXISTS sync_state (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       crawler_type TEXT NOT NULL,
       cursor TEXT,
+      crawler_version TEXT,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
@@ -76,26 +81,24 @@ export function getCollectionDb(dbPath: string) {
       completed_at TEXT
     );
 
-    CREATE TABLE IF NOT EXISTS entity_relations (
+    CREATE TABLE IF NOT EXISTS links (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       source_entity_id INTEGER NOT NULL REFERENCES entities(id),
-      target_entity_id INTEGER NOT NULL REFERENCES entities(id),
-      relation_type TEXT NOT NULL
+      target_entity_id INTEGER NOT NULL REFERENCES entities(id)
     );
 
-    CREATE TABLE IF NOT EXISTS entity_links (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      source_entity_id INTEGER NOT NULL REFERENCES entities(id),
-      source_markdown_path TEXT NOT NULL,
-      target_path TEXT NOT NULL
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_entity_links_target ON entity_links(target_path);
+    CREATE INDEX IF NOT EXISTS idx_links_target ON links(target_entity_id);
+    CREATE INDEX IF NOT EXISTS idx_links_source ON links(source_entity_id);
   `);
 
   // Migrations: add columns to existing tables
   try {
     sqlite.exec("ALTER TABLE sync_runs ADD COLUMN sync_type TEXT NOT NULL DEFAULT 'incremental'");
+  } catch {
+    // Column already exists — expected on new databases
+  }
+  try {
+    sqlite.exec("ALTER TABLE sync_state ADD COLUMN crawler_version TEXT");
   } catch {
     // Column already exists — expected on new databases
   }

--- a/packages/core/src/db/collection-schema.ts
+++ b/packages/core/src/db/collection-schema.ts
@@ -20,15 +20,22 @@ export const entities = sqliteTable("entities", {
     .default(sql`(datetime('now'))`),
 });
 
+export const tags = sqliteTable("tags", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull().unique(),
+});
+
 export const entityTags = sqliteTable("entity_tags", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   entityId: integer("entity_id")
     .notNull()
     .references(() => entities.id),
-  tag: text("tag").notNull(),
+  tagId: integer("tag_id")
+    .notNull()
+    .references(() => tags.id),
 });
 
-export const attachments = sqliteTable("attachments", {
+export const assets = sqliteTable("assets", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   entityId: integer("entity_id")
     .notNull()
@@ -36,13 +43,13 @@ export const attachments = sqliteTable("attachments", {
   filename: text("filename").notNull(),
   mimeType: text("mime_type").notNull(),
   storagePath: text("storage_path").notNull(),
-  backend: text("backend").notNull(),
 });
 
 export const syncState = sqliteTable("sync_state", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   crawlerType: text("crawler_type").notNull(),
   cursor: text("cursor", { mode: "json" }).$type<Record<string, unknown>>(),
+  crawlerVersion: text("crawler_version"),
   updatedAt: text("updated_at")
     .notNull()
     .default(sql`(datetime('now'))`),
@@ -62,7 +69,7 @@ export const syncRuns = sqliteTable("sync_runs", {
   completedAt: text("completed_at"),
 });
 
-export const entityRelations = sqliteTable("entity_relations", {
+export const links = sqliteTable("links", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   sourceEntityId: integer("source_entity_id")
     .notNull()
@@ -70,14 +77,4 @@ export const entityRelations = sqliteTable("entity_relations", {
   targetEntityId: integer("target_entity_id")
     .notNull()
     .references(() => entities.id),
-  relationType: text("relation_type").notNull(),
-});
-
-export const entityLinks = sqliteTable("entity_links", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  sourceEntityId: integer("source_entity_id")
-    .notNull()
-    .references(() => entities.id),
-  sourceMarkdownPath: text("source_markdown_path").notNull(),
-  targetPath: text("target_path").notNull(),
 });

--- a/packages/core/src/export/static-site.ts
+++ b/packages/core/src/export/static-site.ts
@@ -3,7 +3,7 @@ import { join, relative, dirname, extname } from "path";
 import { getFrozenInkHome } from "../config/loader";
 import { getCollection, getCollectionDbPath } from "../config/context";
 import { getCollectionDb } from "../db/client";
-import { entities, entityTags } from "../db/collection-schema";
+import { entities, entityTags, tags } from "../db/collection-schema";
 import { eq } from "drizzle-orm";
 import { ThemeEngine } from "../theme/engine";
 
@@ -132,12 +132,13 @@ async function exportHtml(
     mkdirSync(outColDir, { recursive: true });
 
     for (const entity of allEntities) {
-      const tags = colDb
-        .select()
+      const entityTagNames = colDb
+        .select({ name: tags.name })
         .from(entityTags)
+        .innerJoin(tags, eq(entityTags.tagId, tags.id))
         .where(eq(entityTags.entityId, entity.id))
         .all()
-        .map((t: any) => t.tag);
+        .map((t: any) => t.name);
 
       const data = typeof entity.data === "string" ? JSON.parse(entity.data) : entity.data;
       let html = "";
@@ -151,7 +152,7 @@ async function exportHtml(
             title: entity.title,
             data,
             url: entity.url ?? undefined,
-            tags,
+            tags: entityTagNames,
           },
           collectionName: colName,
           crawlerType: col.crawler,

--- a/packages/crawlers/src/mantisbt/crawler.ts
+++ b/packages/crawlers/src/mantisbt/crawler.ts
@@ -9,7 +9,10 @@ import { createCryptoHasher } from "@frozenink/core";
 import type {
   MantisBTConfig,
   MantisBTCredentials,
+  MantisBTEntityType,
   MantisBTIssue,
+  MantisBTPage,
+  MantisBTPageFile,
   MantisBTProject,
   MantisBTUser,
 } from "./types";
@@ -28,11 +31,15 @@ interface MantisBTSyncCursor extends SyncCursor {
   /** Number of consecutive repeated page signatures. */
   repeatedPageCount?: number;
   /** Current sync phase. Undefined / missing means "issues". */
-  phase?: "issues" | "users";
+  phase?: "issues" | "pages" | "users";
   /** User data accumulated across issue pages (serialized in cursor). */
   _users?: Record<number, { id: number; name: string; email?: string }>;
   /** Project data accumulated across issue pages (serialized in cursor). */
   _projects?: Record<number, { id: number; name: string; categories: string[] }>;
+  /** Remaining project IDs to browse for pages (MantisHub only). */
+  _pagesProjectIds?: number[];
+  /** Current browse page within the current project's pages. */
+  _pagesBrowsePage?: number;
 }
 
 const PAGE_SIZE = 25;
@@ -56,22 +63,17 @@ function padId(id: number): string {
   return String(id).padStart(5, "0");
 }
 
-function attachmentFilename(issueId: number, filename: string): string {
-  const hasher = createCryptoHasher("md5");
-  hasher.update(filename);
-  const hash = hasher.digest("hex").slice(0, 8);
-  const dotIdx = filename.lastIndexOf(".");
-  const ext = dotIdx !== -1 ? filename.slice(dotIdx) : "";
-  return `${padId(issueId)}-${hash}${ext}`;
+/** Asset filename: <id>-<original-filename> */
+function assetFilename(id: number, filename: string): string {
+  return `${id}-${filename}`;
 }
 
-function noteAttachmentFilename(issueId: number, noteId: number, filename: string): string {
-  const hasher = createCryptoHasher("md5");
-  hasher.update(filename);
-  const hash = hasher.digest("hex").slice(0, 8);
-  const dotIdx = filename.lastIndexOf(".");
-  const ext = dotIdx !== -1 ? filename.slice(dotIdx) : "";
-  return `${padId(issueId)}-${padId(noteId)}-${hash}${ext}`;
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60);
 }
 
 /** Detect MantisHub instances by URL pattern. */
@@ -91,16 +93,17 @@ export class MantisBTCrawler implements Crawler {
     displayName: "MantisBT Issue Tracker",
     description:
       "Crawls a MantisBT instance via its REST API, syncing issues from newest to oldest",
+    version: "3.1",
     configSchema: {
-      baseUrl: {
+      url: {
         type: "string",
         required: true,
         description: "Base URL of the MantisBT instance (e.g. https://mantisbt.org/bugs)",
       },
-      projectName: {
-        type: "string",
+      project: {
+        type: "object",
         required: false,
-        description: "Optional project name to filter issues (resolved to ID via API)",
+        description: "Optional project to filter (object with id and name)",
       },
       maxEntities: {
         type: "number",
@@ -116,7 +119,22 @@ export class MantisBTCrawler implements Crawler {
   private projectId?: number;
   private maxEntities?: number;
   private mantisHubMode = false;
+  private syncEntities?: MantisBTEntityType[];
   private fetchFn: typeof fetch = globalThis.fetch;
+
+  /** Accept both new field names and legacy field names for backward compat. */
+  private static resolveConfig(config: Record<string, unknown>): MantisBTConfig {
+    const url = (config.url ?? config.baseUrl) as string;
+    const project = config.project as { id?: number; name?: string } | undefined;
+    const projectId = project?.id ?? (config.projectId as number | undefined);
+    const projectName = project?.name ?? (config.projectName as string | undefined);
+    return {
+      url,
+      project: projectId || projectName ? { id: projectId, name: projectName } : undefined,
+      maxEntities: config.maxEntities as number | undefined,
+      entities: (config.entities ?? config.syncEntities) as MantisBTEntityType[] | undefined,
+    };
+  }
 
   // Accumulated during the issues phase; emitted in the users phase.
   private collectedUsers = new Map<number, { id: number; name: string; email?: string }>();
@@ -126,19 +144,20 @@ export class MantisBTCrawler implements Crawler {
     config: Record<string, unknown>,
     credentials: Record<string, unknown>,
   ): Promise<void> {
-    const cfg = config as unknown as MantisBTConfig;
+    const cfg = MantisBTCrawler.resolveConfig(config);
     const creds = credentials as unknown as MantisBTCredentials;
-    this.baseUrl = cfg.baseUrl.replace(/\/+$/, "");
+    this.baseUrl = cfg.url.replace(/\/+$/, "");
     this.token = creds.token ?? "";
     this.maxEntities = cfg.maxEntities;
     this.mantisHubMode = isMantisHub(this.baseUrl);
+    this.syncEntities = cfg.entities;
 
-    // Use stored projectId if available (persisted at creation time);
-    // otherwise resolve projectName to projectId via API.
-    if (cfg.projectId) {
-      this.projectId = cfg.projectId;
-    } else if (cfg.projectName) {
-      this.projectId = await this.resolveProjectId(cfg.projectName);
+    // Use stored project.id if available (persisted at creation time);
+    // otherwise resolve project.name to project.id via API.
+    if (cfg.project?.id) {
+      this.projectId = cfg.project.id;
+    } else if (cfg.project?.name) {
+      this.projectId = await this.resolveProjectId(cfg.project.name);
     }
   }
 
@@ -178,9 +197,19 @@ export class MantisBTCrawler implements Crawler {
       );
     }
 
-    // Users + projects phase: emit after all issues are processed.
+    // Pages phase (MantisHub only): sync wiki pages between issues and users.
+    if (c.phase === "pages") {
+      return this.syncPages(c);
+    }
+
+    // Users + projects phase: emit after all issues (and pages) are processed.
     if (c.phase === "users") {
       return this.syncUsersAndProjects(c);
+    }
+
+    // If issues sync is disabled, skip directly to the next applicable phase.
+    if (!this.shouldSync("issues") && !c.phase) {
+      return { entities: [], ...this.transitionFromIssues(c.updatedSince) };
     }
 
     // ── Issues phase ─────────────────────────────────────────────
@@ -253,14 +282,7 @@ export class MantisBTCrawler implements Crawler {
     if (page > 1 && repeatedPageCount > 0) {
       return {
         entities: [],
-        nextCursor: {
-          phase: "users",
-          updatedSince: finalUpdatedSince,
-          _users: Object.fromEntries(this.collectedUsers),
-          _projects: Object.fromEntries(this.collectedProjects),
-        },
-        hasMore: true,
-        deletedExternalIds: [],
+        ...this.transitionFromIssues(finalUpdatedSince),
       };
     }
 
@@ -301,12 +323,11 @@ export class MantisBTCrawler implements Crawler {
       };
     }
 
-    // Issues exhausted — transition to users+projects phase.
+    // Issues exhausted — transition to pages phase (MantisHub) or users+projects phase.
+    const transition = this.transitionFromIssues(finalUpdatedSince);
     return {
       entities,
-      nextCursor: { phase: "users", updatedSince: finalUpdatedSince, ...serializedCollected },
-      hasMore: true,
-      deletedExternalIds: [],
+      ...transition,
     };
   }
 
@@ -314,18 +335,20 @@ export class MantisBTCrawler implements Crawler {
     const entities: CrawlerEntityData[] = [];
 
     // Fetch full user profiles; fall back to basic data on error.
-    for (const basic of this.collectedUsers.values()) {
-      if (!basic.name) continue; // Skip users without a name
-      try {
-        const profile = await this.fetchUser(basic.id);
-        entities.push(this.buildUserEntity(profile));
-      } catch {
-        // Build a minimal user entity from data collected during issue sync.
-        entities.push(this.buildUserEntity({
-          id: basic.id,
-          name: basic.name,
-          email: basic.email,
-        }));
+    if (this.shouldSync("users")) {
+      for (const basic of this.collectedUsers.values()) {
+        if (!basic.name) continue; // Skip users without a name
+        try {
+          const profile = await this.fetchUser(basic.id);
+          entities.push(this.buildUserEntity(profile));
+        } catch {
+          // Build a minimal user entity from data collected during issue sync.
+          entities.push(this.buildUserEntity({
+            id: basic.id,
+            name: basic.name,
+            email: basic.email,
+          }));
+        }
       }
     }
 
@@ -348,7 +371,7 @@ export class MantisBTCrawler implements Crawler {
   ): Promise<boolean> {
     try {
       const token = (credentials.token as string) ?? "";
-      const baseUrl = ((credentials.baseUrl as string) ?? this.baseUrl).replace(/\/+$/, "");
+      const baseUrl = ((credentials.url as string) ?? (credentials.baseUrl as string) ?? this.baseUrl).replace(/\/+$/, "");
       if (!baseUrl) return false;
 
       const headers: Record<string, string> = {
@@ -373,6 +396,12 @@ export class MantisBTCrawler implements Crawler {
   }
 
   async dispose(): Promise<void> {}
+
+  /** Whether a given entity type should be synced based on the syncEntities config. */
+  private shouldSync(type: MantisBTEntityType): boolean {
+    if (!this.syncEntities) return true; // default: sync everything applicable
+    return this.syncEntities.includes(type);
+  }
 
   setFetch(fn: typeof fetch): void {
     this.fetchFn = fn;
@@ -462,6 +491,310 @@ export class MantisBTCrawler implements Crawler {
         name: project.name,
         categories: project.categories,
       },
+    };
+  }
+
+  /**
+   * Build the cursor/result for transitioning out of the issues phase.
+   * Goes to pages (if MantisHub + pages enabled) or users, or finishes.
+   */
+  private transitionFromIssues(updatedSince: string | undefined): Pick<SyncResult, "nextCursor" | "hasMore" | "deletedExternalIds"> {
+    const serialized = {
+      _users: Object.fromEntries(this.collectedUsers),
+      _projects: Object.fromEntries(this.collectedProjects),
+    };
+
+    if (this.mantisHubMode && this.shouldSync("pages")) {
+      return {
+        nextCursor: {
+          phase: "pages" as const,
+          updatedSince,
+          ...serialized,
+          _pagesProjectIds: this.getPageProjectIds(),
+        },
+        hasMore: true,
+        deletedExternalIds: [],
+      };
+    }
+
+    if (this.shouldSync("users")) {
+      return {
+        nextCursor: { phase: "users" as const, updatedSince, ...serialized },
+        hasMore: true,
+        deletedExternalIds: [],
+      };
+    }
+
+    // Neither pages nor users selected — we're done.
+    return {
+      nextCursor: updatedSince ? { updatedSince } : null,
+      hasMore: false,
+      deletedExternalIds: [],
+    };
+  }
+
+  /**
+   * Build the cursor/result for transitioning out of the pages phase.
+   * Goes to users if enabled, otherwise finishes.
+   */
+  private transitionFromPages(c: MantisBTSyncCursor): Pick<SyncResult, "nextCursor" | "hasMore" | "deletedExternalIds"> {
+    const serialized = {
+      _users: Object.fromEntries(this.collectedUsers),
+      _projects: c._projects ?? Object.fromEntries(this.collectedProjects),
+    };
+
+    if (this.shouldSync("users")) {
+      return {
+        nextCursor: { phase: "users" as const, updatedSince: c.updatedSince, ...serialized },
+        hasMore: true,
+        deletedExternalIds: [],
+      };
+    }
+
+    return {
+      nextCursor: c.updatedSince ? { updatedSince: c.updatedSince } : null,
+      hasMore: false,
+      deletedExternalIds: [],
+    };
+  }
+
+  /** Compute the assets directory prefix for an entity type and project. */
+  private assetDir(entityType: string, projectName?: string): string {
+    if (this.projectId) {
+      // Single project: content/<entity-type>/assets/
+      return `content/${entityType}/assets`;
+    }
+    // Multi-project: content/<project-slug>/<entity-type>/assets/
+    return `content/${slugify(projectName ?? "unknown")}/${entityType}/assets`;
+  }
+
+  /** Build a project name → ID mapping from collected projects. */
+  private getProjectNameToId(): Record<string, number> {
+    const map: Record<string, number> = {};
+    for (const p of this.collectedProjects.values()) {
+      map[p.name] = p.id;
+    }
+    return map;
+  }
+
+  /** Get project IDs to browse for pages. Uses configured project or all collected projects. */
+  private getPageProjectIds(): number[] {
+    if (this.projectId) return [this.projectId];
+    return [...this.collectedProjects.keys()];
+  }
+
+  /**
+   * Pages phase: browse and fetch wiki pages from MantisHub instances.
+   * Processes one project per sync call to avoid timeouts.
+   */
+  private async syncPages(c: MantisBTSyncCursor): Promise<SyncResult> {
+    const projectIds = c._pagesProjectIds ?? [];
+    if (projectIds.length === 0) {
+      // No projects left — transition to users phase or finish.
+      return { entities: [], ...this.transitionFromPages(c) };
+    }
+
+    const currentProjectId = projectIds[0];
+    const remainingProjectIds = projectIds.slice(1);
+    const entities: CrawlerEntityData[] = [];
+
+    try {
+      // Browse all pages for this project (with pagination).
+      const browsePage = c._pagesBrowsePage ?? 1;
+      const browseResult = await this.browsePages(currentProjectId, browsePage);
+
+      // Fetch full details for each page and build entities.
+      for (const pageSummary of browseResult.pages) {
+        try {
+          const { page, files } = await this.fetchPage(currentProjectId, pageSummary.name);
+          entities.push(await this.buildPageEntity(page, files));
+
+          // Collect users from page metadata.
+          this.collectUsersFromPage(page);
+        } catch (err) {
+          console.warn(`  Warning: could not fetch page "${pageSummary.name}" in project ${currentProjectId}: ${err}`);
+        }
+      }
+
+      // If there are more browse pages, continue with this project.
+      if (browseResult.hasMore) {
+        return {
+          entities,
+          nextCursor: {
+            phase: "pages",
+            updatedSince: c.updatedSince,
+            _users: Object.fromEntries(this.collectedUsers),
+            _projects: c._projects,
+            _pagesProjectIds: projectIds,
+            _pagesBrowsePage: browsePage + 1,
+          },
+          hasMore: true,
+          deletedExternalIds: [],
+        };
+      }
+    } catch (err) {
+      // Pages plugin not available or project has no pages — skip gracefully.
+      console.warn(`  Warning: could not browse pages for project ${currentProjectId}: ${err}`);
+    }
+
+    // Move to the next project (or users phase if no more projects).
+    const serialized = {
+      _users: Object.fromEntries(this.collectedUsers),
+      _projects: c._projects,
+    };
+
+    if (remainingProjectIds.length > 0) {
+      return {
+        entities,
+        nextCursor: {
+          phase: "pages",
+          updatedSince: c.updatedSince,
+          ...serialized,
+          _pagesProjectIds: remainingProjectIds,
+        },
+        hasMore: true,
+        deletedExternalIds: [],
+      };
+    }
+
+    // All projects processed — transition to users phase or finish.
+    return { entities, ...this.transitionFromPages(c) };
+  }
+
+  /** Browse pages for a project via the ApiX browse endpoint. */
+  private async browsePages(
+    projectId: number,
+    page: number,
+  ): Promise<{ pages: Array<{ id: number; name: string; title: string }>; hasMore: boolean }> {
+    const limit = 50;
+    const url = `${this.baseUrl}/api/rest/plugins/ApiX/projects/${projectId}/pages/pages/browse?limit=${limit}&page=${page}`;
+    const response = await this.apiFetch(url);
+    const data = (await response.json()) as {
+      pages: Array<{ id: number; name: string; title: string }>;
+      total_count: number;
+    };
+    const pages = data.pages ?? [];
+    const totalCount = data.total_count ?? pages.length;
+    const hasMore = page * limit < totalCount;
+    return { pages, hasMore };
+  }
+
+  /** Fetch a single page's full content and files via the ApiX update endpoint (raw markdown). */
+  private async fetchPage(
+    projectId: number,
+    pageName: string,
+  ): Promise<{ page: MantisBTPage; files: MantisBTPageFile[] }> {
+    const url = `${this.baseUrl}/api/rest/plugins/ApiX/projects/${projectId}/pages/update/${encodeURIComponent(pageName)}`;
+    const response = await this.apiFetch(url);
+    const data = (await response.json()) as {
+      page_view: {
+        page: MantisBTPage;
+        files: MantisBTPageFile[];
+      };
+    };
+    return {
+      page: data.page_view.page,
+      files: data.page_view.files ?? [],
+    };
+  }
+
+  /** Collect users from a page's created_by and updated_by fields. */
+  private collectUsersFromPage(page: MantisBTPage): void {
+    if (page.created_by?.name) {
+      this.collectedUsers.set(page.created_by.id, {
+        id: page.created_by.id,
+        name: page.created_by.name,
+        email: page.created_by.email,
+      });
+    }
+    if (page.updated_by?.name) {
+      this.collectedUsers.set(page.updated_by.id, {
+        id: page.updated_by.id,
+        name: page.updated_by.name,
+        email: page.updated_by.email,
+      });
+    }
+  }
+
+  private async buildPageEntity(
+    page: MantisBTPage,
+    files: MantisBTPageFile[],
+  ): Promise<CrawlerEntityData> {
+    const hasher = createCryptoHasher("sha256");
+    hasher.update(JSON.stringify({ page, files }));
+    const contentHash = hasher.digest("hex");
+
+    const tags: string[] = ["page"];
+    if (page.project?.name) {
+      tags.push(`project:${page.project.name}`);
+    }
+
+    // Download page file attachments.
+    const entityAttachments: CrawlerEntityData["attachments"] = [];
+    const savedPaths = new Set<string>();
+    const assetPrefix = this.assetDir("pages", page.project?.name);
+
+    for (const file of files) {
+      const storedName = assetFilename(file.id, file.name);
+      const storagePath = `${assetPrefix}/${storedName}`;
+
+      // The download_url from Pages is relative; make it absolute.
+      let downloadUrl = file.download_url;
+      if (downloadUrl && !downloadUrl.startsWith("http")) {
+        downloadUrl = `${this.baseUrl}/${downloadUrl.replace(/^\//, "")}`;
+      }
+
+      const content = await this.downloadBinary(
+        downloadUrl,
+        `page "${page.name}" file "${file.name}"`,
+      );
+
+      if (content) {
+        entityAttachments.push({
+          filename: storedName,
+          mimeType: file.content_type || "application/octet-stream",
+          content,
+          storagePath,
+        });
+        savedPaths.add(storagePath);
+      }
+    }
+
+    const projectId = page.project?.id;
+    const pageName = page.name;
+    const pageUrl = `${this.baseUrl}/plugin.php?page=Pages/view&project_id=${projectId}&name=${encodeURIComponent(pageName)}`;
+
+    return {
+      externalId: `page:${projectId}:${pageName}`,
+      entityType: "page",
+      title: page.title || page.name,
+      contentHash,
+      url: pageUrl,
+      data: {
+        id: page.id,
+        name: page.name,
+        title: page.title,
+        content: page.content ?? "",
+        project: page.project,
+        issueId: page.issue_id,
+        createdBy: page.created_by,
+        updatedBy: page.updated_by,
+        createdAt: page.created_at?.timestamp,
+        updatedAt: page.updated_at?.timestamp,
+        files: files.map((f) => {
+          const sp = `${assetPrefix}/${assetFilename(f.id, f.name)}`;
+          return {
+            name: f.name,
+            content_type: f.content_type,
+            size: f.size,
+            storagePath: savedPaths.has(sp) ? sp : undefined,
+          };
+        }),
+        _projectNameToId: this.getProjectNameToId(),
+        _singleProject: !!this.projectId,
+      },
+      tags,
+      attachments: entityAttachments.length > 0 ? entityAttachments : undefined,
     };
   }
 
@@ -586,13 +919,14 @@ export class MantisBTCrawler implements Crawler {
     // Download attachments; track storage paths that were successfully saved.
     // Uses core MantisBT REST API first. On MantisHub instances, if the core
     // API fails, falls back to the ApiX IssueViewPage for signed download URLs.
-    const attachments: CrawlerEntityData["attachments"] = [];
+    const entityAttachments: CrawlerEntityData["attachments"] = [];
     const savedPaths = new Set<string>();
     let mantisHubUrls: Map<number, AttachmentUrlInfo> | null = null;
+    const assetPrefix = this.assetDir("issues", issue.project?.name);
 
     for (const file of issue.attachments ?? []) {
-      const storedName = attachmentFilename(issue.id, file.filename);
-      const storagePath = `attachments/mantisbt/${storedName}`;
+      const storedName = assetFilename(file.id, file.filename);
+      const storagePath = `${assetPrefix}/${storedName}`;
       let content = await this.downloadAttachment(
         issue.id, file.id, file.download_url,
         `issue ${issue.id} file "${file.filename}"`,
@@ -611,7 +945,7 @@ export class MantisBTCrawler implements Crawler {
       }
 
       if (content) {
-        attachments.push({
+        entityAttachments.push({
           filename: storedName,
           mimeType: file.content_type || "application/octet-stream",
           content,
@@ -623,8 +957,8 @@ export class MantisBTCrawler implements Crawler {
 
     for (const note of issue.notes ?? []) {
       for (const att of note.attachments ?? []) {
-        const storedName = noteAttachmentFilename(issue.id, note.id, att.filename);
-        const storagePath = `attachments/mantisbt/${storedName}`;
+        const storedName = assetFilename(att.id, att.filename);
+        const storagePath = `${assetPrefix}/${storedName}`;
         let content = await this.downloadAttachment(
           issue.id, att.id, att.download_url,
           `issue ${issue.id} note ${note.id} file "${att.filename}"`,
@@ -643,7 +977,7 @@ export class MantisBTCrawler implements Crawler {
         }
 
         if (content) {
-          attachments.push({
+          entityAttachments.push({
             filename: storedName,
             mimeType: att.content_type || "application/octet-stream",
             content,
@@ -679,28 +1013,30 @@ export class MantisBTCrawler implements Crawler {
         updatedAt: issue.updated_at,
         sticky: issue.sticky,
         attachments: (issue.attachments ?? []).map((f) => {
-          const storagePath = `attachments/mantisbt/${attachmentFilename(issue.id, f.filename)}`;
+          const sp = `${assetPrefix}/${assetFilename(f.id, f.filename)}`;
           return {
             filename: f.filename,
             content_type: f.content_type,
             size: f.size,
-            storagePath: savedPaths.has(storagePath) ? storagePath : undefined,
+            storagePath: savedPaths.has(sp) ? sp : undefined,
           };
         }),
         notes: (issue.notes ?? []).map((note) => ({
           ...note,
           attachments: (note.attachments ?? []).map((att) => {
-            const storagePath = `attachments/mantisbt/${noteAttachmentFilename(issue.id, note.id, att.filename)}`;
+            const sp = `${assetPrefix}/${assetFilename(att.id, att.filename)}`;
             return {
               ...att,
-              storagePath: savedPaths.has(storagePath) ? storagePath : undefined,
+              storagePath: savedPaths.has(sp) ? sp : undefined,
             };
           }),
         })),
         relationships: issue.relationships ?? [],
+        _projectNameToId: this.getProjectNameToId(),
+        _singleProject: !!this.projectId,
       },
       tags,
-      attachments: attachments.length > 0 ? attachments : undefined,
+      attachments: entityAttachments.length > 0 ? entityAttachments : undefined,
       relations: relations.length > 0 ? relations : undefined,
     };
   }

--- a/packages/crawlers/src/mantisbt/theme.ts
+++ b/packages/crawlers/src/mantisbt/theme.ts
@@ -13,10 +13,23 @@ function padId(id: number): string {
   return String(id).padStart(5, "0");
 }
 
-/** Returns the wikilink path (no extension) for an issue by id and summary. */
-function issueFilePath(id: number, summary: string): string {
+/**
+ * Convert an attachment storagePath to a relative reference from a markdown file.
+ * Assets are stored as siblings in an `assets/` dir next to the markdown files,
+ * so the reference is always `assets/<filename>`.
+ */
+function assetRef(storagePath: string | undefined): string {
+  if (!storagePath) return "";
+  const filename = storagePath.split("/").pop() ?? storagePath;
+  return `assets/${filename}`;
+}
+
+/** Returns the wikilink path (no extension) for an issue by id and summary. Includes project folder for multi-project collections. */
+function issueFilePath(id: number, summary: string, projectName?: string, singleProject?: boolean): string {
   const slug = slugify(summary);
-  return slug ? `issues/${padId(id)}-${slug}` : `issues/${padId(id)}`;
+  const issuePart = slug ? `${padId(id)}-${slug}` : padId(id);
+  if (singleProject || !projectName) return `issues/${issuePart}`;
+  return `${slugify(projectName)}/issues/${issuePart}`;
 }
 
 function formatDate(iso: string): string {
@@ -85,20 +98,42 @@ type Lookup = (externalId: string) => string | undefined;
  * Convert plain text to HTML with escaped entities, line breaks,
  * and #1234 issue references / @mentions converted to wikilinks.
  */
-function textToHtml(text: string, lookup?: Lookup): string {
+function textToHtml(
+  text: string,
+  lookup?: Lookup,
+  projectId?: number,
+  projectNameToId?: Record<string, number>,
+): string {
   let html = esc(text);
 
-  // Linkify #1234 issue references
   if (lookup) {
+    // Resolve cross-project page links: [[/Project Name/page-name]]
+    html = html.replace(/\[\[\/(.+?)\/([\w-]+)\]\]/g, (match, projName: string, pageName: string) => {
+      // projName may be HTML-escaped; unescape for lookup
+      const rawProjName = projName.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"');
+      const pid = projectNameToId?.[rawProjName];
+      if (!pid) return match;
+      const path = lookup(`page:${pid}:${pageName}`);
+      if (!path) return match;
+      return `<a class="mt-page-link" href="#wikilink/${encodeURIComponent(path)}">${projName}/${esc(pageName)}</a>`;
+    });
+
+    // Resolve same-project page links: [[page-name]]
+    html = html.replace(/\[\[([\w-]+)\]\]/g, (match, pageName: string) => {
+      if (!projectId) return match;
+      const path = lookup(`page:${projectId}:${pageName}`);
+      if (!path) return match;
+      return `<a class="mt-page-link" href="#wikilink/${encodeURIComponent(path)}">${esc(pageName)}</a>`;
+    });
+
+    // Linkify #1234 issue references
     html = html.replace(/#(\d+)/g, (match, id) => {
       const path = lookup(`issue:${id}`);
       if (!path) return match;
       return `<a class="mt-issue-ref" href="#wikilink/${encodeURIComponent(path)}">#${padId(parseInt(id))}</a>`;
     });
-  }
 
-  // Linkify @mentions to user entities
-  if (lookup) {
+    // Linkify @mentions to user entities
     html = html.replace(/@([a-zA-Z0-9_.-]+)/g, (match, name) => {
       const path = lookup(`user:${name}`);
       if (!path) return match;
@@ -118,13 +153,22 @@ function textToHtml(text: string, lookup?: Lookup): string {
   return html;
 }
 
-/** Render a user name as a link to the user entity (underline on hover only). */
+/** Render a username as a link to the user entity, prefixed with @. */
 function mtUserLink(name: string, lookup?: Lookup): string {
   const path = lookup?.(`user:${name}`);
   if (path) {
-    return `<a class="mt-user-link" href="#wikilink/${encodeURIComponent(path)}">${esc(name)}</a>`;
+    return `<a class="mt-user-link" href="#wikilink/${encodeURIComponent(path)}">@${esc(name)}</a>`;
   }
-  return esc(name);
+  return `@${esc(name)}`;
+}
+
+/** Render a user's full name as a link to the user entity (no @ prefix). */
+function mtUserLinkFull(username: string, fullName: string, lookup?: Lookup): string {
+  const path = lookup?.(`user:${username}`);
+  if (path) {
+    return `<a class="mt-user-link" href="#wikilink/${encodeURIComponent(path)}">${esc(fullName)}</a>`;
+  }
+  return esc(fullName);
 }
 
 /** Render a project name as a link to the project entity (underline on hover only). */
@@ -169,37 +213,126 @@ function priorityIndicator(name: string): string {
 }
 
 /**
- * Replace bare #1234 issue references in prose text with wikilinks.
- * Skips text inside code fences, inline code, and existing wikilinks.
+ * Linkify all cross-entity references in prose text for markdown output.
+ * Handles: #1234 issue refs, @username mentions, [[page-name]] same-project
+ * page links, and [[/project-name/page-name]] cross-project page links.
+ * Skips text inside code fences and inline code.
  */
-function linkifyIssueRefs(
+function linkifyContent(
   text: string,
   lookup: (externalId: string) => string | undefined,
+  projectId?: number,
+  projectNameToId?: Record<string, number>,
 ): string {
-  // Split on code fences, inline code, and existing [[...]] blocks to avoid
-  // double-linking or corrupting code samples.
-  const skip = /(```[\s\S]*?```|`[^`\n]+`|\[\[[^\]]*\]\])/g;
+  // Split on code fences and inline code to avoid corrupting code samples.
+  const codeSkip = /(```[\s\S]*?```|`[^`\n]+`)/g;
   const parts: string[] = [];
   let last = 0;
   let m: RegExpExecArray | null;
-  while ((m = skip.exec(text)) !== null) {
-    parts.push(replaceRefs(text.slice(last, m.index), lookup));
+  while ((m = codeSkip.exec(text)) !== null) {
+    parts.push(linkifySegment(text.slice(last, m.index), lookup, projectId, projectNameToId));
     parts.push(m[0]);
     last = m.index + m[0].length;
   }
-  parts.push(replaceRefs(text.slice(last), lookup));
+  parts.push(linkifySegment(text.slice(last), lookup, projectId, projectNameToId));
   return parts.join("");
 }
 
-function replaceRefs(
+/**
+ * Process a single non-code text segment: first resolve [[...]] page links,
+ * then linkify #issue refs and @mentions while skipping resulting wikilinks.
+ */
+function linkifySegment(
+  text: string,
+  lookup: (externalId: string) => string | undefined,
+  projectId?: number,
+  projectNameToId?: Record<string, number>,
+): string {
+  // Step 1: Resolve cross-project page links [[/Project Name/page-name]]
+  text = text.replace(/\[\[\/(.+?)\/([\w-]+)\]\]/g, (_match, projName: string, pageName: string) => {
+    const pid = projectNameToId?.[projName];
+    if (!pid) return `[[${projName}/${pageName}]]`;
+    const path = lookup(`page:${pid}:${pageName}`);
+    if (!path) return `[[${projName}/${pageName}]]`;
+    return `[[${path}|${projName}/${pageName}]]`;
+  });
+
+  // Step 2: Resolve same-project page links [[page-name]]
+  // Only match bare [[word-chars]] that haven't been resolved yet (no | inside).
+  text = text.replace(/\[\[([\w-]+)\]\]/g, (match, pageName: string) => {
+    if (!projectId) return match;
+    const path = lookup(`page:${projectId}:${pageName}`);
+    if (!path) return match;
+    return `[[${path}|${pageName}]]`;
+  });
+
+  // Step 3: Linkify #issue refs and @mentions, skipping inside [[...]] blocks
+  const wikiSkip = /\[\[[^\]]*\]\]/g;
+  const parts: string[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = wikiSkip.exec(text)) !== null) {
+    parts.push(replaceInlineRefs(text.slice(last, m.index), lookup));
+    parts.push(m[0]);
+    last = m.index + m[0].length;
+  }
+  parts.push(replaceInlineRefs(text.slice(last), lookup));
+  return parts.join("");
+}
+
+/** Replace #issue refs and @mentions in a text fragment (no wikilinks inside). */
+function replaceInlineRefs(
   text: string,
   lookup: (externalId: string) => string | undefined,
 ): string {
-  return text.replace(/#(\d+)/g, (match, id) => {
+  // #1234 issue references
+  text = text.replace(/#(\d+)/g, (match, id) => {
     const path = lookup(`issue:${id}`);
     if (!path) return match;
     return `[[${path}|#${padId(parseInt(id))}]]`;
   });
+
+  // @username mentions
+  text = text.replace(/@([a-zA-Z0-9_.-]+)/g, (match, name) => {
+    const path = lookup(`user:${name}`);
+    if (!path) return match;
+    return `[[${path}|@${name}]]`;
+  });
+
+  return text;
+}
+
+/** Render a username as a wikilink to the user entity in markdown, prefixed with @. */
+function mdUserRef(
+  username: string,
+  lookup: (externalId: string) => string | undefined,
+): string {
+  const path = lookup(`user:${username}`);
+  if (path) {
+    return `[[${path}|@${username}]]`;
+  }
+  return `@${username}`;
+}
+
+/** Render a user's full name as a wikilink to the user entity in markdown (no @ prefix). */
+function mdUserRefFull(
+  username: string,
+  fullName: string,
+  lookup: (externalId: string) => string | undefined,
+): string {
+  const path = lookup(`user:${username}`);
+  if (path) {
+    return `[[${path}|${fullName}]]`;
+  }
+  return fullName;
+}
+
+/** Returns the file path (no extension) for a page. Includes project folder for multi-project collections. */
+function pageFilePath(name: string, projectName?: string, singleProject?: boolean): string {
+  const slug = slugify(name);
+  const pagePart = slug || name;
+  if (singleProject || !projectName) return `pages/${pagePart}`;
+  return `${slugify(projectName)}/pages/${pagePart}`;
 }
 
 export class MantisBTTheme implements Theme {
@@ -208,6 +341,7 @@ export class MantisBTTheme implements Theme {
   render(context: ThemeRenderContext): string {
     if (context.entity.entityType === "user") return this.renderUserMd(context);
     if (context.entity.entityType === "project") return this.renderProjectMd(context);
+    if (context.entity.entityType === "page") return this.renderPageMd(context);
     return this.renderIssue(context);
   }
 
@@ -220,29 +354,37 @@ export class MantisBTTheme implements Theme {
     }
 
     if (context.entity.entityType === "project") {
-      const id = d.id as number;
       const name = d.name as string;
       const slug = slugify(name);
-      return slug ? `projects/${padId(id)}-${slug}.md` : `projects/${padId(id)}.md`;
+      return `projects/${slug || "unnamed"}.md`;
+    }
+
+    if (context.entity.entityType === "page") {
+      const name = d.name as string;
+      const projectName = (d.project as { name: string })?.name;
+      const singleProject = d._singleProject as boolean | undefined;
+      return `${pageFilePath(name, projectName, singleProject)}.md`;
     }
 
     const id = d.id as number;
     const summary = d.summary as string;
-    const slug = slugify(summary);
-    return slug
-      ? `issues/${padId(id)}-${slug}.md`
-      : `issues/${padId(id)}.md`;
+    const projectName = (d.project as { name: string })?.name;
+    const singleProject = d._singleProject as boolean | undefined;
+    return `${issueFilePath(id, summary, projectName, singleProject)}.md`;
   }
 
   renderHtml(context: ThemeRenderContext): string | null {
     if (context.entity.entityType === "user") return this.renderUserHtml(context);
     if (context.entity.entityType === "project") return this.renderProjectHtml(context);
+    if (context.entity.entityType === "page") return this.renderPageHtml(context);
     return this.renderIssueHtml(context);
   }
 
   private renderIssueHtml(context: ThemeRenderContext): string {
     const d = context.entity.data;
     const lookup = context.lookupEntityPath;
+    const projectId = (d.project as { id: number } | null)?.id;
+    const projectNameToId = d._projectNameToId as Record<string, number> | undefined;
 
     const status = d.status as { name: string; label: string; color?: string };
     const resolution = d.resolution as { name: string; label: string };
@@ -287,15 +429,15 @@ export class MantisBTTheme implements Theme {
     parts.push(`<h2 class="mt-section-title">Details</h2>`);
     parts.push(`<div class="mt-section-body">`);
     if (d.description) {
-      parts.push(`<div class="mt-description">${textToHtml(d.description as string, lookup)}</div>`);
+      parts.push(`<div class="mt-description">${textToHtml(d.description as string, lookup, projectId, projectNameToId)}</div>`);
     }
     if (d.stepsToReproduce) {
       parts.push(`<h3 class="mt-subsection-title">Steps to Reproduce</h3>`);
-      parts.push(`<div class="mt-description">${textToHtml(d.stepsToReproduce as string, lookup)}</div>`);
+      parts.push(`<div class="mt-description">${textToHtml(d.stepsToReproduce as string, lookup, projectId, projectNameToId)}</div>`);
     }
     if (d.additionalInformation) {
       parts.push(`<h3 class="mt-subsection-title">Additional Information</h3>`);
-      parts.push(`<div class="mt-description">${textToHtml(d.additionalInformation as string, lookup)}</div>`);
+      parts.push(`<div class="mt-description">${textToHtml(d.additionalInformation as string, lookup, projectId, projectNameToId)}</div>`);
     }
 
     // Issue-level attachments
@@ -322,7 +464,7 @@ export class MantisBTTheme implements Theme {
       parts.push(`<h2 class="mt-section-title">Relationships</h2>`);
       parts.push(`<div class="mt-section-body">`);
       for (const rel of relationships) {
-        const targetPath = issueFilePath(rel.issue.id, rel.issue.summary ?? "");
+        const targetPath = lookup?.(`issue:${rel.issue.id}`) ?? issueFilePath(rel.issue.id, rel.issue.summary ?? "", project?.name, !!(d._singleProject));
         const label = rel.issue.summary
           ? `${padId(rel.issue.id)} - ${esc(rel.issue.summary)}`
           : padId(rel.issue.id);
@@ -392,7 +534,7 @@ export class MantisBTTheme implements Theme {
           parts.push(`</div>`);
           parts.push(`<div class="mt-activity-body">`);
           parts.push(`<div class="mt-note-body ${borderClass}">`);
-          parts.push(`<div class="mt-note-text">${textToHtml(note.text, lookup)}</div>`);
+          parts.push(`<div class="mt-note-text">${textToHtml(note.text, lookup, projectId, projectNameToId)}</div>`);
 
           // Note attachments
           if (note.attachments?.length) {
@@ -411,7 +553,7 @@ export class MantisBTTheme implements Theme {
           const entry = activity.data as typeof history[number];
           parts.push(`<div class="mt-activity mt-history-entry">`);
           parts.push(`<div class="mt-activity-header">`);
-          parts.push(`${mtAvatar(entry.user.name)} <strong class="mt-activity-author">${esc(entry.user.name)}</strong>`);
+          parts.push(`${mtAvatar(entry.user.name)} <strong class="mt-activity-author">${mtUserLink(entry.user.name, lookup)}</strong>`);
           parts.push(`<span class="mt-activity-date">${formatDateCompact(entry.created_at)}</span>`);
           parts.push(`</div>`);
           if (entry.field || entry.message) {
@@ -546,6 +688,157 @@ export class MantisBTTheme implements Theme {
     return parts.join("\n");
   }
 
+  private renderPageMd(context: ThemeRenderContext): string {
+    const d = context.entity.data;
+    const lookup = context.lookupEntityPath ?? (() => undefined);
+    const projectId = (d.project as { id: number } | null)?.id;
+    const projectNameToId = d._projectNameToId as Record<string, number> | undefined;
+    const project = d.project as { id: number; name: string } | null;
+    const createdBy = d.createdBy as { name: string; real_name?: string } | null;
+    const updatedBy = d.updatedBy as { name: string; real_name?: string } | null;
+    const content = (d.content as string) ?? "";
+
+    const fm: Record<string, unknown> = {
+      title: d.title || d.name,
+      type: "page",
+      name: d.name,
+    };
+    if (project) fm.project = project.name;
+    if (d.createdAt) fm.created = d.createdAt;
+    if (d.updatedAt) fm.updated = d.updatedAt;
+    if (context.entity.tags?.length) fm.tags = context.entity.tags;
+
+    const sections: string[] = [frontmatter(fm)];
+
+    // Header with project breadcrumb
+    const crumbs = [project?.name, d.name as string].filter(Boolean).join(" > ");
+    sections.push(`**${crumbs}**`);
+
+    sections.push(`## ${d.title || d.name}`);
+
+    // Page content (raw markdown)
+    if (content) {
+      sections.push(linkifyContent(content, lookup, projectId, projectNameToId));
+    }
+
+    // File attachments
+    const files = d.files as Array<{ name: string; storagePath?: string }> | undefined;
+    if (files?.length) {
+      const embeds = files
+        .filter((f) => f.storagePath)
+        .map((f) => `![${f.name}](${assetRef(f.storagePath)})`);
+      if (embeds.length) {
+        sections.push("### Attachments\n\n" + embeds.join("\n\n"));
+      }
+    }
+
+    // Metadata
+    const rows: string[] = ["| | |", "|---|---|"];
+    if (createdBy?.name) {
+      const ref = createdBy.real_name
+        ? mdUserRefFull(createdBy.name, createdBy.real_name, lookup)
+        : mdUserRef(createdBy.name, lookup);
+      rows.push(tableRow("Created By", ref));
+    }
+    if (updatedBy?.name) {
+      const ref = updatedBy.real_name
+        ? mdUserRefFull(updatedBy.name, updatedBy.real_name, lookup)
+        : mdUserRef(updatedBy.name, lookup);
+      rows.push(tableRow("Updated By", ref));
+    }
+    if (d.createdAt) rows.push(tableRow("Created", formatDate(d.createdAt as string)));
+    if (d.updatedAt) rows.push(tableRow("Updated", formatDate(d.updatedAt as string)));
+    sections.push("### Metadata\n\n" + rows.join("\n"));
+
+    return sections.join("\n\n");
+  }
+
+  private renderPageHtml(context: ThemeRenderContext): string {
+    const d = context.entity.data;
+    const lookup = context.lookupEntityPath;
+    const projectId = (d.project as { id: number } | null)?.id;
+    const projectNameToId = d._projectNameToId as Record<string, number> | undefined;
+    const project = d.project as { id: number; name: string } | null;
+    const createdBy = d.createdBy as { name: string; real_name?: string } | null;
+    const updatedBy = d.updatedBy as { name: string; real_name?: string } | null;
+    const content = (d.content as string) ?? "";
+
+    const parts: string[] = [];
+    parts.push(`<div class="mt-issue-view">`);
+
+    // Header
+    parts.push(`<div class="mt-header">`);
+    if (project) {
+      const projectHtml = mtProjectLink(project, lookup);
+      parts.push(`<div class="mt-breadcrumb">${projectHtml} &rsaquo; ${esc(d.name as string)}</div>`);
+    }
+    parts.push(`<h1 class="mt-title">${esc((d.title as string) || (d.name as string))}</h1>`);
+    parts.push(`</div>`);
+
+    // Two-column layout
+    parts.push(`<div class="mt-columns">`);
+
+    // Main column
+    parts.push(`<div class="mt-main-col">`);
+
+    // Content section
+    if (content) {
+      parts.push(`<div class="mt-section">`);
+      parts.push(`<div class="mt-section-body">`);
+      parts.push(`<div class="mt-description">${textToHtml(content, lookup, projectId, projectNameToId)}</div>`);
+      parts.push(`</div>`);
+      parts.push(`</div>`);
+    }
+
+    // File attachments
+    const files = d.files as Array<{ name: string; storagePath?: string; size: number }> | undefined;
+    if (files?.length) {
+      parts.push(`<div class="mt-section">`);
+      parts.push(`<h2 class="mt-section-title">Attachments</h2>`);
+      parts.push(`<div class="mt-section-body">`);
+      parts.push(`<div class="mt-attachments">`);
+      for (const f of files) {
+        const sizeKb = Math.round(f.size / 1024);
+        parts.push(`<div class="mt-attachment-item">${esc(f.name)} <span class="mt-attachment-size">(${sizeKb} KB)</span></div>`);
+      }
+      parts.push(`</div>`);
+      parts.push(`</div>`);
+      parts.push(`</div>`);
+    }
+
+    parts.push(`</div>`); // mt-main-col
+
+    // Sidebar
+    parts.push(`<div class="mt-sidebar-col">`);
+    parts.push(`<h3 class="mt-sidebar-heading">Overview</h3>`);
+
+    if (createdBy?.name) {
+      const userHtml = createdBy.real_name
+        ? mtUserLinkFull(createdBy.name, createdBy.real_name, lookup)
+        : mtUserLink(createdBy.name, lookup);
+      parts.push(mtSidebarRow("Created By", `${mtAvatar(createdBy.name, null, 20)} <strong>${userHtml}</strong>`));
+    }
+    if (updatedBy?.name) {
+      const userHtml = updatedBy.real_name
+        ? mtUserLinkFull(updatedBy.name, updatedBy.real_name, lookup)
+        : mtUserLink(updatedBy.name, lookup);
+      parts.push(mtSidebarRow("Updated By", `${mtAvatar(updatedBy.name, null, 20)} <strong>${userHtml}</strong>`));
+    }
+
+    if (d.createdAt) parts.push(mtSidebarRow("Created", formatDateCompact(d.createdAt as string)));
+    if (d.updatedAt) parts.push(mtSidebarRow("Updated", formatDateCompact(d.updatedAt as string)));
+
+    if (context.entity.url) {
+      parts.push(`<div class="mt-sidebar-row mt-sidebar-link-row"><a class="mt-sidebar-link" href="${esc(context.entity.url)}" target="_blank" rel="noopener noreferrer">View in MantisHub &rarr;</a></div>`);
+    }
+
+    parts.push(`</div>`); // mt-sidebar-col
+    parts.push(`</div>`); // mt-columns
+    parts.push(`</div>`); // mt-issue-view
+
+    return parts.join("\n");
+  }
+
   private renderIssue(context: ThemeRenderContext): string {
     const d = context.entity.data;
     const sections: string[] = [];
@@ -554,13 +847,15 @@ export class MantisBTTheme implements Theme {
     const resolution = d.resolution as { name: string; label: string };
     const priority = d.priority as { name: string; label: string };
     const severity = d.severity as { name: string; label: string };
-    const project = d.project as { name: string } | null;
+    const project = d.project as { id: number; name: string } | null;
     const category = d.category as { name: string } | null;
     const reporter = d.reporter as { name: string } | null;
     const handler = d.handler as { name: string } | null;
     const reproducibility = d.reproducibility as { label: string } | null;
 
     const lookup = context.lookupEntityPath ?? (() => undefined);
+    const projectId = project?.id;
+    const projectNameToId = d._projectNameToId as Record<string, number> | undefined;
 
     // Frontmatter
     const fm: Record<string, unknown> = {
@@ -598,8 +893,8 @@ export class MantisBTTheme implements Theme {
       tableRow("Priority", priority.label),
       tableRow("Severity", severity.label),
     ];
-    if (reporter?.name) rows.push(tableRow("Reporter", reporter.name));
-    if (handler?.name) rows.push(tableRow("Assigned To", handler.name));
+    if (reporter?.name) rows.push(tableRow("Reporter", mdUserRef(reporter.name, lookup)));
+    if (handler?.name) rows.push(tableRow("Assigned To", mdUserRef(handler.name, lookup)));
     if (reproducibility) rows.push(tableRow("Reproducibility", reproducibility.label));
     rows.push(tableRow("Created", formatDate(d.createdAt as string)));
     rows.push(tableRow("Updated", formatDate(d.updatedAt as string)));
@@ -610,7 +905,7 @@ export class MantisBTTheme implements Theme {
     if (files?.length) {
       const embeds = files
         .filter((f) => f.storagePath)
-        .map((f) => `![${f.filename}](../../${f.storagePath})`);
+        .map((f) => `![${f.filename}](${assetRef(f.storagePath)})`);
       if (embeds.length) {
         sections.push("### Attachments\n\n" + embeds.join("\n\n"));
       }
@@ -619,7 +914,7 @@ export class MantisBTTheme implements Theme {
     // Description
     if (d.description) {
       sections.push(
-        linkifyIssueRefs(d.description as string, lookup),
+        linkifyContent(d.description as string, lookup, projectId, projectNameToId),
       );
     }
 
@@ -627,7 +922,7 @@ export class MantisBTTheme implements Theme {
     if (d.stepsToReproduce) {
       sections.push(
         "### Steps to Reproduce\n\n" +
-          linkifyIssueRefs(d.stepsToReproduce as string, lookup),
+          linkifyContent(d.stepsToReproduce as string, lookup, projectId, projectNameToId),
       );
     }
 
@@ -635,7 +930,7 @@ export class MantisBTTheme implements Theme {
     if (d.additionalInformation) {
       sections.push(
         "### Additional Information\n\n" +
-          linkifyIssueRefs(d.additionalInformation as string, lookup),
+          linkifyContent(d.additionalInformation as string, lookup, projectId, projectNameToId),
       );
     }
 
@@ -646,7 +941,7 @@ export class MantisBTTheme implements Theme {
     }>;
     if (relationships?.length) {
       const relLines = relationships.map((rel) => {
-        const targetPath = issueFilePath(rel.issue.id, rel.issue.summary ?? "");
+        const targetPath = lookup(`issue:${rel.issue.id}`) ?? issueFilePath(rel.issue.id, rel.issue.summary ?? "", project?.name, !!projectId && !!(d._singleProject));
         const label = rel.issue.summary
           ? `${padId(rel.issue.id)} ${rel.issue.summary}`
           : padId(rel.issue.id);
@@ -666,18 +961,19 @@ export class MantisBTTheme implements Theme {
     }>;
     if (notes?.length) {
       const noteBlocks = notes.map((note) => {
-        const author = note.reporter?.name ?? "Unknown";
+        const authorName = note.reporter?.name ?? "Unknown";
+        const authorRef = authorName !== "Unknown" ? mdUserRef(authorName, lookup) : authorName;
         const isPrivate = note.view_state?.name === "private";
-        const parts = [author, formatDate(note.created_at)];
-        if (isPrivate) parts.push("private");
-        const header = `**${parts.join(" | ")}**`;
+        const headerParts = [authorRef, formatDate(note.created_at)];
+        if (isPrivate) headerParts.push("private");
+        const header = `**${headerParts.join(" | ")}**`;
 
-        const body = linkifyIssueRefs(note.text, lookup);
+        const body = linkifyContent(note.text, lookup, projectId, projectNameToId);
 
         // Embed note attachments using stored paths (relative from markdown/<type>/)
         const embeds = (note.attachments ?? [])
           .filter((att) => att.storagePath)
-          .map((att) => `![${att.filename}](../../${att.storagePath})`);
+          .map((att) => `![${att.filename}](${assetRef(att.storagePath)})`);
 
         return [header, body, ...embeds].filter(Boolean).join("\n\n");
       });

--- a/packages/crawlers/src/mantisbt/types.ts
+++ b/packages/crawlers/src/mantisbt/types.ts
@@ -16,15 +16,47 @@ export interface MantisBTProject {
   status?: { id: number; name: string; label: string };
 }
 
+/** Entity types that can be synced for a MantisBT collection. */
+export type MantisBTEntityType = "issues" | "pages" | "users";
+
 export interface MantisBTConfig {
-  baseUrl: string;
-  projectId?: number;
-  projectName?: string;
+  url: string;
+  project?: { id?: number; name?: string };
   maxEntities?: number;
+  /**
+   * Entity types to synchronize. Defaults to all applicable types when omitted.
+   * "pages" is only available on MantisHub instances.
+   */
+  entities?: MantisBTEntityType[];
 }
 
 export interface MantisBTCredentials {
   token: string;
+}
+
+/** A wiki page from MantisHub Pages plugin (via ApiX update endpoint). */
+export interface MantisBTPage {
+  id: number;
+  name: string;
+  title: string;
+  project: { id: number; name: string };
+  issue_id: number;
+  created_by: { id: number; name: string; real_name?: string; email?: string; avatar?: string };
+  created_at: { timestamp: string };
+  updated_by: { id: number; name: string; real_name?: string; email?: string; avatar?: string };
+  updated_at: { timestamp: string };
+  content: string;
+}
+
+/** A file attachment on a MantisHub wiki page. */
+export interface MantisBTPageFile {
+  id: number;
+  page_id: number;
+  name: string;
+  size: number;
+  content_type: string;
+  created_at: { timestamp: string };
+  download_url: string;
 }
 
 export interface MantisBTIssue {

--- a/packages/desktop/src/main/workspace-manager.ts
+++ b/packages/desktop/src/main/workspace-manager.ts
@@ -37,16 +37,13 @@ export function createWorkspace(name: string, dirPath: string): void {
   // Ensure the workspace directory exists with proper structure
   mkdirSync(join(dirPath, "collections"), { recursive: true });
 
-  // Create initial context.yml if it doesn't exist
-  const contextPath = join(dirPath, "context.yml");
-  if (!existsSync(contextPath)) {
-    writeFileSync(contextPath, "collections: {}\ndeployments: {}\n", "utf-8");
-  }
+  // Collections directory is created above — no separate context file needed.
+  // Collection metadata is stored in per-collection .config files.
 
-  // Create initial config.json if it doesn't exist
-  const configPath = join(dirPath, "config.json");
+  // Create initial frozenink.yml if it doesn't exist
+  const configPath = join(dirPath, "frozenink.yml");
   if (!existsSync(configPath)) {
-    writeFileSync(configPath, "{}", "utf-8");
+    writeFileSync(configPath, "", "utf-8");
   }
 
   // Register in workspaces

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -4,8 +4,9 @@ import { dirname, join } from "path";
 import {
   getCollectionDb,
   entities,
+  tags,
   entityTags,
-  attachments,
+  assets,
   syncRuns,
   SearchIndexer,
   addCollection as coreAddCollection,
@@ -36,7 +37,7 @@ function addCollection(
   opts?: { enabled?: boolean },
 ): { dbPath: string } {
   const collectionDir = join(TEST_DIR, "collections", name);
-  const dbPath = join(collectionDir, "data.db");
+  const dbPath = join(collectionDir, "db", "data.db");
 
   mkdirSync(collectionDir, { recursive: true });
   mkdirSync(join(collectionDir, "markdown"), { recursive: true });
@@ -87,7 +88,16 @@ function addEntity(
 
   if (data.tags?.length) {
     for (const tag of data.tags) {
-      colDb.insert(entityTags).values({ entityId, tag }).run();
+      // Insert tag if it doesn't exist, then link to entity
+      const existing = colDb.select().from(tags).all().find((t) => t.name === tag);
+      let tagId: number;
+      if (existing) {
+        tagId = existing.id;
+      } else {
+        colDb.insert(tags).values({ name: tag }).run();
+        tagId = colDb.select().from(tags).all().find((t) => t.name === tag)!.id;
+      }
+      colDb.insert(entityTags).values({ entityId, tagId }).run();
     }
   }
 
@@ -107,13 +117,12 @@ function addAttachment(
 ): void {
   const colDb = getCollectionDb(dbPath);
   colDb
-    .insert(attachments)
+    .insert(assets)
     .values({
       entityId: data.entityId,
       filename: data.filename,
       mimeType: data.mimeType,
       storagePath: data.storagePath,
-      backend: "local",
     })
     .run();
 

--- a/packages/mcp/src/resources/entity.ts
+++ b/packages/mcp/src/resources/entity.ts
@@ -9,6 +9,7 @@ import {
   getCollectionDbPath,
   entities,
   entityTags,
+  tags,
 } from "@frozenink/core";
 import { eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
@@ -87,12 +88,13 @@ export function registerEntityResources(
         };
       }
 
-      const tags = colDb
-        .select()
+      const entityTagRows = colDb
+        .select({ name: tags.name })
         .from(entityTags)
+        .innerJoin(tags, eq(entityTags.tagId, tags.id))
         .where(eq(entityTags.entityId, entity.id))
         .all()
-        .map((t: any) => t.tag);
+        .map((t: any) => t.name);
 
       return {
         contents: [
@@ -106,7 +108,7 @@ export function registerEntityResources(
               title: entity.title,
               data: entity.data,
               url: entity.url,
-              tags,
+              tags: entityTagRows,
               createdAt: entity.createdAt,
               updatedAt: entity.updatedAt,
             }),

--- a/packages/mcp/src/tools/get-attachment.ts
+++ b/packages/mcp/src/tools/get-attachment.ts
@@ -8,7 +8,7 @@ import {
   getCollectionDb,
   getCollectionDbPath,
   entities,
-  attachments,
+  assets,
 } from "@frozenink/core";
 import { and, eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
@@ -54,22 +54,22 @@ function buildCandidates(refPath: string, markdownPath: string | null): string[]
   }
 
   candidates.add(clean);
-  if (!clean.startsWith("attachments/")) {
-    candidates.add(`attachments/${clean}`);
+  if (!clean.startsWith("assets/")) {
+    candidates.add(`assets/${clean}`);
   }
 
   if (markdownPath) {
     const markdownDir = posix.dirname(markdownPath);
     const relResolved = posix.normalize(posix.join(markdownDir, clean));
     candidates.add(relResolved);
-    if (!relResolved.startsWith("attachments/")) {
-      candidates.add(`attachments/${relResolved}`);
+    if (!relResolved.startsWith("assets/")) {
+      candidates.add(`assets/${relResolved}`);
     }
 
     const relResolvedNoMd = posix.normalize(posix.join(markdownDir.replace(/^markdown\/?/, ""), clean));
     candidates.add(relResolvedNoMd);
-    if (!relResolvedNoMd.startsWith("attachments/")) {
-      candidates.add(`attachments/${relResolvedNoMd}`);
+    if (!relResolvedNoMd.startsWith("assets/")) {
+      candidates.add(`assets/${relResolvedNoMd}`);
     }
   }
 
@@ -90,7 +90,7 @@ export function registerGetAttachment(
         collection: z.string().describe("Collection name"),
         reference: z
           .string()
-          .describe("Attachment reference from markdown, e.g. ![[git/abc/logo.png]] or attachments/git/abc/logo.png"),
+          .describe("Attachment reference from markdown, e.g. ![[git/abc/logo.png]] or assets/git/abc/logo.png"),
         externalId: z
           .string()
           .optional()
@@ -186,7 +186,6 @@ export function registerGetAttachment(
             filename: string;
             mimeType: string;
             storagePath: string;
-            backend: string;
           }
         | undefined;
 
@@ -194,18 +193,18 @@ export function registerGetAttachment(
         const rows = sourceEntityId
           ? colDb
             .select()
-            .from(attachments)
+            .from(assets)
             .where(
               and(
-                eq(attachments.storagePath, candidate),
-                eq(attachments.entityId, sourceEntityId),
+                eq(assets.storagePath, candidate),
+                eq(assets.entityId, sourceEntityId),
               ),
             )
             .all()
           : colDb
             .select()
-            .from(attachments)
-            .where(eq(attachments.storagePath, candidate))
+            .from(assets)
+            .where(eq(assets.storagePath, candidate))
             .all();
 
         if (rows.length > 0) {
@@ -219,13 +218,13 @@ export function registerGetAttachment(
         const byFilename = sourceEntityId
           ? colDb
             .select()
-            .from(attachments)
-            .where(and(eq(attachments.filename, fileName), eq(attachments.entityId, sourceEntityId)))
+            .from(assets)
+            .where(and(eq(assets.filename, fileName), eq(assets.entityId, sourceEntityId)))
             .all()
           : colDb
             .select()
-            .from(attachments)
-            .where(eq(attachments.filename, fileName))
+            .from(assets)
+            .where(eq(assets.filename, fileName))
             .all();
 
         if (byFilename.length === 1) {

--- a/packages/mcp/src/tools/get-entity.ts
+++ b/packages/mcp/src/tools/get-entity.ts
@@ -9,6 +9,7 @@ import {
   getCollectionDbPath,
   entities,
   entityTags,
+  tags,
 } from "@frozenink/core";
 import { eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
@@ -87,12 +88,13 @@ export function registerGetEntity(
         };
       }
 
-      const tags = colDb
-        .select()
+      const entityTagRows = colDb
+        .select({ name: tags.name })
         .from(entityTags)
+        .innerJoin(tags, eq(entityTags.tagId, tags.id))
         .where(eq(entityTags.entityId, entity.id))
         .all()
-        .map((t: any) => t.tag);
+        .map((t: any) => t.name);
 
       let markdown: string | null = null;
       if (entity.markdownPath) {
@@ -114,7 +116,7 @@ export function registerGetEntity(
         title: entity.title,
         data: entity.data,
         url: entity.url,
-        tags,
+        tags: entityTagRows,
         markdown,
         createdAt: entity.createdAt,
         updatedAt: entity.updatedAt,

--- a/packages/worker/src/db/client.ts
+++ b/packages/worker/src/db/client.ts
@@ -23,18 +23,22 @@ export interface EntityTag {
   id: number;
   collection_name: string;
   entity_id: number;
-  tag: string;
+  tag_id: number;
+}
+
+export interface Tag {
+  id: number;
+  name: string;
 }
 
 export interface EntityLink {
   id: number;
   collection_name: string;
   source_entity_id: number;
-  source_markdown_path: string;
-  target_path: string;
+  target_entity_id: number;
 }
 
-export interface Attachment {
+export interface Asset {
   id: number;
   collection_name: string;
   entity_id: number;
@@ -136,36 +140,24 @@ export async function getEntityTags(
   entityId: number,
 ): Promise<string[]> {
   const { results } = await db
-    .prepare("SELECT tag FROM entity_tags WHERE collection_name = ? AND entity_id = ?")
+    .prepare(
+      "SELECT t.name FROM entity_tags et INNER JOIN tags t ON et.tag_id = t.id WHERE et.collection_name = ? AND et.entity_id = ?",
+    )
     .bind(collectionName, entityId)
-    .all<{ tag: string }>();
-  return (results ?? []).map((r) => r.tag);
+    .all<{ name: string }>();
+  return (results ?? []).map((r) => r.name);
 }
 
 export async function getBacklinks(
   db: D1Database,
   collectionName: string,
-  targetPath: string,
+  targetEntityId: number,
 ): Promise<Array<{ entity: Entity; link: EntityLink }>> {
-  // Build variants for matching
-  const variants = [targetPath, `markdown/${targetPath}`];
-  if (!targetPath.endsWith(".md")) {
-    variants.push(`${targetPath}.md`, `markdown/${targetPath}.md`);
-  }
-  const filename = targetPath.includes("/") ? targetPath.split("/").pop()! : null;
-  if (filename) {
-    variants.push(filename, `markdown/${filename}`);
-    if (!filename.endsWith(".md")) {
-      variants.push(`${filename}.md`, `markdown/${filename}.md`);
-    }
-  }
-
-  const placeholders = variants.map(() => "?").join(",");
   const { results: linkRows } = await db
     .prepare(
-      `SELECT * FROM entity_links WHERE collection_name = ? AND target_path IN (${placeholders})`,
+      "SELECT * FROM links WHERE collection_name = ? AND target_entity_id = ?",
     )
-    .bind(collectionName, ...variants)
+    .bind(collectionName, targetEntityId)
     .all<EntityLink>();
 
   const seen = new Set<number>();
@@ -188,43 +180,28 @@ export async function getBacklinks(
 export async function getOutgoingLinks(
   db: D1Database,
   collectionName: string,
-  sourcePath: string,
-): Promise<Array<{ entity: Entity | null; targetPath: string }>> {
-  const variants = [sourcePath, `markdown/${sourcePath}`];
-  const placeholders = variants.map(() => "?").join(",");
-
+  sourceEntityId: number,
+): Promise<Array<{ entity: Entity | null; link: EntityLink }>> {
   const { results: linkRows } = await db
     .prepare(
-      `SELECT * FROM entity_links WHERE collection_name = ? AND source_markdown_path IN (${placeholders})`,
+      "SELECT * FROM links WHERE collection_name = ? AND source_entity_id = ?",
     )
-    .bind(collectionName, ...variants)
+    .bind(collectionName, sourceEntityId)
     .all<EntityLink>();
 
-  const seen = new Set<string>();
-  const out: Array<{ entity: Entity | null; targetPath: string }> = [];
+  const seen = new Set<number>();
+  const out: Array<{ entity: Entity | null; link: EntityLink }> = [];
 
   for (const link of linkRows ?? []) {
-    if (seen.has(link.target_path)) continue;
-    seen.add(link.target_path);
+    if (seen.has(link.target_entity_id)) continue;
+    seen.add(link.target_entity_id);
 
-    // Try direct match
-    let entity = await db
-      .prepare("SELECT * FROM entities WHERE markdown_path = ?")
-      .bind(link.target_path)
+    const entity = await db
+      .prepare("SELECT * FROM entities WHERE id = ?")
+      .bind(link.target_entity_id)
       .first<Entity>();
 
-    // Try filename match
-    if (!entity) {
-      const filename = link.target_path.split("/").pop();
-      if (filename) {
-        entity = await db
-          .prepare("SELECT * FROM entities WHERE markdown_path LIKE ?")
-          .bind(`%/${filename}`)
-          .first<Entity>();
-      }
-    }
-
-    out.push({ entity, targetPath: link.target_path });
+    out.push({ entity, link });
   }
 
   return out;

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -193,13 +193,15 @@ api.get("/api/search", async (c) => {
   return c.json(enriched);
 });
 
-// GET /api/collections/:name/backlinks/*
-api.get("/api/collections/:name/backlinks/*", async (c) => {
+// GET /api/collections/:name/backlinks/:externalId
+api.get("/api/collections/:name/backlinks/:externalId", async (c) => {
   const name = c.req.param("name");
-  const targetFile = c.req.path.replace(`/api/collections/${encodeURIComponent(name)}/backlinks/`, "");
-  const decoded = decodeURIComponent(targetFile);
+  const externalId = decodeURIComponent(c.req.param("externalId"));
 
-  const links = await getBacklinks(c.env.DB, name, decoded);
+  const targetEntity = await getEntityByExternalId(c.env.DB, name, externalId);
+  if (!targetEntity) return c.json({ error: "Entity not found" }, 404);
+
+  const links = await getBacklinks(c.env.DB, name, targetEntity.id);
 
   const results = links.map(({ entity }) => {
     const relPath = entity.markdown_path?.replace(/^markdown\//, "");
@@ -218,13 +220,15 @@ api.get("/api/collections/:name/backlinks/*", async (c) => {
   return c.json(results);
 });
 
-// GET /api/collections/:name/outgoing-links/*
-api.get("/api/collections/:name/outgoing-links/*", async (c) => {
+// GET /api/collections/:name/outgoing-links/:externalId
+api.get("/api/collections/:name/outgoing-links/:externalId", async (c) => {
   const name = c.req.param("name");
-  const sourceFile = c.req.path.replace(`/api/collections/${encodeURIComponent(name)}/outgoing-links/`, "");
-  const decoded = decodeURIComponent(sourceFile);
+  const externalId = decodeURIComponent(c.req.param("externalId"));
 
-  const links = await getOutgoingLinks(c.env.DB, name, decoded);
+  const sourceEntity = await getEntityByExternalId(c.env.DB, name, externalId);
+  if (!sourceEntity) return c.json({ error: "Entity not found" }, 404);
+
+  const links = await getOutgoingLinks(c.env.DB, name, sourceEntity.id);
 
   const results = links
     .filter(({ entity }) => entity !== null)


### PR DESCRIPTION
## Summary

- **Collection config**: `.config` → `<name>.yml` per collection
- **Content layout**: Assets inside entity folders, multi-project path flip (`<project>/<type>/` instead of `<type>/<project>/`)
- **Sites replace deployments**: `publish.yml` → `sites/<name>/` directory with `<name>.yml` + `state.yml`
- **DB schema**: `entity_links` → `links` (entity ID-based), `attachments` → `assets`, new `tags` table with ID-based `entity_tags`
- **Config**: `config.json` → `frozenink.yml` (YAML), removed dead sections (db, storage, mcp)
- **Asset filtering**: Image + PDF only by default, configurable via collection YAML `assets.extensions`/`assets.maxSize`, skipped files still tracked in DB
- **Auto-init**: All commands auto-initialize — no explicit `fink init` required
- **Cleanup**: Removed `entity_relations` table, GitHub creds cleanup, simplified MantisBT page/project filenames

## Test plan

- [x] `bun test packages/core/src/` — 73 pass
- [x] `bun test packages/crawlers/src/` — 162 pass
- [x] `bun test packages/mcp/src/` — 12 pass
- [x] `bun test packages/cli/src/__tests__/cli.test.ts` — 13 pass
- [x] `bun test packages/cli/src/__tests__/daemon-serve.test.ts` — 17 pass
- [x] `bun test packages/cli/src/__tests__/management-api-publish.test.ts` — 2 pass
- [ ] Full sync MantisBT collection → verify new `content/<type>/assets/` structure
- [ ] Publish a site → verify `sites/<name>/` structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)