### PR TITLE
Add MCP link management and scoped serve flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ Running `fink` with no arguments launches the **interactive TUI** with keyboard-
 | `fink generate <name\|"*">` | Re-generate markdown without re-syncing |
 | `fink index <name\|"*">` | Rebuild search index and links |
 | `fink serve` | Start API server + MCP server |
+| `fink mcp add --tool <tool> <collection...>` | Register collection-scoped MCP links in a client tool |
+| `fink mcp remove --tool <tool> <collection...>` | Remove collection-scoped MCP links from a client tool |
+| `fink mcp list [--tool <tool>]` | Show MCP link status by collection |
+| `fink mcp serve --collection <name>` | MCP stdio entrypoint used by client tools |
 | `fink daemon start\|stop\|status` | Background sync daemon |
 | `fink publish <collections...>` | Publish to Cloudflare (see [docs/publish.md](docs/publish.md)) |
 | `fink unpublish <name>` | Remove a Cloudflare deployment |
@@ -316,6 +320,33 @@ Exposes 5 tools and 4 resources for AI assistants:
 **Tools:** `collection_list`, `entity_search`, `entity_get_data`, `entity_get_markdown`, `entity_get_attachment`
 
 **Resources:** `frozenink://collections`, `frozenink://collections/{name}`, `frozenink://entities/{collection}/{externalId}`, `frozenink://markdown/{collection}/{+path}`
+
+### Installed-user MCP flow (no Bun required)
+
+```bash
+# Link one collection
+fink mcp add --tool claude-code my-github
+
+# Link multiple collections (still one connection per collection)
+fink mcp add --tool claude-code my-github my-notes
+
+# Remove one collection link without affecting others
+fink mcp remove --tool claude-code my-github
+
+# Inspect links
+fink mcp list --tool claude-code
+```
+
+Client tools execute `fink mcp serve --collection <name>` on demand over stdio, so no manual MCP server process is required for local tool links.
+
+Connection count semantics:
+
+- Add `my-github` then `my-notes` => 2 MCP connections
+- Add `my-github my-notes` in one command => also 2 MCP connections
+
+TUI path: `fink` -> `Collections` -> select collection -> `[m]` MCP config.
+
+Codex MCP support is best-effort and available only when `codex mcp` CLI commands are detected.
 
 ## Development
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -116,6 +116,10 @@ All commands are also available in headless mode for scripting and CI:
 | `fink index <name\|"*">` | Rebuild search index |
 | `fink serve` | Start API server + web UI |
 | `fink serve --mcp-only` | Start MCP server only |
+| `fink mcp add --tool <tool> <collection...>` | Register collection-scoped MCP links in a client tool |
+| `fink mcp remove --tool <tool> <collection...>` | Remove collection-scoped MCP links from a client tool |
+| `fink mcp list [--tool <tool>]` | Show MCP link status by collection |
+| `fink mcp serve --collection <name>` | MCP stdio entrypoint used by client tools |
 | `fink daemon start\|stop\|status` | Background sync daemon |
 | `fink publish <collections...>` | Publish to Cloudflare |
 | `fink unpublish <name>` | Remove a deployment |
@@ -150,14 +154,38 @@ Published sites include:
 Frozen Ink includes an MCP server for AI tools (Claude, etc.):
 
 ```bash
-# Local MCP server (STDIO transport)
-fink serve --mcp-only
+# Link one or more collections to Claude Code
+fink mcp add --tool claude-code my-repo
+fink mcp add --tool claude-code my-notes
+
+# Or add both in one command
+fink mcp add --tool claude-code my-repo my-notes
+
+# List link status
+fink mcp list --tool claude-code
+
+# Remove a single collection link
+fink mcp remove --tool claude-code my-repo
+
+# MCP stdio command used by clients
+fink mcp serve --collection my-notes
 
 # Or use the published MCP endpoint
 claude mcp add frozenink --transport streamable-http \
   --url https://my-site.workers.dev/mcp \
   --header "Authorization: Bearer <password>"
 ```
+
+Behavior notes:
+
+- Installed-user flow uses `fink mcp serve --collection <name>` and does not require Bun.
+- MCP clients launch the stdio command on demand; you do not run a background MCP server manually.
+- One MCP connection is created per `(tool, collection)`:
+  - Add `my-repo` then `my-notes` => 2 connections
+  - Add `my-repo my-notes` together => also 2 connections
+- Codex tool support is best-effort and shown only when `codex mcp` commands are detected.
+
+TUI path: open `fink` -> `Collections` -> select a collection -> press `[m]` for MCP actions.
 
 **Tools:** `collection_list`, `entity_search`, `entity_get_data`, `entity_get_markdown`, `entity_get_attachment`
 

--- a/packages/cli/src/__tests__/management-api-publish.test.ts
+++ b/packages/cli/src/__tests__/management-api-publish.test.ts
@@ -8,6 +8,7 @@ type HandleManagementRequest = (req: Request) => Response | null;
 type SetPublishOverride = (fn: ((options: {
   collectionNames: string[];
   workerName: string;
+  toolDescription?: string;
   password?: string;
   removePassword?: boolean;
   forcePublic?: boolean;
@@ -113,6 +114,7 @@ describe("management API publish security options", () => {
         body: JSON.stringify({
           collections: ["alpha"],
           name: "worker-alpha",
+          toolDescription: "Alpha collection helper",
           password: "secret123",
           removePassword: false,
           forcePublic: true,
@@ -126,6 +128,7 @@ describe("management API publish security options", () => {
     expect(captured).toBeTruthy();
     expect(captured?.collectionNames).toEqual(["alpha"]);
     expect(captured?.workerName).toBe("worker-alpha");
+    expect(captured?.toolDescription).toBe("Alpha collection helper");
     expect(captured?.password).toBe("secret123");
     expect(captured?.removePassword).toBe(false);
     expect(captured?.forcePublic).toBe(true);

--- a/packages/cli/src/__tests__/mcp-command.test.ts
+++ b/packages/cli/src/__tests__/mcp-command.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { saveContext } from "@frozenink/core";
+
+const TEST_DIR = join(import.meta.dir, ".test-mcp-command");
+
+let addArgs: unknown;
+let removeArgs: unknown;
+let listArg: unknown;
+
+beforeEach(() => {
+  addArgs = null;
+  removeArgs = null;
+  listArg = null;
+
+  mkdirSync(TEST_DIR, { recursive: true });
+  process.env.FROZENINK_HOME = TEST_DIR;
+  saveContext({ collections: {}, deployments: {} });
+
+  mock.module("../mcp/manager", () => ({
+    addMcpConnections: async (opts: unknown) => {
+      addArgs = opts;
+      return [];
+    },
+    removeMcpConnections: async (opts: unknown) => {
+      removeArgs = opts;
+      return [];
+    },
+    listMcpConnections: async (tool?: unknown) => {
+      listArg = tool;
+      return [];
+    },
+  }));
+});
+
+afterEach(() => {
+  mock.restore();
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  delete process.env.FROZENINK_HOME;
+});
+
+describe("mcp command", () => {
+  it("add passes multiple collections in one request", async () => {
+    const { addCollection } = await import("@frozenink/core");
+    addCollection("collection-a", { crawler: "github", config: {}, credentials: {} });
+    addCollection("collection-b", { crawler: "github", config: {}, credentials: {} });
+
+    const { mcpCommand } = await import("../commands/mcp");
+    await mcpCommand.parseAsync([
+      "add",
+      "--tool",
+      "claude-code",
+      "collection-a",
+      "collection-b",
+    ], { from: "user" });
+
+    expect(addArgs).toEqual({
+      tool: "claude-code",
+      collections: ["collection-a", "collection-b"],
+      description: undefined,
+    });
+  });
+
+  it("remove passes multiple collections in one request", async () => {
+    const { addCollection } = await import("@frozenink/core");
+    addCollection("collection-a", { crawler: "github", config: {}, credentials: {} });
+    addCollection("collection-b", { crawler: "github", config: {}, credentials: {} });
+
+    const { mcpCommand } = await import("../commands/mcp");
+    await mcpCommand.parseAsync([
+      "remove",
+      "--tool",
+      "claude-code",
+      "collection-a",
+      "collection-b",
+    ], { from: "user" });
+
+    expect(removeArgs).toEqual({
+      tool: "claude-code",
+      collections: ["collection-a", "collection-b"],
+    });
+  });
+
+  it("list forwards optional tool filter", async () => {
+    const { mcpCommand } = await import("../commands/mcp");
+    await mcpCommand.parseAsync(["list", "--tool", "claude-code"], { from: "user" });
+
+    expect(listArg).toBe("claude-code");
+  });
+});

--- a/packages/cli/src/__tests__/mcp-command.test.ts
+++ b/packages/cli/src/__tests__/mcp-command.test.ts
@@ -15,6 +15,8 @@ beforeEach(() => {
   listArg = null;
 
   mkdirSync(TEST_DIR, { recursive: true });
+  mkdirSync(join(TEST_DIR, "collections"), { recursive: true });
+  mkdirSync(join(TEST_DIR, "sites"), { recursive: true });
   process.env.FROZENINK_HOME = TEST_DIR;
   saveContext({ collections: {}, deployments: {} });
 

--- a/packages/cli/src/__tests__/mcp-tools.test.ts
+++ b/packages/cli/src/__tests__/mcp-tools.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { getConnectionName, getMcpServeCommandArgs } from "../mcp/tools";
+
+describe("MCP tool naming and command shape", () => {
+  it("uses deterministic per-collection connection names", () => {
+    expect(getConnectionName("collection-a")).toBe("fink-collection-a");
+    expect(getConnectionName("collection-a")).toBe(getConnectionName("collection-a"));
+  });
+
+  it("uses installed-user stdio command (no bun prefix)", () => {
+    const args = getMcpServeCommandArgs("collection-a");
+    expect(args).toEqual(["fink", "mcp", "serve", "--collection", "collection-a"]);
+    expect(args.join(" ")).not.toContain("bun run");
+  });
+});

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -91,6 +91,7 @@ type PublishCollectionsFn = (
   options: {
     collectionNames: string[];
     workerName: string;
+    toolDescription?: string;
     password?: string;
     removePassword?: boolean;
     forcePublic?: boolean;
@@ -619,12 +620,13 @@ async function triggerPublish(opts: Record<string, unknown>): Promise<void> {
       ?? (await import("./publish")).publishCollections;
     const collectionNames = (opts.collections as string[]) ?? [];
     const workerName = (opts.name as string) ?? "";
+    const toolDescription = opts.toolDescription as string | undefined;
     const password = opts.password as string | undefined;
     const removePassword = opts.removePassword as boolean | undefined;
     const forcePublic = opts.forcePublic as boolean | undefined;
 
     await publishCollections(
-      { collectionNames, workerName, password, removePassword, forcePublic },
+      { collectionNames, workerName, toolDescription, password, removePassword, forcePublic },
       (step, detail) => {
         publishProgress = { ...publishProgress, step, detail };
       },

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,142 @@
+import { Command } from "commander";
+import {
+  contextExists,
+  getCollection,
+  getFrozenInkHome,
+} from "@frozenink/core";
+import { startStdioServer } from "@frozenink/mcp";
+import {
+  MCP_TOOL_NAMES,
+  isMcpToolName,
+  type McpToolName,
+} from "../mcp/tools";
+import {
+  addMcpConnections,
+  listMcpConnections,
+  removeMcpConnections,
+} from "../mcp/manager";
+
+function parseTool(value: string): McpToolName {
+  if (!isMcpToolName(value)) {
+    throw new Error(`Unsupported MCP tool "${value}". Use one of: ${MCP_TOOL_NAMES.join(", ")}`);
+  }
+  return value;
+}
+
+function requireInitialized(): void {
+  if (!contextExists()) {
+    console.error("Frozen Ink not initialized. Run: fink init");
+    process.exit(1);
+  }
+}
+
+export const mcpCommand = new Command("mcp")
+  .description("Manage MCP tool registrations and run collection-scoped MCP stdio server");
+
+mcpCommand
+  .command("serve")
+  .description("Run MCP stdio server scoped to a single collection")
+  .requiredOption("--collection <name>", "Collection name")
+  .action(async (opts: { collection: string }) => {
+    requireInitialized();
+
+    const col = getCollection(opts.collection);
+    if (!col) {
+      console.error(`Collection "${opts.collection}" not found`);
+      process.exit(1);
+    }
+
+    console.error(`Starting Frozen Ink MCP server (STDIO) for collection "${opts.collection}"...`);
+    await startStdioServer({
+      frozeninkHome: getFrozenInkHome(),
+      allowedCollections: [opts.collection],
+    });
+  });
+
+mcpCommand
+  .command("add")
+  .description("Add MCP tool links for one or more collections")
+  .requiredOption("--tool <tool>", `Target MCP client tool (${MCP_TOOL_NAMES.join(", ")})`)
+  .option("--description <text>", "Optional tool description to store on collection(s)")
+  .argument("<collections...>", "Collection names")
+  .action(async (collectionNames: string[], opts: { tool: string; description?: string }) => {
+    requireInitialized();
+
+    try {
+      const results = await addMcpConnections({
+        tool: parseTool(opts.tool),
+        collections: collectionNames,
+        description: opts.description,
+      });
+
+      for (const row of results) {
+        console.log(`Linked ${row.collection} -> ${opts.tool} (${row.connectionName})`);
+      }
+      console.log(`Added ${results.length} MCP link(s).`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Failed to add MCP links: ${message}`);
+      process.exit(1);
+    }
+  });
+
+mcpCommand
+  .command("remove")
+  .description("Remove MCP tool links for one or more collections")
+  .requiredOption("--tool <tool>", `Target MCP client tool (${MCP_TOOL_NAMES.join(", ")})`)
+  .argument("<collections...>", "Collection names")
+  .action(async (collectionNames: string[], opts: { tool: string }) => {
+    requireInitialized();
+
+    try {
+      const results = await removeMcpConnections({
+        tool: parseTool(opts.tool),
+        collections: collectionNames,
+      });
+
+      for (const row of results) {
+        console.log(`Removed ${row.collection} from ${opts.tool} (${row.connectionName})`);
+      }
+      console.log(`Removed ${results.length} MCP link(s).`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Failed to remove MCP links: ${message}`);
+      process.exit(1);
+    }
+  });
+
+mcpCommand
+  .command("list")
+  .description("List MCP tool links by collection")
+  .option("--tool <tool>", `Filter by tool (${MCP_TOOL_NAMES.join(", ")})`)
+  .action(async (opts: { tool?: string }) => {
+    requireInitialized();
+
+    try {
+      const statuses = await listMcpConnections(opts.tool ? parseTool(opts.tool) : undefined);
+
+      for (const status of statuses) {
+        console.log(`\n${status.displayName} (${status.tool})`);
+        if (!status.available) {
+          console.log(`  unavailable: ${status.reason || "not detected"}`);
+          continue;
+        }
+
+        const linked = status.links.filter((link) => link.linked);
+        if (linked.length === 0) {
+          console.log("  no linked collections");
+          continue;
+        }
+
+        for (const link of linked) {
+          const desc = link.description ? ` | description: ${link.description}` : "";
+          console.log(`  ${link.collection} -> ${link.connectionName} [linked]${desc}`);
+        }
+      }
+      console.log("");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Failed to list MCP links: ${message}`);
+      process.exit(1);
+    }
+  });

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -92,6 +92,7 @@ async function runConcurrent<T>(
 export interface PublishOptions {
   collectionNames: string[];
   workerName: string;
+  toolDescription?: string;
   password?: string;
   removePassword?: boolean;
   forcePublic?: boolean;
@@ -102,6 +103,7 @@ export interface PublishResult {
   workerName: string;
   workerUrl: string;
   mcpUrl: string;
+  toolDescription?: string;
   collections: string[];
   isUpdate: boolean;
   workerOnly: boolean;
@@ -119,6 +121,35 @@ async function hashPassword(password: string): Promise<string> {
   return `${salt}:${hashHex}`;
 }
 
+function deriveToolDescriptionFromCollections(collectionNames: string[]): string | undefined {
+  const descriptions = collectionNames
+    .map((name) => getCollection(name)?.mcpToolDescription?.trim())
+    .filter((value): value is string => !!value);
+
+  if (descriptions.length === 0) return undefined;
+  return descriptions.join(" | ");
+}
+
+async function promptToolDescription(
+  initialValue?: string,
+): Promise<string | undefined> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return initialValue;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const label = initialValue
+    ? `MCP tool description [${initialValue}] (optional): `
+    : "MCP tool description (optional): ";
+  const answer = await new Promise<string>((resolve) => {
+    rl.question(label, (value) => resolve(value));
+  });
+  rl.close();
+
+  const trimmed = answer.trim();
+  return trimmed || initialValue;
+}
+
 /**
  * Core publish logic, callable from both CLI and desktop app.
  * Progress is reported via the onProgress callback instead of console.log.
@@ -130,6 +161,7 @@ export async function publishCollections(
   await checkWranglerAuth();
 
   const { workerName, workerOnly = false, removePassword = false, forcePublic = false } = options;
+  let toolDescription = options.toolDescription?.trim() || undefined;
   const password = options.password?.trim();
   if (password && removePassword) {
     throw new Error("Cannot use --password and --remove-password together.");
@@ -145,6 +177,9 @@ export async function publishCollections(
 
   if (workerOnly && existingSite) {
     collectionNames = existingSite.collections;
+    if (!toolDescription) {
+      toolDescription = existingSite.toolDescription;
+    }
   }
 
   const home = getFrozenInkHome();
@@ -221,6 +256,7 @@ export async function publishCollections(
     d1DatabaseId,
     r2BucketName,
     passwordHash,
+    toolDescription,
   });
   const tomlFile = writeTempFile(tomlContent, ".toml");
   let workerUrl = "";
@@ -486,6 +522,7 @@ export async function publishCollections(
   addSite(workerName, {
     url: workerUrl,
     mcpUrl,
+    toolDescription,
     collections: collectionNames,
     database: { type: "cloudflare-d1", id: d1DatabaseId, name: d1DatabaseName },
     bucket: { type: "cloudflare-r2", name: r2BucketName },
@@ -495,7 +532,15 @@ export async function publishCollections(
 
   onProgress("done", "Publish completed");
 
-  return { workerName, workerUrl, mcpUrl, collections: collectionNames, isUpdate, workerOnly };
+  return {
+    workerName,
+    workerUrl,
+    mcpUrl,
+    toolDescription,
+    collections: collectionNames,
+    isUpdate,
+    workerOnly,
+  };
 }
 
 // --- CLI command ---
@@ -506,12 +551,14 @@ export const publishCommand = new Command("publish")
   .option("--password <password>", "Password to protect access")
   .option("--remove-password", "Explicitly remove password protection")
   .option("--public", "Explicitly allow public access on initial publish (skip confirmation prompt)")
+  .option("--tool-description <description>", "Tool description advertised to MCP clients")
   .option("--name <name>", "Worker name (default: fink-<first-collection>-<random>)")
   .option("--worker-only", "Deploy worker code only (skip D1/R2 data upload); requires --name for an existing deployment")
   .action(async (collectionNamesArg: string[], opts: {
     password?: string;
     removePassword?: boolean;
     public?: boolean;
+    toolDescription?: string;
     name?: string;
     workerOnly?: boolean;
   }) => {
@@ -532,6 +579,7 @@ export const publishCommand = new Command("publish")
 
       const workerName = opts.name || `fink-${collectionNames[0]}-${randomSuffix()}`;
       let forcePublic = !!opts.public;
+      let toolDescription = opts.toolDescription?.trim() || undefined;
 
       if (!forcePublic && !opts.password && !workerOnly) {
         const existingSite = getSite(workerName);
@@ -552,10 +600,16 @@ export const publishCommand = new Command("publish")
         }
       }
 
+      if (!workerOnly && !toolDescription) {
+        const derived = deriveToolDescriptionFromCollections(collectionNames);
+        toolDescription = await promptToolDescription(derived);
+      }
+
       const result = await publishCollections(
         {
           collectionNames,
           workerName,
+          toolDescription,
           password: opts.password,
           removePassword: opts.removePassword,
           forcePublic,

--- a/packages/cli/src/commands/wrangler-api.ts
+++ b/packages/cli/src/commands/wrangler-api.ts
@@ -233,7 +233,12 @@ export function generateWranglerToml(config: {
   d1DatabaseId: string;
   r2BucketName: string;
   passwordHash: string;
+  toolDescription?: string;
 }): string {
+  const escapedToolDescription = (config.toolDescription ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+
   return `name = "${config.workerName}"
 main = "${config.mainScript}"
 compatibility_date = "2024-01-01"
@@ -241,6 +246,7 @@ compatibility_date = "2024-01-01"
 [vars]
 PASSWORD_HASH = "${config.passwordHash}"
 WORKER_NAME = "${config.workerName}"
+TOOL_DESCRIPTION = "${escapedToolDescription}"
 
 [[d1_databases]]
 binding = "DB"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import { publishCommand } from "./commands/publish";
 import { updateCommand } from "./commands/update";
 import { unpublishCommand } from "./commands/unpublish";
 import { tuiCommand } from "./commands/tui";
+import { mcpCommand } from "./commands/mcp";
 import { startTui } from "./tui/index";
 
 const program = new Command();
@@ -39,6 +40,7 @@ program.addCommand(daemonCommand);
 program.addCommand(publishCommand);
 program.addCommand(unpublishCommand);
 program.addCommand(tuiCommand);
+program.addCommand(mcpCommand);
 
 // If no arguments passed (just "fink"), launch TUI by default
 const args = process.argv.slice(2);

--- a/packages/cli/src/mcp/manager.ts
+++ b/packages/cli/src/mcp/manager.ts
@@ -1,0 +1,196 @@
+import {
+  getCollection,
+  listCollections,
+  updateCollection,
+  spawnProcess,
+} from "@frozenink/core";
+import {
+  getConnectionName,
+  getMcpToolAdapter,
+  listMcpToolAdapters,
+  type McpToolName,
+} from "./tools";
+
+export interface AvailableToolInfo {
+  tool: McpToolName;
+  displayName: string;
+  available: boolean;
+  reason?: string;
+}
+
+export interface AddMcpResult {
+  collection: string;
+  connectionName: string;
+  description?: string;
+}
+
+export interface RemoveMcpResult {
+  collection: string;
+  connectionName: string;
+}
+
+export interface ToolCollectionLink {
+  collection: string;
+  connectionName: string;
+  linked: boolean;
+  description?: string;
+}
+
+export interface ToolLinkStatus {
+  tool: McpToolName;
+  displayName: string;
+  available: boolean;
+  reason?: string;
+  links: ToolCollectionLink[];
+}
+
+async function ensureFinkOnPath(): Promise<void> {
+  try {
+    const result = await spawnProcess(["fink", "--version"]);
+    if (result.exitCode !== 0) {
+      throw new Error((result.stderr || result.stdout).trim() || `exit code ${result.exitCode}`);
+    }
+  } catch (err) {
+    throw new Error(
+      "`fink` is not on PATH for subprocesses. Add it to PATH before running `fink mcp add`, " +
+      "or install globally via npm/binary so MCP clients can execute `fink mcp serve`.",
+    );
+  }
+}
+
+async function ensureToolAvailable(tool: McpToolName): Promise<void> {
+  const adapter = getMcpToolAdapter(tool);
+  const availability = await adapter.isAvailable();
+  if (!availability.available) {
+    throw new Error(
+      `${adapter.displayName} MCP CLI support is unavailable${availability.reason ? `: ${availability.reason}` : ""}`,
+    );
+  }
+}
+
+export async function listAvailableMcpTools(): Promise<AvailableToolInfo[]> {
+  const adapters = listMcpToolAdapters();
+  const rows: AvailableToolInfo[] = [];
+
+  for (const adapter of adapters) {
+    const availability = await adapter.isAvailable();
+    rows.push({
+      tool: adapter.tool,
+      displayName: adapter.displayName,
+      available: availability.available,
+      reason: availability.reason,
+    });
+  }
+
+  return rows;
+}
+
+export async function addMcpConnections(params: {
+  tool: McpToolName;
+  collections: string[];
+  description?: string;
+}): Promise<AddMcpResult[]> {
+  await ensureFinkOnPath();
+  await ensureToolAvailable(params.tool);
+
+  const adapter = getMcpToolAdapter(params.tool);
+  const results: AddMcpResult[] = [];
+
+  for (const collectionName of params.collections) {
+    const collection = getCollection(collectionName);
+    if (!collection) {
+      throw new Error(`Collection "${collectionName}" not found`);
+    }
+
+    const providedDescription = params.description?.trim();
+    const finalDescription = providedDescription || collection.mcpToolDescription?.trim() || undefined;
+
+    if (providedDescription) {
+      updateCollection(collectionName, { mcpToolDescription: providedDescription });
+    }
+
+    const connectionName = getConnectionName(collectionName);
+    await adapter.addConnection({
+      collection: collectionName,
+      connectionName,
+      description: finalDescription,
+    });
+
+    results.push({
+      collection: collectionName,
+      connectionName,
+      description: finalDescription,
+    });
+  }
+
+  return results;
+}
+
+export async function removeMcpConnections(params: {
+  tool: McpToolName;
+  collections: string[];
+}): Promise<RemoveMcpResult[]> {
+  await ensureToolAvailable(params.tool);
+
+  const adapter = getMcpToolAdapter(params.tool);
+  const results: RemoveMcpResult[] = [];
+
+  for (const collectionName of params.collections) {
+    const collection = getCollection(collectionName);
+    if (!collection) {
+      throw new Error(`Collection "${collectionName}" not found`);
+    }
+
+    const connectionName = getConnectionName(collectionName);
+    await adapter.removeConnection(connectionName);
+    results.push({ collection: collectionName, connectionName });
+  }
+
+  return results;
+}
+
+export async function listMcpConnections(tool?: McpToolName): Promise<ToolLinkStatus[]> {
+  const adapters = tool
+    ? [getMcpToolAdapter(tool)]
+    : listMcpToolAdapters();
+
+  const collections = listCollections();
+  const allStatuses: ToolLinkStatus[] = [];
+
+  for (const adapter of adapters) {
+    const availability = await adapter.isAvailable();
+    if (!availability.available) {
+      allStatuses.push({
+        tool: adapter.tool,
+        displayName: adapter.displayName,
+        available: false,
+        reason: availability.reason,
+        links: collections.map((collection) => ({
+          collection: collection.name,
+          connectionName: getConnectionName(collection.name),
+          linked: false,
+          description: collection.mcpToolDescription,
+        })),
+      });
+      continue;
+    }
+
+    const connectionNames = await adapter.listConnectionNames();
+    allStatuses.push({
+      tool: adapter.tool,
+      displayName: adapter.displayName,
+      available: true,
+      links: collections.map((collection) => {
+        const connectionName = getConnectionName(collection.name);
+        return {
+          collection: collection.name,
+          connectionName,
+          linked: connectionNames.has(connectionName),
+          description: collection.mcpToolDescription,
+        };
+      }),
+    });
+  }
+
+  return allStatuses;
+}

--- a/packages/cli/src/mcp/tools/claude-code.ts
+++ b/packages/cli/src/mcp/tools/claude-code.ts
@@ -1,0 +1,115 @@
+import { spawnProcess } from "@frozenink/core";
+import {
+  getMcpServeCommandArgs,
+  type McpToolAdapter,
+  type ToolConnectionSpec,
+} from "./types";
+
+const BINARY = "claude";
+
+async function runCommand(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  try {
+    const res = await spawnProcess([BINARY, ...args]);
+    return { stdout: res.stdout, stderr: res.stderr, exitCode: res.exitCode };
+  } catch (err) {
+    throw new Error(
+      `Claude Code CLI not found on PATH. Install it, then retry. (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+}
+
+function parseConnectionNames(output: string): Set<string> {
+  const names = new Set<string>();
+  const trimmed = output.trim();
+  if (!trimmed) return names;
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    const rows = Array.isArray(parsed)
+      ? parsed
+      : (parsed && typeof parsed === "object" && "mcpServers" in parsed
+        ? (parsed as { mcpServers?: unknown[] }).mcpServers ?? []
+        : []);
+
+    for (const row of rows) {
+      if (!row || typeof row !== "object") continue;
+      const candidate = (row as { name?: unknown; id?: unknown }).name ?? (row as { id?: unknown }).id;
+      if (typeof candidate === "string" && candidate.length > 0) {
+        names.add(candidate);
+      }
+    }
+    if (names.size > 0) return names;
+  } catch {
+    // Fallback parser below.
+  }
+
+  for (const line of trimmed.split("\n")) {
+    const token = line.trim().split(/\s+/)[0];
+    if (token && token !== "Name" && token !== "-" && !token.startsWith("(")) {
+      names.add(token);
+    }
+  }
+
+  return names;
+}
+
+async function ensureSuccess(args: string[], operation: string): Promise<void> {
+  const res = await runCommand(args);
+  if (res.exitCode !== 0) {
+    const detail = (res.stderr || res.stdout).trim() || `exit code ${res.exitCode}`;
+    throw new Error(`Claude Code ${operation} failed: ${detail}`);
+  }
+}
+
+export const claudeCodeAdapter: McpToolAdapter = {
+  tool: "claude-code",
+  displayName: "Claude Code",
+
+  async isAvailable() {
+    try {
+      const help = await runCommand(["mcp", "--help"]);
+      if (help.exitCode !== 0) {
+        return { available: false, reason: (help.stderr || help.stdout).trim() || "mcp command unavailable" };
+      }
+
+      const out = `${help.stdout}\n${help.stderr}`.toLowerCase();
+      const hasCommands = out.includes("add") && out.includes("remove") && out.includes("list");
+      if (!hasCommands) {
+        return { available: false, reason: "`claude mcp` add/remove/list commands not detected" };
+      }
+
+      return { available: true };
+    } catch (err) {
+      return { available: false, reason: err instanceof Error ? err.message : String(err) };
+    }
+  },
+
+  async addConnection(spec: ToolConnectionSpec): Promise<void> {
+    const commandArgs = getMcpServeCommandArgs(spec.collection);
+    const args = ["mcp", "add", spec.connectionName];
+    if (spec.description) {
+      args.push("--description", spec.description);
+    }
+    args.push("--", ...commandArgs);
+    await ensureSuccess(args, "mcp add");
+  },
+
+  async removeConnection(connectionName: string): Promise<void> {
+    await ensureSuccess(["mcp", "remove", connectionName], "mcp remove");
+  },
+
+  async listConnectionNames(): Promise<Set<string>> {
+    const jsonRes = await runCommand(["mcp", "list", "--json"]);
+    if (jsonRes.exitCode === 0) {
+      return parseConnectionNames(jsonRes.stdout || jsonRes.stderr);
+    }
+
+    const textRes = await runCommand(["mcp", "list"]);
+    if (textRes.exitCode !== 0) {
+      const detail = (textRes.stderr || textRes.stdout).trim() || `exit code ${textRes.exitCode}`;
+      throw new Error(`Claude Code mcp list failed: ${detail}`);
+    }
+
+    return parseConnectionNames(textRes.stdout || textRes.stderr);
+  },
+};

--- a/packages/cli/src/mcp/tools/codex.ts
+++ b/packages/cli/src/mcp/tools/codex.ts
@@ -1,0 +1,115 @@
+import { spawnProcess } from "@frozenink/core";
+import {
+  getMcpServeCommandArgs,
+  type McpToolAdapter,
+  type ToolConnectionSpec,
+} from "./types";
+
+const BINARY = "codex";
+
+async function runCommand(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  try {
+    const res = await spawnProcess([BINARY, ...args]);
+    return { stdout: res.stdout, stderr: res.stderr, exitCode: res.exitCode };
+  } catch (err) {
+    throw new Error(
+      `Codex CLI not found on PATH. Install/enable it, then retry. (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+}
+
+function parseConnectionNames(output: string): Set<string> {
+  const names = new Set<string>();
+  const trimmed = output.trim();
+  if (!trimmed) return names;
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    const rows = Array.isArray(parsed)
+      ? parsed
+      : (parsed && typeof parsed === "object" && "mcpServers" in parsed
+        ? (parsed as { mcpServers?: unknown[] }).mcpServers ?? []
+        : []);
+
+    for (const row of rows) {
+      if (!row || typeof row !== "object") continue;
+      const candidate = (row as { name?: unknown; id?: unknown }).name ?? (row as { id?: unknown }).id;
+      if (typeof candidate === "string" && candidate.length > 0) {
+        names.add(candidate);
+      }
+    }
+    if (names.size > 0) return names;
+  } catch {
+    // Fallback parser below.
+  }
+
+  for (const line of trimmed.split("\n")) {
+    const token = line.trim().split(/\s+/)[0];
+    if (token && token !== "Name" && token !== "-" && !token.startsWith("(")) {
+      names.add(token);
+    }
+  }
+
+  return names;
+}
+
+async function ensureSuccess(args: string[], operation: string): Promise<void> {
+  const res = await runCommand(args);
+  if (res.exitCode !== 0) {
+    const detail = (res.stderr || res.stdout).trim() || `exit code ${res.exitCode}`;
+    throw new Error(`Codex ${operation} failed: ${detail}`);
+  }
+}
+
+export const codexAdapter: McpToolAdapter = {
+  tool: "codex",
+  displayName: "Codex",
+
+  async isAvailable() {
+    try {
+      const help = await runCommand(["mcp", "--help"]);
+      if (help.exitCode !== 0) {
+        return { available: false, reason: (help.stderr || help.stdout).trim() || "mcp command unavailable" };
+      }
+
+      const out = `${help.stdout}\n${help.stderr}`.toLowerCase();
+      const hasCommands = out.includes("add") && out.includes("remove") && out.includes("list");
+      if (!hasCommands) {
+        return { available: false, reason: "`codex mcp` add/remove/list commands not detected" };
+      }
+
+      return { available: true };
+    } catch (err) {
+      return { available: false, reason: err instanceof Error ? err.message : String(err) };
+    }
+  },
+
+  async addConnection(spec: ToolConnectionSpec): Promise<void> {
+    const commandArgs = getMcpServeCommandArgs(spec.collection);
+    const args = ["mcp", "add", spec.connectionName];
+    if (spec.description) {
+      args.push("--description", spec.description);
+    }
+    args.push("--", ...commandArgs);
+    await ensureSuccess(args, "mcp add");
+  },
+
+  async removeConnection(connectionName: string): Promise<void> {
+    await ensureSuccess(["mcp", "remove", connectionName], "mcp remove");
+  },
+
+  async listConnectionNames(): Promise<Set<string>> {
+    const jsonRes = await runCommand(["mcp", "list", "--json"]);
+    if (jsonRes.exitCode === 0) {
+      return parseConnectionNames(jsonRes.stdout || jsonRes.stderr);
+    }
+
+    const textRes = await runCommand(["mcp", "list"]);
+    if (textRes.exitCode !== 0) {
+      const detail = (textRes.stderr || textRes.stdout).trim() || `exit code ${textRes.exitCode}`;
+      throw new Error(`Codex mcp list failed: ${detail}`);
+    }
+
+    return parseConnectionNames(textRes.stdout || textRes.stderr);
+  },
+};

--- a/packages/cli/src/mcp/tools/index.ts
+++ b/packages/cli/src/mcp/tools/index.ts
@@ -1,0 +1,28 @@
+import { claudeCodeAdapter } from "./claude-code";
+import { codexAdapter } from "./codex";
+import {
+  MCP_TOOL_NAMES,
+  type McpToolAdapter,
+  type McpToolName,
+} from "./types";
+
+const adapterMap: Record<McpToolName, McpToolAdapter> = {
+  "claude-code": claudeCodeAdapter,
+  codex: codexAdapter,
+};
+
+export { MCP_TOOL_NAMES };
+export type { McpToolAdapter, McpToolName } from "./types";
+export { getConnectionName, getMcpServeCommandArgs } from "./types";
+
+export function isMcpToolName(value: string): value is McpToolName {
+  return MCP_TOOL_NAMES.includes(value as McpToolName);
+}
+
+export function getMcpToolAdapter(tool: McpToolName): McpToolAdapter {
+  return adapterMap[tool];
+}
+
+export function listMcpToolAdapters(): McpToolAdapter[] {
+  return MCP_TOOL_NAMES.map((tool) => adapterMap[tool]);
+}

--- a/packages/cli/src/mcp/tools/types.ts
+++ b/packages/cli/src/mcp/tools/types.ts
@@ -1,0 +1,26 @@
+export const MCP_TOOL_NAMES = ["claude-code", "codex"] as const;
+
+export type McpToolName = (typeof MCP_TOOL_NAMES)[number];
+
+export interface ToolConnectionSpec {
+  collection: string;
+  connectionName: string;
+  description?: string;
+}
+
+export interface McpToolAdapter {
+  tool: McpToolName;
+  displayName: string;
+  isAvailable(): Promise<{ available: boolean; reason?: string }>;
+  addConnection(spec: ToolConnectionSpec): Promise<void>;
+  removeConnection(connectionName: string): Promise<void>;
+  listConnectionNames(): Promise<Set<string>>;
+}
+
+export function getConnectionName(collection: string): string {
+  return `fink-${collection}`;
+}
+
+export function getMcpServeCommandArgs(collection: string): string[] {
+  return ["fink", "mcp", "serve", "--collection", collection];
+}

--- a/packages/cli/src/tui/components/CollectionList.tsx
+++ b/packages/cli/src/tui/components/CollectionList.tsx
@@ -32,6 +32,7 @@ import { TextInput } from "./TextInput.js";
 import { AddCollection } from "./AddCollection.js";
 import { ExportView } from "./ExportView.js";
 import { SearchView } from "./SearchView.js";
+import { McpConfigView } from "./McpConfigView.js";
 import type { Screen } from "./App.js";
 
 type Mode =
@@ -40,6 +41,7 @@ type Mode =
   | "add"
   | "export"
   | "search"
+  | "mcp"
   | "confirm-delete"
   | "confirm-full-sync"
   | "syncing";
@@ -544,6 +546,7 @@ export function CollectionList({
       }
       if (input === "e" && current) { setEditingCollection(current.name); setMode("export"); }
       if (input === "f" && current) { setEditingCollection(current.name); setMode("search"); }
+      if (input === "m" && current) { setEditingCollection(current.name); setMode("mcp"); }
     } else if (mode === "confirm-full-sync") {
       if (input === "y" && current) {
         startSync(undefined, "full");
@@ -596,6 +599,10 @@ export function CollectionList({
         <Text>Run full sync? This will re-download all data. (y/n)</Text>
       </Box>
     );
+  }
+
+  if (mode === "mcp" && editingCollection) {
+    return <McpConfigView collectionName={editingCollection} onDone={() => { setMode("list"); refresh(); }} />;
   }
 
   if (mode === "syncing") {
@@ -721,6 +728,7 @@ export function CollectionList({
         <Text dimColor>[s] Sync</Text>
         <Text dimColor>[f] Search</Text>
         <Text dimColor>[e] Export</Text>
+        <Text dimColor>[m] MCP</Text>
         <Text dimColor>[Space] Toggle</Text>
         <Text dimColor>[a] Add</Text>
         <Text dimColor>[x] Delete</Text>

--- a/packages/cli/src/tui/components/McpConfigView.tsx
+++ b/packages/cli/src/tui/components/McpConfigView.tsx
@@ -1,0 +1,224 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { getCollection, updateCollection } from "@frozenink/core";
+import {
+  addMcpConnections,
+  listAvailableMcpTools,
+  listMcpConnections,
+  removeMcpConnections,
+  type AvailableToolInfo,
+} from "../../mcp/manager";
+import type { McpToolName } from "../../mcp/tools";
+import { TextInput } from "./TextInput.js";
+
+type Mode = "menu" | "edit-description" | "busy";
+
+export function McpConfigView({
+  collectionName,
+  onDone,
+}: {
+  collectionName: string;
+  onDone: () => void;
+}): React.ReactElement {
+  const [mode, setMode] = useState<Mode>("menu");
+  const [tools, setTools] = useState<AvailableToolInfo[]>([]);
+  const [toolCursor, setToolCursor] = useState(0);
+  const [linked, setLinked] = useState(false);
+  const [descriptionInput, setDescriptionInput] = useState(
+    getCollection(collectionName)?.mcpToolDescription ?? "",
+  );
+  const [message, setMessage] = useState("");
+
+  const selectedTool = useMemo(() => {
+    if (tools.length === 0) return null;
+    return tools[Math.min(toolCursor, tools.length - 1)] ?? null;
+  }, [toolCursor, tools]);
+
+  const refreshTools = useCallback(async () => {
+    const detected = await listAvailableMcpTools();
+    setTools(detected);
+    setToolCursor((current) => Math.min(current, Math.max(0, detected.length - 1)));
+  }, []);
+
+  const refreshLinked = useCallback(async (tool: McpToolName | undefined) => {
+    if (!tool) {
+      setLinked(false);
+      return;
+    }
+
+    const statuses = await listMcpConnections(tool);
+    const row = statuses[0]?.links.find((link) => link.collection === collectionName);
+    setLinked(!!row?.linked);
+  }, [collectionName]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await refreshTools();
+      } catch (err) {
+        if (!cancelled) {
+          setMessage(err instanceof Error ? err.message : String(err));
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshTools]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await refreshLinked(selectedTool?.tool);
+      } catch (err) {
+        if (!cancelled) {
+          setMessage(err instanceof Error ? err.message : String(err));
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshLinked, selectedTool?.tool]);
+
+  const runAddOrUpdate = useCallback(async () => {
+    if (!selectedTool) return;
+    setMode("busy");
+    setMessage("");
+    try {
+      await addMcpConnections({
+        tool: selectedTool.tool,
+        collections: [collectionName],
+        description: descriptionInput.trim() || undefined,
+      });
+      setMessage(`Linked ${collectionName} to ${selectedTool.displayName}.`);
+      await refreshLinked(selectedTool.tool);
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : String(err));
+    } finally {
+      setMode("menu");
+    }
+  }, [collectionName, descriptionInput, refreshLinked, selectedTool]);
+
+  const runRemove = useCallback(async () => {
+    if (!selectedTool) return;
+    setMode("busy");
+    setMessage("");
+    try {
+      await removeMcpConnections({
+        tool: selectedTool.tool,
+        collections: [collectionName],
+      });
+      setMessage(`Removed MCP link for ${collectionName} from ${selectedTool.displayName}.`);
+      await refreshLinked(selectedTool.tool);
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : String(err));
+    } finally {
+      setMode("menu");
+    }
+  }, [collectionName, refreshLinked, selectedTool]);
+
+  useInput((input, key) => {
+    if (mode === "menu") {
+      if (key.escape) {
+        onDone();
+        return;
+      }
+      if (key.upArrow) {
+        setToolCursor((current) => Math.max(0, current - 1));
+      }
+      if (key.downArrow) {
+        setToolCursor((current) => Math.min(Math.max(0, tools.length - 1), current + 1));
+      }
+      if (input === "a") {
+        runAddOrUpdate();
+      }
+      if (input === "r") {
+        runRemove();
+      }
+      if (input === "d") {
+        setMode("edit-description");
+      }
+    }
+  });
+
+  const currentCollection = getCollection(collectionName);
+  if (!currentCollection) {
+    return <Text color="red">Collection "{collectionName}" not found.</Text>;
+  }
+
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      <Text bold>MCP Config: {collectionName}</Text>
+      <Text dimColor>
+        Link this collection to an MCP client using `fink mcp serve --collection {collectionName}`.
+      </Text>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text dimColor bold>Tool</Text>
+        {tools.length === 0 && <Text dimColor>No MCP tools detected.</Text>}
+        {tools.map((tool, index) => (
+          <Box key={tool.tool} gap={1}>
+            <Text color={index === toolCursor ? "cyan" : undefined}>
+              {index === toolCursor ? "❯" : " "}
+            </Text>
+            <Text>{tool.displayName}</Text>
+            <Text dimColor>({tool.tool})</Text>
+            {!tool.available && <Text color="yellow">unavailable: {tool.reason ?? "not detected"}</Text>}
+          </Box>
+        ))}
+      </Box>
+
+      <Box marginTop={1}>
+        <Text>
+          Link status: <Text color={linked ? "green" : "yellow"}>{linked ? "linked" : "not linked"}</Text>
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        {mode === "edit-description" ? (
+          <TextInput
+            label="Tool description"
+            value={descriptionInput}
+            onChange={setDescriptionInput}
+            onSubmit={() => {
+              const trimmed = descriptionInput.trim();
+              updateCollection(collectionName, { mcpToolDescription: trimmed || undefined });
+              setMessage("Saved collection MCP tool description.");
+              setMode("menu");
+            }}
+            placeholder="Optional description shown to MCP clients"
+          />
+        ) : (
+          <Text>
+            Description: <Text dimColor>{currentCollection.mcpToolDescription ?? "(none)"}</Text>
+          </Text>
+        )}
+      </Box>
+
+      {mode === "busy" && (
+        <Box marginTop={1}>
+          <Text color="yellow">Working...</Text>
+        </Box>
+      )}
+
+      {message && (
+        <Box marginTop={1}>
+          <Text color="green">{message}</Text>
+        </Box>
+      )}
+
+      <Box marginTop={1} gap={2}>
+        <Text dimColor>[a] Add/Update link</Text>
+        <Text dimColor>[r] Remove link</Text>
+        <Text dimColor>[d] Edit description</Text>
+        <Text dimColor>[↑↓] Tool</Text>
+        <Text dimColor>[ESC] Back</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/core/src/config/context.ts
+++ b/packages/core/src/config/context.ts
@@ -31,6 +31,7 @@ const collectionEntrySchema = z.object({
 const siteConfigSchema = z.object({
   url: z.string(),
   mcpUrl: z.string(),
+  toolDescription: z.string().optional(),
   collections: z.array(z.string()),
   database: z.object({
     type: z.string(),
@@ -56,6 +57,7 @@ const siteStateSchema = z.object({
 const siteEntrySchema = z.object({
   url: z.string(),
   mcpUrl: z.string(),
+  toolDescription: z.string().optional(),
   collections: z.array(z.string()),
   database: z.object({
     type: z.string(),
@@ -204,6 +206,7 @@ export function migrateFromLegacyContext(): void {
       addSite(name, {
         url: dep.url,
         mcpUrl: dep.mcpUrl,
+        toolDescription: dep.toolDescription,
         collections: dep.collections,
         database: { type: "cloudflare-d1", id: dep.d1DatabaseId, name: dep.d1DatabaseName },
         bucket: { type: "cloudflare-r2", name: dep.r2BucketName },
@@ -241,6 +244,7 @@ function migrateLegacyPublishYml(): void {
       addSite(name, {
         url: dep.url,
         mcpUrl: dep.mcpUrl,
+        toolDescription: dep.toolDescription,
         collections: dep.collections,
         database: { type: "cloudflare-d1", id: dep.d1DatabaseId, name: dep.d1DatabaseName },
         bucket: { type: "cloudflare-r2", name: dep.r2BucketName },

--- a/packages/core/src/config/context.ts
+++ b/packages/core/src/config/context.ts
@@ -16,6 +16,7 @@ const assetsConfigSchema = z.object({
 
 const collectionEntrySchema = z.object({
   title: z.string().optional(),
+  mcpToolDescription: z.string().optional(),
   crawler: z.string(),
   enabled: z.boolean().optional().default(true),
   /** Crawler schema version the collection was last synced with. Defaults to "1.0". */
@@ -76,6 +77,7 @@ const siteEntrySchema = z.object({
 const legacyDeploymentEntrySchema = z.object({
   url: z.string(),
   mcpUrl: z.string(),
+  toolDescription: z.string().optional(),
   collections: z.array(z.string()),
   d1DatabaseId: z.string(),
   d1DatabaseName: z.string().optional(),

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -131,8 +131,8 @@ function addAttachment(
   writeFileSync(attachmentFile, data.content);
 }
 
-async function setupClient() {
-  const server = createMcpServer(options);
+async function setupClient(overrides?: Partial<McpServerOptions>) {
+  const server = createMcpServer({ ...options, ...overrides });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
   client = new Client({ name: "test-client", version: "1.0.0" });
@@ -180,6 +180,19 @@ describe("collection_list tool", () => {
     expect(data[0].entityCount).toBe(2);
     expect(data[0].lastSyncTime).toBe("2025-01-15 10:00:00");
     expect(data[0].lastSyncStatus).toBe("completed");
+  });
+
+  it("respects allowedCollections filter", async () => {
+    addCollection("allowed-col");
+    addCollection("blocked-col");
+
+    await setupClient({ allowedCollections: ["allowed-col"] });
+
+    const result = await client.callTool({ name: "collection_list" });
+    const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+
+    expect(data).toHaveLength(1);
+    expect(data[0].name).toBe("allowed-col");
   });
 });
 
@@ -256,6 +269,25 @@ describe("entity_get_data tool", () => {
     expect(data.data.state).toBe("open");
     expect(data.url).toBe("https://github.com/test/get-test/issues/5");
     expect(data.tags).toEqual(["bug", "critical"]);
+  });
+
+  it("denies access to disallowed collection", async () => {
+    const { dbPath } = addCollection("private-col");
+    addEntity(dbPath, {
+      externalId: "issue-1",
+      entityType: "issue",
+      title: "Hidden issue",
+      data: {},
+    });
+
+    await setupClient({ allowedCollections: ["other-col"] });
+    const result = await client.callTool({
+      name: "entity_get_data",
+      arguments: { collection: "private-col", externalId: "issue-1" },
+    });
+    const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+
+    expect(data.error).toContain("not allowed");
   });
 });
 
@@ -373,5 +405,17 @@ describe("MCP resources", () => {
 
     expect(result.contents[0].text).toBe("# Test Issue\n\nBody content.");
     expect(result.contents[0].mimeType).toBe("text/markdown");
+  });
+
+  it("filters collection resources by allowlist", async () => {
+    addCollection("allow-one");
+    addCollection("allow-two");
+
+    await setupClient({ allowedCollections: ["allow-one"] });
+    const result = await client.readResource({ uri: "frozenink://collections" });
+    const data = JSON.parse(result.contents[0].text as string);
+
+    expect(data).toHaveLength(1);
+    expect(data[0].name).toBe("allow-one");
   });
 });

--- a/packages/mcp/src/collection-scope.ts
+++ b/packages/mcp/src/collection-scope.ts
@@ -1,0 +1,41 @@
+import type { McpServerOptions } from "./server";
+
+export function normalizeAllowedCollections(
+  options: McpServerOptions,
+): Set<string> | null {
+  if (!options.allowedCollections || options.allowedCollections.length === 0) {
+    return null;
+  }
+  return new Set(options.allowedCollections);
+}
+
+export function isCollectionAllowed(
+  options: McpServerOptions,
+  collectionName: string,
+): boolean {
+  const allowed = normalizeAllowedCollections(options);
+  if (!allowed) return true;
+  return allowed.has(collectionName);
+}
+
+export function filterAllowedCollectionNames(
+  options: McpServerOptions,
+  collectionNames: string[],
+): string[] {
+  const allowed = normalizeAllowedCollections(options);
+  if (!allowed) return collectionNames;
+  return collectionNames.filter((name) => allowed.has(name));
+}
+
+export function filterAllowedCollections<T extends { name: string }>(
+  options: McpServerOptions,
+  collections: T[],
+): T[] {
+  const allowed = normalizeAllowedCollections(options);
+  if (!allowed) return collections;
+  return collections.filter((collection) => allowed.has(collection.name));
+}
+
+export function buildCollectionDeniedError(collectionName: string): string {
+  return `Collection "${collectionName}" is not allowed for this MCP server`;
+}

--- a/packages/mcp/src/resources/collection.ts
+++ b/packages/mcp/src/resources/collection.ts
@@ -12,6 +12,11 @@ import {
 } from "@frozenink/core";
 import { desc } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
+import {
+  buildCollectionDeniedError,
+  filterAllowedCollections,
+  isCollectionAllowed,
+} from "../collection-scope";
 
 export function registerCollectionResources(
   server: McpServer,
@@ -38,7 +43,7 @@ export function registerCollectionResources(
         };
       }
 
-      const rows = listCollections();
+      const rows = filterAllowedCollections(options, listCollections());
       const result = rows.map((col) => ({
         name: col.name,
         crawlerType: col.crawler,
@@ -64,7 +69,7 @@ export function registerCollectionResources(
       list: async () => {
         if (!contextExists()) return { resources: [] };
 
-        const rows = listCollections();
+        const rows = filterAllowedCollections(options, listCollections());
 
         return {
           resources: rows.map((col) => ({
@@ -101,6 +106,17 @@ export function registerCollectionResources(
       }
 
       const col = getCollection(name);
+      if (!isCollectionAllowed(options, name)) {
+        return {
+          contents: [
+            {
+              uri: uri.toString(),
+              mimeType: "application/json",
+              text: JSON.stringify({ error: buildCollectionDeniedError(name) }),
+            },
+          ],
+        };
+      }
       if (!col) {
         return {
           contents: [

--- a/packages/mcp/src/resources/entity.ts
+++ b/packages/mcp/src/resources/entity.ts
@@ -13,6 +13,10 @@ import {
 } from "@frozenink/core";
 import { eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
+import {
+  buildCollectionDeniedError,
+  isCollectionAllowed,
+} from "../collection-scope";
 
 export function registerEntityResources(
   server: McpServer,
@@ -45,6 +49,20 @@ export function registerEntityResources(
               uri: uri.toString(),
               mimeType: "application/json",
               text: JSON.stringify({ error: "Frozen Ink not initialized" }),
+            },
+          ],
+        };
+      }
+
+      if (!isCollectionAllowed(options, collectionName)) {
+        return {
+          contents: [
+            {
+              uri: uri.toString(),
+              mimeType: "application/json",
+              text: JSON.stringify({
+                error: buildCollectionDeniedError(collectionName),
+              }),
             },
           ],
         };
@@ -144,6 +162,18 @@ export function registerEntityResources(
               uri: uri.toString(),
               mimeType: "text/plain",
               text: "Frozen Ink not initialized",
+            },
+          ],
+        };
+      }
+
+      if (!isCollectionAllowed(options, collectionName)) {
+        return {
+          contents: [
+            {
+              uri: uri.toString(),
+              mimeType: "text/plain",
+              text: buildCollectionDeniedError(collectionName),
             },
           ],
         };

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -10,6 +10,7 @@ import { registerEntityResources } from "./resources/entity";
 
 export interface McpServerOptions {
   frozeninkHome: string;
+  allowedCollections?: string[];
 }
 
 export function createMcpServer(options: McpServerOptions): McpServer {

--- a/packages/mcp/src/tools/get-attachment.ts
+++ b/packages/mcp/src/tools/get-attachment.ts
@@ -12,6 +12,10 @@ import {
 } from "@frozenink/core";
 import { and, eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
+import {
+  buildCollectionDeniedError,
+  isCollectionAllowed,
+} from "../collection-scope";
 
 function extractReferencePath(reference: string): string {
   const raw = reference.trim();
@@ -105,6 +109,19 @@ export function registerGetAttachment(
             {
               type: "text" as const,
               text: JSON.stringify({ error: "Frozen Ink not initialized" }),
+            },
+          ],
+        };
+      }
+
+      if (!isCollectionAllowed(options, args.collection)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: buildCollectionDeniedError(args.collection),
+              }),
             },
           ],
         };

--- a/packages/mcp/src/tools/get-entity.ts
+++ b/packages/mcp/src/tools/get-entity.ts
@@ -13,6 +13,10 @@ import {
 } from "@frozenink/core";
 import { eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
+import {
+  buildCollectionDeniedError,
+  isCollectionAllowed,
+} from "../collection-scope";
 
 export function registerGetEntity(
   server: McpServer,
@@ -37,6 +41,19 @@ export function registerGetEntity(
             {
               type: "text" as const,
               text: JSON.stringify({ error: "Frozen Ink not initialized" }),
+            },
+          ],
+        };
+      }
+
+      if (!isCollectionAllowed(options, args.collection)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: buildCollectionDeniedError(args.collection),
+              }),
             },
           ],
         };

--- a/packages/mcp/src/tools/get-markdown.ts
+++ b/packages/mcp/src/tools/get-markdown.ts
@@ -11,6 +11,10 @@ import {
 } from "@frozenink/core";
 import { eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
+import {
+  buildCollectionDeniedError,
+  isCollectionAllowed,
+} from "../collection-scope";
 
 export function registerGetMarkdown(
   server: McpServer,
@@ -35,6 +39,19 @@ export function registerGetMarkdown(
             {
               type: "text" as const,
               text: JSON.stringify({ error: "Frozen Ink not initialized" }),
+            },
+          ],
+        };
+      }
+
+      if (!isCollectionAllowed(options, args.collection)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: buildCollectionDeniedError(args.collection),
+              }),
             },
           ],
         };

--- a/packages/mcp/src/tools/list-collections.ts
+++ b/packages/mcp/src/tools/list-collections.ts
@@ -10,6 +10,7 @@ import {
 } from "@frozenink/core";
 import { desc } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
+import { filterAllowedCollections } from "../collection-scope";
 
 export function registerListCollections(
   server: McpServer,
@@ -35,7 +36,7 @@ export function registerListCollections(
         };
       }
 
-      const rows = listCollections();
+      const rows = filterAllowedCollections(options, listCollections());
 
       const result = rows.map((col) => {
         let entityCount = 0;

--- a/packages/mcp/src/tools/search.ts
+++ b/packages/mcp/src/tools/search.ts
@@ -10,6 +10,11 @@ import {
   type SearchResult,
 } from "@frozenink/core";
 import type { McpServerOptions } from "../server";
+import {
+  buildCollectionDeniedError,
+  filterAllowedCollections,
+  isCollectionAllowed,
+} from "../collection-scope";
 
 export function registerSearch(
   server: McpServer,
@@ -53,12 +58,28 @@ export function registerSearch(
         };
       }
 
-      let collectionRows = args.collection
+      const collectionRows = args.collection
         ? (() => {
+            if (!isCollectionAllowed(options, args.collection)) {
+              return [];
+            }
             const col = getCollection(args.collection);
             return col ? [col] : [];
           })()
-        : listCollections();
+        : filterAllowedCollections(options, listCollections());
+
+      if (args.collection && !isCollectionAllowed(options, args.collection)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: buildCollectionDeniedError(args.collection),
+              }),
+            },
+          ],
+        };
+      }
 
       const allResults: Array<SearchResult & { collection: string }> = [];
 

--- a/packages/worker/src/handlers/mcp.ts
+++ b/packages/worker/src/handlers/mcp.ts
@@ -34,12 +34,17 @@ export async function handleMcpRequest(
   const rpc = body as { jsonrpc: string; method: string; params?: unknown; id?: unknown };
 
   if (rpc.method === "initialize") {
+    const description = env.TOOL_DESCRIPTION?.trim();
+    const instructions = description
+      ? `Frozen Ink MCP server. ${description}`
+      : "Frozen Ink MCP server. Provides collection and entity retrieval tools over published collections.";
+
     return jsonRpcResult(
       {
         protocolVersion: "2025-03-26",
         capabilities: { tools: {} },
         serverInfo: { name: "frozenink", version: "0.1.0" },
-        instructions: "Frozen Ink MCP server. Provides collection and entity retrieval tools over published collections.",
+        instructions,
       },
       rpc.id,
     );

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -3,4 +3,5 @@ export interface Env {
   BUCKET: R2Bucket;
   PASSWORD_HASH: string;
   WORKER_NAME: string;
+  TOOL_DESCRIPTION?: string;
 }


### PR DESCRIPTION
## Summary
- add new `fink mcp` command group (`add`, `remove`, `list`, `serve --collection`)
- implement MCP tool adapters for Claude Code and best-effort Codex detection
- enforce MCP collection allowlist across tools/resources via `allowedCollections`
- add collection/deployment tool description persistence and publish integration
- propagate worker tool description into MCP initialize instructions
- add TUI Collections `[m]` flow with new `McpConfigView`
- update README docs for installed-user MCP flow and connection semantics
- add tests for MCP allowlist, CLI MCP command behavior, and publish forwarding

## Notes
- rebased on latest `origin/main`
- targeted MCP/CLI tests added and run for new behavior