### PR TITLE
Lazy-load wrangler-api to limit Cloudflare dependency to publish/unpublish

### DIFF
--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -22,19 +22,6 @@ import {
 
 const __moduleDir = getModuleDir(import.meta.url);
 import { eq } from "drizzle-orm";
-import {
-  checkWranglerAuth,
-  createD1,
-  executeD1File,
-  executeD1Command,
-  createR2Bucket,
-  putR2Object,
-  deleteR2Object,
-  deployWorker,
-  generateWranglerToml,
-  writeTempFile,
-  cleanupTempFile,
-} from "./wrangler-api";
 import { assertInitialPublishConfirmation } from "./publish-policy";
 
 function randomSuffix(): string {
@@ -158,6 +145,20 @@ export async function publishCollections(
   options: PublishOptions,
   onProgress: PublishProgressCallback = () => {},
 ): Promise<PublishResult> {
+  const {
+    checkWranglerAuth,
+    createD1,
+    executeD1File,
+    executeD1Command,
+    createR2Bucket,
+    putR2Object,
+    deleteR2Object,
+    deployWorker,
+    generateWranglerToml,
+    writeTempFile,
+    cleanupTempFile,
+  } = await import("./wrangler-api");
+
   await checkWranglerAuth();
 
   const { workerName, workerOnly = false, removePassword = false, forcePublic = false } = options;

--- a/packages/cli/src/commands/unpublish.ts
+++ b/packages/cli/src/commands/unpublish.ts
@@ -6,15 +6,6 @@ import {
   removeSite,
   type SiteEntry,
 } from "@frozenink/core";
-import {
-  checkWranglerAuth,
-  deleteWorker,
-  deleteR2Object,
-  deleteR2Bucket,
-  deleteD1,
-  executeD1Command,
-  WranglerError,
-} from "./wrangler-api";
 
 async function confirm(message: string): Promise<boolean> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
@@ -37,6 +28,15 @@ export async function unpublishDeployment(
   deployment: SiteEntry & { name: string },
   onProgress: UnpublishProgressCallback = () => {},
 ): Promise<void> {
+  const {
+    checkWranglerAuth,
+    deleteWorker,
+    deleteR2Object,
+    deleteR2Bucket,
+    deleteD1,
+    executeD1Command,
+  } = await import("./wrangler-api");
+
   await checkWranglerAuth();
 
   // 1. Delete worker


### PR DESCRIPTION
## Summary

- Convert static `wrangler-api` imports in `publish.ts` and `unpublish.ts` to dynamic `await import()` calls inside `publishCollections()` and `unpublishDeployment()`
- Wrangler/Cloudflare code is now only loaded when site operations are actually invoked, not on every CLI startup
- Matches the pattern already used in `management-api.ts` for the `/api/cloudflare/check-auth` endpoint

## Test plan

- [ ] `fink sync` / `fink add` / other non-site commands start without loading wrangler
- [ ] `fink publish` still works end-to-end
- [ ] `fink unpublish` still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)