### PR TITLE
Replace Obsidian wiki-link syntax with standard markdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
 # CLAUDE.md
 
 See [AGENTS.md](AGENTS.md) for full project context, architecture, schemas, conventions, and navigation guide.
+
+## Pre-push checklist
+
+Always run `bun run ci` before pushing. This mirrors the full GitHub Actions CI pipeline including markdown lint, typecheck, all test suites (bun + vitest), UI build, and **worker build**. The worker build (Cloudflare Workers via esbuild) catches imports that work in Node/Bun but fail in the Workers runtime (e.g., `"path"`, `"fs"`).

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "serve": "bun run build:ui && bun run packages/cli/src/index.ts serve --ui-only",
     "typecheck": "tsc --build",
     "lint:md": "markdownlint-cli2",
+    "ci": "bun run lint:md && bun run typecheck && bun test packages/core/src/ && bun test packages/crawlers/src/ && bun test packages/mcp/src/ && (cd packages/ui && npx vitest run) && bun run build:ui && (cd packages/worker && bun run build)",
     "clean": "rm -rf packages/*/dist"
   },
   "devDependencies": {

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -88,6 +88,33 @@ export const generateCommand = new Command("generate")
         return relative.endsWith(".md") ? relative.slice(0, -3) : relative;
       };
 
+      // Build stem-matching wikilink resolver (for Obsidian [[bare name]] links)
+      const allEntityRows = colDb
+        .select({ externalId: entities.externalId, markdownPath: entities.markdownPath })
+        .from(entities)
+        .all();
+      const byExtId = new Map<string, string>();
+      const byStem = new Map<string, string>();
+      const base = `${markdownBasePath}/`;
+      for (const r of allEntityRows) {
+        if (!r.markdownPath) continue;
+        const rel = r.markdownPath.startsWith(base) ? r.markdownPath.slice(base.length) : r.markdownPath;
+        const noExt = rel.endsWith(".md") ? rel.slice(0, -3) : rel;
+        byExtId.set(r.externalId, noExt);
+        const stem = r.externalId.replace(/\.md$/, "");
+        const stemName = stem.includes("/") ? stem.split("/").pop()! : stem;
+        if (!byStem.has(stemName)) byStem.set(stemName, noExt);
+      }
+      const resolveWikilink = (target: string): string | undefined => {
+        const clean = target.replace(/[#^].*$/, "").trim();
+        if (!clean) return undefined;
+        const withMd = clean.endsWith(".md") ? clean : `${clean}.md`;
+        if (byExtId.has(withMd)) return byExtId.get(withMd);
+        if (byExtId.has(clean)) return byExtId.get(clean);
+        const stemName = clean.includes("/") ? clean.split("/").pop()! : clean;
+        return byStem.get(stemName);
+      };
+
       const indexer = new SearchIndexer(dbPath);
       indexer.clearIndex();
       colDb.delete(links).run();
@@ -120,6 +147,7 @@ export const generateCommand = new Command("generate")
           collectionName: col.name,
           crawlerType: col.crawler,
           lookupEntityPath: entityPathLookup,
+          resolveWikilink,
         };
 
         const newPath = `${markdownBasePath}/${themeEngine.getFilePath(renderCtx)}`;
@@ -161,7 +189,10 @@ export const generateCommand = new Command("generate")
         });
 
         // Rebuild entity links
-        const targets = extractWikilinks(markdown);
+        const sourceFile = newPath.startsWith(markdownBasePath + "/")
+          ? newPath.slice(markdownBasePath.length + 1)
+          : undefined;
+        const targets = extractWikilinks(markdown, sourceFile);
         for (const target of targets) {
           const targetPath = `${markdownBasePath}/${target}.md`;
           const [targetEntity] = colDb

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -97,7 +97,10 @@ export const indexCommand = new Command("index")
         indexed++;
 
         // Rebuild links
-        const targets = extractWikilinks(markdown);
+        const sourceFile = entity.markdownPath?.startsWith(markdownBasePath + "/")
+          ? entity.markdownPath.slice(markdownBasePath.length + 1)
+          : undefined;
+        const targets = extractWikilinks(markdown, sourceFile);
         for (const target of targets) {
           const targetPath = `${markdownBasePath}/${target}.md`;
           const [targetEntity] = colDb

--- a/packages/core/src/crawler/__tests__/sync-engine.test.ts
+++ b/packages/core/src/crawler/__tests__/sync-engine.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { eq } from "drizzle-orm";
-import { SyncEngine } from "../sync-engine";
+import { SyncEngine, extractWikilinks } from "../sync-engine";
 import { getCollectionDb } from "../../db/client";
 import {
   entities,
@@ -1008,6 +1008,37 @@ describe("SyncEngine", () => {
     expect(linkerLinks).toHaveLength(2);
     const targetIds = linkerLinks.map((l) => l.targetEntityId).sort();
     expect(targetIds).toEqual([otherEntity.id, anotherEntity.id].sort());
+  });
+
+  it("extracts standard markdown links and resolves relative paths", () => {
+    // Same-directory link from commits/abc.md
+    const md1 = "See [def](def.md) for the parent commit.";
+    expect(extractWikilinks(md1, "commits/abc.md")).toEqual(["commits/def"]);
+
+    // Cross-directory link from branches/main.md → commits/abc
+    const md2 = "Tip: [abc](../commits/abc.md)";
+    expect(extractWikilinks(md2, "branches/main.md")).toEqual(["commits/abc"]);
+
+    // Multiple links including same-dir and cross-dir
+    const md3 = "[a](a.md) and [b](../issues/b.md)";
+    expect(extractWikilinks(md3, "commits/x.md").sort()).toEqual(["commits/a", "issues/b"]);
+  });
+
+  it("excludes image links and external URLs from extraction", () => {
+    const md = "![img](../../attachments/pic.md) and [ext](https://example.com/page.md) and [local](sibling.md)";
+    expect(extractWikilinks(md, "issues/42.md")).toEqual(["issues/sibling"]);
+  });
+
+  it("extracts legacy Obsidian wikilinks alongside standard links", () => {
+    const md = "[[legacy/target]] and [standard](../standard/link.md)";
+    const targets = extractWikilinks(md, "issues/42.md");
+    expect(targets).toContain("legacy/target");
+    expect(targets).toContain("standard/link");
+  });
+
+  it("handles extractWikilinks without sourceFilePath (root-relative)", () => {
+    const md = "[label](commits/abc.md)";
+    expect(extractWikilinks(md)).toEqual(["commits/abc"]);
   });
 
   it("cleans up links when an entity is deleted", async () => {

--- a/packages/core/src/crawler/sync-engine.ts
+++ b/packages/core/src/crawler/sync-engine.ts
@@ -29,17 +29,45 @@ function statMatches(
   return stored.markdownMtime === current.mtimeMs && stored.markdownSize === current.size;
 }
 
-/** Extract wikilink targets from rendered markdown. Returns unique target strings. */
-export function extractWikilinks(markdown: string): string[] {
+/**
+ * Extract internal link targets from rendered markdown.
+ * Returns unique target strings as root-relative paths (without .md extension).
+ *
+ * @param markdown  The markdown content to extract links from.
+ * @param sourceFilePath  The markdown file's path relative to the markdown root
+ *   (e.g. "commits/abc.md"). When provided, relative links are resolved to
+ *   root-relative paths. When omitted, relative prefixes are stripped as a best-effort.
+ */
+export function extractWikilinks(markdown: string, sourceFilePath?: string): string[] {
   const targets = new Set<string>();
-  // Negative lookbehind excludes ![[embeds]] (images / transclusions).
-  // Capture group strips [[target#section]] and [[target^blockref]] anchors.
-  const regex = /(?<!!)\[\[([^\]|]+?)(?:[#^][^\]|]*)?(?:\|[^\]]+?)?\]\]/g;
+
+  // Standard markdown links: [label](target.md) — exclude images, external URLs, and anchors.
+  const mdLinkRegex = /(?<!!)\[([^\]]*)\]\((?!https?:\/\/|mailto:|#)([^)]+\.md)(?:#[^)]*)?\)/g;
   let match;
-  while ((match = regex.exec(markdown)) !== null) {
+  while ((match = mdLinkRegex.exec(markdown)) !== null) {
+    let target = match[2].replace(/\.md$/, "").trim();
+    if (!target) continue;
+    // Resolve relative path to root-relative
+    if (sourceFilePath && (target.startsWith("../") || !target.includes("/"))) {
+      const sourceDir = sourceFilePath.replace(/\/[^/]+$/, "");
+      const parts = (sourceDir ? `${sourceDir}/${target}` : target).split("/");
+      const resolved: string[] = [];
+      for (const p of parts) {
+        if (p === "..") resolved.pop();
+        else if (p !== "." && p !== "") resolved.push(p);
+      }
+      target = resolved.join("/");
+    }
+    if (target) targets.add(target);
+  }
+
+  // Legacy Obsidian wikilinks: [[target|label]] — for backward compatibility with vault content.
+  const wikiRegex = /(?<!!)\[\[([^\]|]+?)(?:[#^][^\]|]*)?(?:\|[^\]]+?)?\]\]/g;
+  while ((match = wikiRegex.exec(markdown)) !== null) {
     const target = match[1].trim();
     if (target) targets.add(target);
   }
+
   return Array.from(targets);
 }
 
@@ -188,7 +216,7 @@ export class SyncEngine {
         });
 
         // Process entities (links are deferred until all entities exist)
-        const deferredLinks: Array<{ entityId: number; markdown: string }> = [];
+        const deferredLinks: Array<{ entityId: number; markdown: string; markdownPath?: string }> = [];
         for (const entityData of result.entities) {
           const counts = await this.upsertEntity(entityData, crawlerType, deferredLinks);
           created += counts.created;
@@ -202,8 +230,8 @@ export class SyncEngine {
         }
 
         // Sync links now that all entities in the batch exist
-        for (const { entityId, markdown } of deferredLinks) {
-          this.syncLinks(entityId, markdown);
+        for (const { entityId, markdown, markdownPath } of deferredLinks) {
+          this.syncLinks(entityId, markdown, markdownPath);
         }
 
         // Handle deletions
@@ -286,7 +314,7 @@ export class SyncEngine {
   private async upsertEntity(
     entityData: CrawlerEntityData,
     crawlerType: string,
-    deferredLinks?: Array<{ entityId: number; markdown: string }>,
+    deferredLinks?: Array<{ entityId: number; markdown: string; markdownPath?: string }>,
   ): Promise<{ created: number; updated: number }> {
     const contentHash = entityData.contentHash ?? computeHash(entityData.data);
 
@@ -343,9 +371,9 @@ export class SyncEngine {
 
       // Defer link syncing until all entities in the batch exist
       if (deferredLinks) {
-        deferredLinks.push({ entityId: existing.id, markdown });
+        deferredLinks.push({ entityId: existing.id, markdown, markdownPath: filePath });
       } else {
-        this.syncLinks(existing.id, markdown);
+        this.syncLinks(existing.id, markdown, filePath);
       }
 
       // Update search index
@@ -397,9 +425,9 @@ export class SyncEngine {
 
     // Defer link syncing until all entities in the batch exist
     if (deferredLinks) {
-      deferredLinks.push({ entityId: inserted.id, markdown });
+      deferredLinks.push({ entityId: inserted.id, markdown, markdownPath: filePath });
     } else {
-      this.syncLinks(inserted.id, markdown);
+      this.syncLinks(inserted.id, markdown, filePath);
     }
 
     // Add to search index
@@ -495,9 +523,14 @@ export class SyncEngine {
   private syncLinks(
     entityId: number,
     markdown: string,
+    markdownPath?: string,
   ): void {
     // Extract wikilink targets and resolve them to entity IDs
-    const wikiTargets = extractWikilinks(markdown);
+    // Strip the base path prefix to get the file-relative path for resolution
+    const sourceFile = markdownPath?.startsWith(this.markdownBasePath + "/")
+      ? markdownPath.slice(this.markdownBasePath.length + 1)
+      : markdownPath;
+    const wikiTargets = extractWikilinks(markdown, sourceFile);
     const newTargetIds = new Set<number>();
     for (const target of wikiTargets) {
       const targetPath = `${this.markdownBasePath}/${target}.md`;
@@ -562,6 +595,52 @@ export class SyncEngine {
     };
   }
 
+  /**
+   * Build a wikilink resolver that supports Obsidian-style stem matching.
+   * "Topic" matches an entity whose externalId ends with "/Topic.md" or is "Topic.md".
+   */
+  private makeResolveWikilink(): (target: string) => string | undefined {
+    const allRows = this.db
+      .select({ externalId: entities.externalId, markdownPath: entities.markdownPath })
+      .from(entities)
+      .all();
+
+    const byExternalId = new Map<string, string>();
+    const byStem = new Map<string, string>();
+    const base = `${this.markdownBasePath}/`;
+
+    for (const row of allRows) {
+      if (!row.markdownPath) continue;
+      const relative = row.markdownPath.startsWith(base)
+        ? row.markdownPath.slice(base.length)
+        : row.markdownPath;
+      const withoutExt = relative.endsWith(".md") ? relative.slice(0, -3) : relative;
+
+      byExternalId.set(row.externalId, withoutExt);
+
+      // Stem key: filename without path and extension
+      const idWithoutExt = row.externalId.replace(/\.md$/, "");
+      const stemName = idWithoutExt.includes("/") ? idWithoutExt.split("/").pop()! : idWithoutExt;
+      if (!byStem.has(stemName)) {
+        byStem.set(stemName, withoutExt);
+      }
+    }
+
+    return (target: string) => {
+      const clean = target.replace(/[#^].*$/, "").trim();
+      if (!clean) return undefined;
+
+      // Try exact externalId match (with and without .md)
+      const withMd = clean.endsWith(".md") ? clean : `${clean}.md`;
+      if (byExternalId.has(withMd)) return byExternalId.get(withMd);
+      if (byExternalId.has(clean)) return byExternalId.get(clean);
+
+      // Stem match: bare filename without path
+      const stemName = clean.includes("/") ? clean.split("/").pop()! : clean;
+      return byStem.get(stemName);
+    };
+  }
+
   private renderMarkdown(
     entityData: CrawlerEntityData,
     crawlerType: string,
@@ -578,6 +657,7 @@ export class SyncEngine {
       collectionName: this.collectionName,
       crawlerType,
       lookupEntityPath: this.makeLookupEntityPath(),
+      resolveWikilink: this.makeResolveWikilink(),
     });
   }
 
@@ -638,7 +718,7 @@ export class SyncEngine {
         .run();
 
       // Re-sync wikilinks
-      this.syncLinks(row.id, markdown);
+      this.syncLinks(row.id, markdown, filePath);
 
       // Update search index
       this.searchIndexer.updateIndex({
@@ -677,6 +757,7 @@ export class SyncEngine {
         collectionName: this.collectionName,
         crawlerType,
         lookupEntityPath: this.makeLookupEntityPath(),
+        resolveWikilink: this.makeResolveWikilink(),
       });
       await this.storage.write(entity.markdownPath, expected);
       const writtenStat = await this.storage.stat(entity.markdownPath);

--- a/packages/core/src/export/textbundle.ts
+++ b/packages/core/src/export/textbundle.ts
@@ -157,16 +157,18 @@ export function buildTextPack(
   let markdown = readFileSync(mdFullPath, "utf-8");
   const attachmentsDir = join(home, "collections", collection, "attachments");
 
-  // Find all Obsidian-style image embeds: ![[path]]
+  // Find image embeds referencing attachments in all supported formats.
   const imageRefs: Array<{ match: string; path: string }> = [];
-  const embedRegex = /!\[\[([^\]]+)\]\]/g;
   let m: RegExpExecArray | null;
+
+  // Obsidian-style embeds: ![[path]] (backward compat for vault content)
+  const embedRegex = /!\[\[([^\]]+)\]\]/g;
   while ((m = embedRegex.exec(markdown)) !== null) {
     imageRefs.push({ match: m[0], path: m[1] });
   }
 
-  // Also find standard markdown images referencing attachments: ![alt](attachments/path)
-  const mdImageRegex = /!\[([^\]]*)\]\((attachments\/[^)]+)\)/g;
+  // Standard markdown images: ![alt](../../attachments/path) or ![alt](attachments/path)
+  const mdImageRegex = /!\[([^\]]*)\]\((?:\.\.\/\.\.\/)?attachments\/([^)]+)\)/g;
   while ((m = mdImageRegex.exec(markdown)) !== null) {
     imageRefs.push({ match: m[0], path: m[2] });
   }

--- a/packages/core/src/theme/__tests__/obsidian.test.ts
+++ b/packages/core/src/theme/__tests__/obsidian.test.ts
@@ -53,16 +53,36 @@ describe("frontmatter", () => {
 });
 
 describe("wikilink", () => {
-  it("produces [[target]] syntax", () => {
-    expect(wikilink("My Page")).toBe("[[My Page]]");
+  it("produces root-relative link without sourcePath", () => {
+    expect(wikilink("My Page")).toBe("[My Page](My Page.md)");
   });
 
-  it("produces [[target|label]] syntax with label", () => {
-    expect(wikilink("My Page", "click here")).toBe("[[My Page|click here]]");
+  it("produces link with label without sourcePath", () => {
+    expect(wikilink("My Page", "click here")).toBe("[click here](My Page.md)");
   });
 
-  it("handles paths with slashes", () => {
-    expect(wikilink("folder/page")).toBe("[[folder/page]]");
+  it("handles paths with slashes without sourcePath", () => {
+    expect(wikilink("folder/page")).toBe("[folder/page](folder/page.md)");
+  });
+
+  it("produces same-directory relative link when source and target share a folder", () => {
+    // commits/abc.md → commits/def.md = just "def.md"
+    expect(wikilink("commits/def", "def", "commits/abc.md")).toBe("[def](def.md)");
+  });
+
+  it("produces cross-directory relative link", () => {
+    // branches/main.md → commits/abc.md = "../commits/abc.md"
+    expect(wikilink("commits/abc", "abc", "branches/main.md")).toBe("[abc](../commits/abc.md)");
+  });
+
+  it("handles deep source paths", () => {
+    // project/issues/42.md → users/john = "../../users/john.md"
+    expect(wikilink("users/john", "@john", "project/issues/42.md")).toBe("[@john](../../users/john.md)");
+  });
+
+  it("handles same-project cross-type paths", () => {
+    // project/issues/42.md → project/issues/100 = "100.md"
+    expect(wikilink("project/issues/100", "#100", "project/issues/42.md")).toBe("[#100](100.md)");
   });
 });
 
@@ -86,11 +106,21 @@ describe("callout", () => {
 });
 
 describe("embed", () => {
-  it("produces ![[path]] syntax", () => {
-    expect(embed("image.png")).toBe("![[image.png]]");
+  it("produces default relative attachment path without sourcePath", () => {
+    expect(embed("image.png")).toBe("![image](../../attachments/image.png)");
   });
 
-  it("handles paths with folders", () => {
-    expect(embed("attachments/photo.jpg")).toBe("![[attachments/photo.jpg]]");
+  it("handles paths with folders without sourcePath", () => {
+    expect(embed("git/abc1234/photo.jpg")).toBe("![photo](../../attachments/git/abc1234/photo.jpg)");
+  });
+
+  it("computes correct relative path from one-level-deep source", () => {
+    // markdown/commits/abc.md → attachments/git/abc/logo.png
+    expect(embed("git/abc/logo.png", "commits/abc.md")).toBe("![logo](../../attachments/git/abc/logo.png)");
+  });
+
+  it("computes correct relative path from two-level-deep source", () => {
+    // markdown/project/issues/42.md → attachments/files/img.png
+    expect(embed("files/img.png", "project/issues/42.md")).toBe("![img](../../../attachments/files/img.png)");
   });
 });

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -1,3 +1,3 @@
 export type { Theme, ThemeRenderContext } from "./interface";
-export { frontmatter, wikilink, callout, embed } from "./obsidian";
+export { frontmatter, wikilink, callout, embed, basename, dirname, relativePath } from "./obsidian";
 export { ThemeEngine } from "./engine";

--- a/packages/core/src/theme/interface.ts
+++ b/packages/core/src/theme/interface.ts
@@ -15,6 +15,12 @@ export interface ThemeRenderContext {
    * Used by themes to generate correct cross-reference wikilinks.
    */
   lookupEntityPath?: (externalId: string) => string | undefined;
+  /**
+   * Resolve an Obsidian-style wikilink target (bare name or path) to a markdown
+   * file path (relative to markdown root, without .md extension).
+   * Supports stem matching: "Topic" matches "subfolder/Topic.md".
+   */
+  resolveWikilink?: (target: string) => string | undefined;
 }
 
 export interface Theme {

--- a/packages/core/src/theme/obsidian.ts
+++ b/packages/core/src/theme/obsidian.ts
@@ -1,3 +1,5 @@
+import { posix } from "path";
+
 function serializeYamlValue(value: unknown, indent: number = 0): string {
   if (value === null || value === undefined) {
     return "null";
@@ -55,11 +57,14 @@ export function frontmatter(fields: Record<string, unknown>): string {
   return lines.join("\n");
 }
 
-export function wikilink(target: string, label?: string): string {
-  if (label) {
-    return `[[${target}|${label}]]`;
+export function wikilink(target: string, label?: string, sourcePath?: string): string {
+  const targetFile = `${target}.md`;
+  if (sourcePath) {
+    const sourceDir = posix.dirname(sourcePath);
+    const relPath = posix.relative(sourceDir, targetFile);
+    return `[${label ?? target}](${relPath})`;
   }
-  return `[[${target}]]`;
+  return `[${label ?? target}](${targetFile})`;
 }
 
 export function callout(type: string, title: string, content: string): string {
@@ -70,6 +75,14 @@ export function callout(type: string, title: string, content: string): string {
   return lines.join("\n");
 }
 
-export function embed(path: string): string {
-  return `![[${path}]]`;
+export function embed(path: string, sourcePath?: string): string {
+  const filename = path.split("/").pop() ?? path;
+  const alt = filename.replace(/\.[^.]+$/, "");
+  if (sourcePath) {
+    // Source is under markdown/, attachments is a sibling directory
+    const sourceDir = posix.dirname(`markdown/${sourcePath}`);
+    const relPath = posix.relative(sourceDir, `attachments/${path}`);
+    return `![${alt}](${relPath})`;
+  }
+  return `![${alt}](../../attachments/${path})`;
 }

--- a/packages/core/src/theme/obsidian.ts
+++ b/packages/core/src/theme/obsidian.ts
@@ -1,4 +1,42 @@
-import { posix } from "path";
+// Portable posix path helpers — avoids importing "path" which is unavailable
+// in the Cloudflare Worker bundle (esbuild without --platform=node).
+
+function dirname(p: string): string {
+  const idx = p.lastIndexOf("/");
+  return idx === -1 ? "." : p.slice(0, idx) || ".";
+}
+
+function basename(p: string, ext?: string): string {
+  const name = p.includes("/") ? p.split("/").pop()! : p;
+  if (ext && name.endsWith(ext)) return name.slice(0, -ext.length);
+  return name;
+}
+
+function normalizeParts(parts: string[]): string[] {
+  const out: string[] = [];
+  for (const p of parts) {
+    if (p === "..") {
+      if (out.length > 0 && out[out.length - 1] !== "..") out.pop();
+      else out.push("..");
+    } else if (p !== "." && p !== "") {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function relativePath(from: string, to: string): string {
+  const fromParts = normalizeParts(from.split("/"));
+  const toParts = normalizeParts(to.split("/"));
+  // Remove common prefix
+  let common = 0;
+  while (common < fromParts.length && common < toParts.length && fromParts[common] === toParts[common]) {
+    common++;
+  }
+  const ups = fromParts.length - common;
+  const result = [...Array(ups).fill(".."), ...toParts.slice(common)];
+  return result.join("/") || ".";
+}
 
 function serializeYamlValue(value: unknown, indent: number = 0): string {
   if (value === null || value === undefined) {
@@ -60,8 +98,8 @@ export function frontmatter(fields: Record<string, unknown>): string {
 export function wikilink(target: string, label?: string, sourcePath?: string): string {
   const targetFile = `${target}.md`;
   if (sourcePath) {
-    const sourceDir = posix.dirname(sourcePath);
-    const relPath = posix.relative(sourceDir, targetFile);
+    const sourceDir = dirname(sourcePath);
+    const relPath = relativePath(sourceDir, targetFile);
     return `[${label ?? target}](${relPath})`;
   }
   return `[${label ?? target}](${targetFile})`;
@@ -80,9 +118,11 @@ export function embed(path: string, sourcePath?: string): string {
   const alt = filename.replace(/\.[^.]+$/, "");
   if (sourcePath) {
     // Source is under markdown/, attachments is a sibling directory
-    const sourceDir = posix.dirname(`markdown/${sourcePath}`);
-    const relPath = posix.relative(sourceDir, `attachments/${path}`);
+    const sourceDir = dirname(`markdown/${sourcePath}`);
+    const relPath = relativePath(sourceDir, `attachments/${path}`);
     return `![${alt}](${relPath})`;
   }
   return `![${alt}](../../attachments/${path})`;
 }
+
+export { basename, dirname, relativePath };

--- a/packages/crawlers/src/git/__tests__/theme.test.ts
+++ b/packages/crawlers/src/git/__tests__/theme.test.ts
@@ -134,9 +134,10 @@ describe("GitTheme", () => {
     expect(md).toContain("**Hash:** `abc1234`");
   });
 
-  it("renders parent wikilinks", () => {
+  it("renders parent wikilinks with same-directory relative path", () => {
     const md = theme.render(commitContext());
-    expect(md).toContain("[[commits/def5678-add-auth-module|def5678]]");
+    // commit → commit is same directory, so no commits/ prefix needed
+    expect(md).toContain("[def5678](def5678-add-auth-module.md)");
   });
 
   it("renders file changes callout", () => {
@@ -183,7 +184,7 @@ describe("GitTheme", () => {
       ],
     });
     const md = theme.render(ctx);
-    expect(md).toContain("![[git/abc1234/logo.png]]");
+    expect(md).toContain("![logo](../../attachments/git/abc1234/logo.png)");
   });
 
   // --- Branch rendering ---
@@ -193,9 +194,10 @@ describe("GitTheme", () => {
     expect(md).toContain("# main");
   });
 
-  it("renders branch tip wikilink", () => {
+  it("renders branch tip wikilink with relative path", () => {
     const md = theme.render(branchContext());
-    expect(md).toContain("[[commits/abc1234-fix-login-bug|abc1234]]");
+    // branches/main.md → ../commits/abc1234-fix-login-bug.md (cross-directory)
+    expect(md).toContain("[abc1234](../commits/abc1234-fix-login-bug.md)");
   });
 
   it("renders branch recent commits as list", () => {
@@ -220,9 +222,10 @@ describe("GitTheme", () => {
     expect(md).toContain("# v1.0.0");
   });
 
-  it("renders tag target wikilink", () => {
+  it("renders tag target wikilink with relative path", () => {
     const md = theme.render(tagContext());
-    expect(md).toContain("[[commits/abc1234-fix-login-bug|abc1234]]");
+    // tags/v1-0-0.md → ../commits/abc1234-fix-login-bug.md (cross-directory)
+    expect(md).toContain("[abc1234](../commits/abc1234-fix-login-bug.md)");
   });
 
   it("renders tag type and tagger", () => {

--- a/packages/crawlers/src/git/theme.ts
+++ b/packages/crawlers/src/git/theme.ts
@@ -1,5 +1,5 @@
 import type { Theme, ThemeRenderContext } from "@frozenink/core/theme";
-import { frontmatter, wikilink, callout } from "@frozenink/core/theme";
+import { frontmatter, wikilink, callout, embed } from "@frozenink/core/theme";
 
 function slugify(text: string): string {
   return text
@@ -64,6 +64,7 @@ export class GitTheme implements Theme {
 
   private renderCommit(context: ThemeRenderContext): string {
     const d = context.entity.data;
+    const source = this.getFilePath(context);
     const sections: string[] = [];
 
     // Frontmatter
@@ -97,7 +98,7 @@ export class GitTheme implements Theme {
     }> | undefined;
     if (parentDetails?.length) {
       const parentLinks = parentDetails.map((p) =>
-        wikilink(commitFilePath(p.shortHash, p.subject), p.shortHash),
+        wikilink(commitFilePath(p.shortHash, p.subject), p.shortHash, source),
       );
       meta.push(`**Parents:** ${parentLinks.join(", ")}`);
     }
@@ -128,7 +129,7 @@ export class GitTheme implements Theme {
           if (["png", "jpg", "jpeg", "gif", "svg", "webp", "bmp"].includes(ext) && f.status !== "D") {
             const shortHash = d.shortHash as string;
             const filename = f.path.split("/").pop() ?? f.path;
-            line += `\n![[git/${shortHash}/${filename}]]`;
+            line += `\n${embed(`git/${shortHash}/${filename}`, source)}`;
           }
         } else {
           const parts: string[] = [];
@@ -151,6 +152,7 @@ export class GitTheme implements Theme {
 
   private renderBranch(context: ThemeRenderContext): string {
     const d = context.entity.data;
+    const source = this.getFilePath(context);
     const sections: string[] = [];
 
     // Frontmatter
@@ -170,7 +172,7 @@ export class GitTheme implements Theme {
 
     if (recentCommits?.[0]) {
       const tip = recentCommits[0];
-      meta.push(`**Tip:** ${wikilink(commitFilePath(tip.shortHash, tip.subject), tip.shortHash)}`);
+      meta.push(`**Tip:** ${wikilink(commitFilePath(tip.shortHash, tip.subject), tip.shortHash, source)}`);
     }
     meta.push(`**Type:** ${d.isRemote ? "Remote" : "Local"}`);
     sections.push(callout("info", "Branch Info", meta.join("\n")));
@@ -178,7 +180,7 @@ export class GitTheme implements Theme {
     // Recent commits
     if (recentCommits?.length) {
       const lines = recentCommits.map((c) => {
-        const link = wikilink(commitFilePath(c.shortHash, c.subject), c.shortHash);
+        const link = wikilink(commitFilePath(c.shortHash, c.subject), c.shortHash, source);
         return `- ${link} ${c.subject}`;
       });
       sections.push("## Recent Commits\n\n" + lines.join("\n"));
@@ -189,6 +191,7 @@ export class GitTheme implements Theme {
 
   private renderTag(context: ThemeRenderContext): string {
     const d = context.entity.data;
+    const source = this.getFilePath(context);
     const sections: string[] = [];
 
     // Frontmatter
@@ -209,7 +212,7 @@ export class GitTheme implements Theme {
       d.targetShortHash as string,
       d.targetSubject as string,
     );
-    meta.push(`**Target:** ${wikilink(targetPath, d.targetShortHash as string)}`);
+    meta.push(`**Target:** ${wikilink(targetPath, d.targetShortHash as string, source)}`);
     meta.push(`**Type:** ${d.annotated ? "Annotated" : "Lightweight"}`);
     if (d.tagger) meta.push(`**Tagger:** ${d.tagger}`);
     if (d.date) meta.push(`**Date:** ${d.date}`);

--- a/packages/crawlers/src/github/__tests__/theme.test.ts
+++ b/packages/crawlers/src/github/__tests__/theme.test.ts
@@ -139,8 +139,8 @@ describe("GitHubTheme", () => {
     it("renders wikilinks for related issues", () => {
       const md = theme.render(makeIssueContext());
       expect(md).toContain("> [!link] Related Issues");
-      expect(md).toContain("[[issues/100|#100]]");
-      expect(md).toContain("[[issues/200|#200]]");
+      expect(md).toContain("[#100](100.md)");
+      expect(md).toContain("[#200](200.md)");
     });
 
     it("omits related issues section when no refs in body", () => {
@@ -256,8 +256,8 @@ describe("GitHubTheme", () => {
     it("renders linked issues as wikilinks", () => {
       const md = theme.render(makePRContext());
       expect(md).toContain("> [!link] Linked Issues");
-      expect(md).toContain("[[issues/50|#50]]");
-      expect(md).toContain("[[issues/51|#51]]");
+      expect(md).toContain("[#50](../issues/50.md)");
+      expect(md).toContain("[#51](../issues/51.md)");
     });
 
     it("shows merged review status when PR is merged", () => {

--- a/packages/crawlers/src/github/theme.ts
+++ b/packages/crawlers/src/github/theme.ts
@@ -414,6 +414,7 @@ export class GitHubTheme implements Theme {
   private renderIssue(context: ThemeRenderContext): string {
     const { entity } = context;
     const d = entity.data;
+    const source = this.getFilePath(context);
     const user = d.user as MappedUser | null;
     const sections: string[] = [];
 
@@ -469,7 +470,7 @@ export class GitHubTheme implements Theme {
     if (relatedNumbers.length > 0) {
       const links = relatedNumbers.map((num) => {
         const resolved = context.lookupEntityPath?.(`issue-${num}`);
-        return wikilink(resolved ?? `issues/${num}`, `#${num}`);
+        return wikilink(resolved ?? `issues/${num}`, `#${num}`, source);
       });
       sections.push(
         callout("link", "Related Issues", links.join("\n")),
@@ -488,6 +489,7 @@ export class GitHubTheme implements Theme {
   private renderPullRequest(context: ThemeRenderContext): string {
     const { entity } = context;
     const d = entity.data;
+    const source = this.getFilePath(context);
     const user = d.user as MappedUser | null;
     const sections: string[] = [];
 
@@ -569,7 +571,7 @@ export class GitHubTheme implements Theme {
     if (relatedNumbers.length > 0) {
       const links = relatedNumbers.map((num) => {
         const resolved = context.lookupEntityPath?.(`issue-${num}`);
-        return wikilink(resolved ?? `issues/${num}`, `#${num}`);
+        return wikilink(resolved ?? `issues/${num}`, `#${num}`, source);
       });
       sections.push(
         callout("link", "Linked Issues", links.join("\n")),

--- a/packages/crawlers/src/mantisbt/theme.ts
+++ b/packages/crawlers/src/mantisbt/theme.ts
@@ -302,27 +302,29 @@ function replaceInlineRefs(
   return text;
 }
 
-/** Render a username as a wikilink to the user entity in markdown, prefixed with @. */
+/** Render a username as a link to the user entity in markdown, prefixed with @. */
 function mdUserRef(
   username: string,
   lookup: (externalId: string) => string | undefined,
+  sourcePath?: string,
 ): string {
   const path = lookup(`user:${username}`);
   if (path) {
-    return `[[${path}|@${username}]]`;
+    return wikilink(path, `@${username}`, sourcePath);
   }
   return `@${username}`;
 }
 
-/** Render a user's full name as a wikilink to the user entity in markdown (no @ prefix). */
+/** Render a user's full name as a link to the user entity in markdown (no @ prefix). */
 function mdUserRefFull(
   username: string,
   fullName: string,
   lookup: (externalId: string) => string | undefined,
+  sourcePath?: string,
 ): string {
   const path = lookup(`user:${username}`);
   if (path) {
-    return `[[${path}|${fullName}]]`;
+    return wikilink(path, fullName, sourcePath);
   }
   return fullName;
 }
@@ -690,6 +692,7 @@ export class MantisBTTheme implements Theme {
 
   private renderPageMd(context: ThemeRenderContext): string {
     const d = context.entity.data;
+    const source = this.getFilePath(context);
     const lookup = context.lookupEntityPath ?? (() => undefined);
     const projectId = (d.project as { id: number } | null)?.id;
     const projectNameToId = d._projectNameToId as Record<string, number> | undefined;
@@ -736,14 +739,14 @@ export class MantisBTTheme implements Theme {
     const rows: string[] = ["| | |", "|---|---|"];
     if (createdBy?.name) {
       const ref = createdBy.real_name
-        ? mdUserRefFull(createdBy.name, createdBy.real_name, lookup)
-        : mdUserRef(createdBy.name, lookup);
+        ? mdUserRefFull(createdBy.name, createdBy.real_name, lookup, source)
+        : mdUserRef(createdBy.name, lookup, source);
       rows.push(tableRow("Created By", ref));
     }
     if (updatedBy?.name) {
       const ref = updatedBy.real_name
-        ? mdUserRefFull(updatedBy.name, updatedBy.real_name, lookup)
-        : mdUserRef(updatedBy.name, lookup);
+        ? mdUserRefFull(updatedBy.name, updatedBy.real_name, lookup, source)
+        : mdUserRef(updatedBy.name, lookup, source);
       rows.push(tableRow("Updated By", ref));
     }
     if (d.createdAt) rows.push(tableRow("Created", formatDate(d.createdAt as string)));
@@ -841,6 +844,7 @@ export class MantisBTTheme implements Theme {
 
   private renderIssue(context: ThemeRenderContext): string {
     const d = context.entity.data;
+    const source = this.getFilePath(context);
     const sections: string[] = [];
 
     const status = d.status as { name: string; label: string };
@@ -893,8 +897,8 @@ export class MantisBTTheme implements Theme {
       tableRow("Priority", priority.label),
       tableRow("Severity", severity.label),
     ];
-    if (reporter?.name) rows.push(tableRow("Reporter", mdUserRef(reporter.name, lookup)));
-    if (handler?.name) rows.push(tableRow("Assigned To", mdUserRef(handler.name, lookup)));
+    if (reporter?.name) rows.push(tableRow("Reporter", mdUserRef(reporter.name, lookup, source)));
+    if (handler?.name) rows.push(tableRow("Assigned To", mdUserRef(handler.name, lookup, source)));
     if (reproducibility) rows.push(tableRow("Reproducibility", reproducibility.label));
     rows.push(tableRow("Created", formatDate(d.createdAt as string)));
     rows.push(tableRow("Updated", formatDate(d.updatedAt as string)));
@@ -945,7 +949,7 @@ export class MantisBTTheme implements Theme {
         const label = rel.issue.summary
           ? `${padId(rel.issue.id)} ${rel.issue.summary}`
           : padId(rel.issue.id);
-        return `- **${rel.type.label ?? rel.type.name}:** ${wikilink(targetPath, label)}`;
+        return `- **${rel.type.label ?? rel.type.name}:** ${wikilink(targetPath, label, source)}`;
       });
       sections.push("### Relationships\n\n" + relLines.join("\n"));
     }
@@ -962,7 +966,7 @@ export class MantisBTTheme implements Theme {
     if (notes?.length) {
       const noteBlocks = notes.map((note) => {
         const authorName = note.reporter?.name ?? "Unknown";
-        const authorRef = authorName !== "Unknown" ? mdUserRef(authorName, lookup) : authorName;
+        const authorRef = authorName !== "Unknown" ? mdUserRef(authorName, lookup, source) : authorName;
         const isPrivate = note.view_state?.name === "private";
         const headerParts = [authorRef, formatDate(note.created_at)];
         if (isPrivate) headerParts.push("private");

--- a/packages/crawlers/src/obsidian/__tests__/crawler.test.ts
+++ b/packages/crawlers/src/obsidian/__tests__/crawler.test.ts
@@ -158,6 +158,21 @@ describe("ObsidianCrawler", () => {
     expect(secondResult.deletedExternalIds).toContain("delete-me.md");
   });
 
+  it("stores imageRefMap mapping image references to resolved vault paths", async () => {
+    const imgContent = Buffer.from("image-bytes");
+    writeVaultBinary("assets/diagram.png", imgContent);
+    writeVaultFile("note.md", "# Note\n\n![[diagram.png]]");
+
+    await crawler.initialize({ vaultPath: vaultDir }, { vaultPath: vaultDir });
+    const result = await crawler.sync(null);
+
+    const entity = result.entities[0];
+    const imageRefMap = entity.data.imageRefMap as Record<string, string>;
+    expect(imageRefMap).toBeDefined();
+    // Short-form "diagram.png" resolves to "assets/diagram.png"
+    expect(imageRefMap["diagram.png"]).toBe("assets/diagram.png");
+  });
+
   it("includes image attachments referenced via wiki embeds", async () => {
     const imgContent = Buffer.from("fake-png-data");
     writeVaultBinary("images/photo.png", imgContent);

--- a/packages/crawlers/src/obsidian/__tests__/theme.test.ts
+++ b/packages/crawlers/src/obsidian/__tests__/theme.test.ts
@@ -4,7 +4,14 @@ import type { ThemeRenderContext } from "@frozenink/core";
 
 const theme = new ObsidianTheme();
 
-function makeContext(overrides: Partial<ThemeRenderContext["entity"]> & { content?: string; relativePath?: string } = {}): ThemeRenderContext {
+function makeContext(
+  overrides: Partial<ThemeRenderContext["entity"]> & {
+    content?: string;
+    relativePath?: string;
+    imageRefMap?: Record<string, string>;
+  } = {},
+  contextOverrides: Partial<Omit<ThemeRenderContext, "entity">> = {},
+): ThemeRenderContext {
   return {
     entity: {
       externalId: overrides.externalId ?? "notes/test.md",
@@ -13,30 +20,20 @@ function makeContext(overrides: Partial<ThemeRenderContext["entity"]> & { conten
       data: {
         content: overrides.content ?? "# Test Note\n\nSome content.",
         relativePath: overrides.relativePath ?? "notes/test.md",
+        imageRefMap: overrides.imageRefMap ?? {},
       },
       url: undefined,
       tags: overrides.tags ?? [],
     },
     collectionName: "my-vault",
     crawlerType: "obsidian",
+    ...contextOverrides,
   };
 }
 
 describe("ObsidianTheme", () => {
   it("has correct crawlerType", () => {
     expect(theme.crawlerType).toBe("obsidian");
-  });
-
-  it("renders content as-is (passthrough)", () => {
-    const ctx = makeContext({ content: "# Hello\n\n![[image.png]]\n\nSome text with [[wikilink]]." });
-    const rendered = theme.render(ctx);
-    expect(rendered).toBe("# Hello\n\n![[image.png]]\n\nSome text with [[wikilink]].");
-  });
-
-  it("preserves frontmatter in rendered output", () => {
-    const content = "---\ntitle: Test\ntags: [a, b]\n---\n\n# Test\n\nContent.";
-    const ctx = makeContext({ content });
-    expect(theme.render(ctx)).toBe(content);
   });
 
   it("returns vault-relative path as file path", () => {
@@ -47,5 +44,219 @@ describe("ObsidianTheme", () => {
   it("preserves nested directory structure in file path", () => {
     const ctx = makeContext({ relativePath: "daily/2024/01/15.md" });
     expect(theme.getFilePath(ctx)).toBe("daily/2024/01/15.md");
+  });
+
+  // --- Wikilink conversion ---
+
+  it("converts wikilinks to standard markdown links using resolveWikilink", () => {
+    const ctx = makeContext(
+      { content: "See [[Other Note]] for details.", relativePath: "notes/test.md" },
+      { resolveWikilink: (t) => (t === "Other Note" ? "notes/Other Note" : undefined) },
+    );
+    const md = theme.render(ctx);
+    // Same directory → just filename
+    expect(md).toContain("[Other Note](Other Note.md)");
+    expect(md).not.toContain("[[");
+  });
+
+  it("resolves bare wikilink to file in a different folder via stem matching", () => {
+    const ctx = makeContext(
+      { content: "See [[Topic]] for info.", relativePath: "notes/test.md" },
+      { resolveWikilink: (t) => (t === "Topic" ? "projects/Topic" : undefined) },
+    );
+    const md = theme.render(ctx);
+    // notes/test.md → ../projects/Topic.md
+    expect(md).toContain("[Topic](../projects/Topic.md)");
+  });
+
+  it("converts labeled wikilinks with correct relative path", () => {
+    const ctx = makeContext(
+      { content: "Read [[guides/setup|Setup Guide]] first.", relativePath: "notes/test.md" },
+      { resolveWikilink: (t) => (t === "guides/setup" ? "guides/setup" : undefined) },
+    );
+    const md = theme.render(ctx);
+    expect(md).toContain("[Setup Guide](../guides/setup.md)");
+  });
+
+  it("renders unresolved wikilinks as plain text", () => {
+    const ctx = makeContext(
+      { content: "See [[Missing Page]] here.", relativePath: "notes/test.md" },
+      { resolveWikilink: () => undefined },
+    );
+    const md = theme.render(ctx);
+    expect(md).toContain("Missing Page");
+    expect(md).not.toContain("[[");
+    expect(md).not.toContain("](");
+  });
+
+  it("renders unresolved labeled wikilinks using the label text", () => {
+    const ctx = makeContext(
+      { content: "See [[gone|Click Here]] now.", relativePath: "notes/test.md" },
+      { resolveWikilink: () => undefined },
+    );
+    const md = theme.render(ctx);
+    expect(md).toContain("Click Here");
+    expect(md).not.toContain("[[");
+  });
+
+  it("resolves bare wikilink from deeply nested file to different folder", () => {
+    const ctx = makeContext(
+      { content: "See [[Topic]] here.", relativePath: "daily/2024/01/note.md" },
+      { resolveWikilink: (t) => (t === "Topic" ? "projects/Topic" : undefined) },
+    );
+    const md = theme.render(ctx);
+    // daily/2024/01/note.md → ../../../projects/Topic.md
+    expect(md).toContain("[Topic](../../../projects/Topic.md)");
+  });
+
+  it("resolves path-qualified wikilink across folders", () => {
+    const ctx = makeContext(
+      { content: "See [[projects/setup]] here.", relativePath: "notes/test.md" },
+      { resolveWikilink: (t) => (t === "projects/setup" ? "projects/setup" : undefined) },
+    );
+    const md = theme.render(ctx);
+    expect(md).toContain("[setup](../projects/setup.md)");
+  });
+
+  it("strips section anchors from wikilinks for resolution", () => {
+    const ctx = makeContext(
+      { content: "See [[Topic#section-two]] here.", relativePath: "notes/test.md" },
+      { resolveWikilink: (t) => (t === "Topic" ? "guides/Topic" : undefined) },
+    );
+    const md = theme.render(ctx);
+    expect(md).toContain("[Topic](../guides/Topic.md)");
+    expect(md).not.toContain("#section-two");
+  });
+
+  it("handles multiple wikilinks in same content (resolved and unresolved)", () => {
+    const ctx = makeContext(
+      { content: "See [[Found]] and [[Missing]] and [[Also Found]].", relativePath: "notes/test.md" },
+      {
+        resolveWikilink: (t) => {
+          if (t === "Found") return "docs/Found";
+          if (t === "Also Found") return "notes/Also Found";
+          return undefined;
+        },
+      },
+    );
+    const md = theme.render(ctx);
+    expect(md).toContain("[Found](../docs/Found.md)");
+    expect(md).toContain("Missing");
+    expect(md).not.toContain("[[Missing]]");
+    expect(md).toContain("[Also Found](Also Found.md)");
+  });
+
+  // --- Image embed conversion ---
+
+  it("converts image embeds to standard markdown using imageRefMap", () => {
+    const ctx = makeContext({
+      content: "![[photo.png]]",
+      relativePath: "notes/test.md",
+      imageRefMap: { "photo.png": "images/photo.png" },
+    });
+    const md = theme.render(ctx);
+    // notes/test.md (markdown/notes/test.md) → ../../attachments/images/photo.png
+    expect(md).toContain("![photo](../../attachments/images/photo.png)");
+    expect(md).not.toContain("![[");
+  });
+
+  it("handles image embeds with pipe sizing (Obsidian |400 syntax)", () => {
+    const ctx = makeContext({
+      content: "![[photo.png|400]]",
+      relativePath: "notes/test.md",
+      imageRefMap: { "photo.png": "images/photo.png" },
+    });
+    const md = theme.render(ctx);
+    expect(md).toContain("![photo](../../attachments/images/photo.png)");
+  });
+
+  it("uses raw ref as fallback when imageRefMap has no entry", () => {
+    const ctx = makeContext({
+      content: "![[unknown.png]]",
+      relativePath: "notes/test.md",
+      imageRefMap: {},
+    });
+    const md = theme.render(ctx);
+    expect(md).toContain("![unknown](../../attachments/unknown.png)");
+  });
+
+  it("computes correct image relative path from deeply nested file", () => {
+    const ctx = makeContext({
+      content: "![[diagram.png]]",
+      relativePath: "projects/alpha/docs/readme.md",
+      imageRefMap: { "diagram.png": "assets/diagram.png" },
+    });
+    const md = theme.render(ctx);
+    // markdown/projects/alpha/docs/readme.md → ../../../../attachments/assets/diagram.png
+    expect(md).toContain("![diagram](../../../../attachments/assets/diagram.png)");
+  });
+
+  // --- H1 header injection ---
+
+  it("preserves existing H1 header", () => {
+    const ctx = makeContext({
+      content: "# My Title\n\nBody text.",
+      relativePath: "notes/my-note.md",
+    });
+    const md = theme.render(ctx);
+    expect(md).toContain("# My Title");
+    // Should NOT prepend another H1
+    expect(md).not.toContain("# my-note");
+  });
+
+  it("adds H1 from filename when content has no H1", () => {
+    const ctx = makeContext({
+      content: "Just some body text without a heading.",
+      relativePath: "notes/daily-standup.md",
+    });
+    const md = theme.render(ctx);
+    expect(md).toStartWith("# daily-standup\n\n");
+    expect(md).toContain("Just some body text");
+  });
+
+  it("adds H1 after frontmatter when content has no H1", () => {
+    const ctx = makeContext({
+      content: "---\ntags: [journal]\n---\n\nNo heading here.",
+      relativePath: "daily/2024-01-15.md",
+    });
+    const md = theme.render(ctx);
+    expect(md).toStartWith("---\ntags: [journal]\n---\n\n# 2024-01-15\n\n");
+    expect(md).toContain("No heading here.");
+  });
+
+  it("does not treat H1 inside code block as real H1", () => {
+    const ctx = makeContext({
+      content: "```\n# This is code\n```\n\nBody.",
+      relativePath: "notes/snippet.md",
+    });
+    const md = theme.render(ctx);
+    expect(md).toContain("# snippet\n\n");
+  });
+
+  it("adds H1 when content only has H2 headings", () => {
+    const ctx = makeContext({
+      content: "## Section One\n\nBody.\n\n## Section Two\n\nMore.",
+      relativePath: "notes/my-topic.md",
+    });
+    const md = theme.render(ctx);
+    expect(md).toStartWith("# my-topic\n\n");
+    expect(md).toContain("## Section One");
+  });
+
+  it("adds H1 for empty body content", () => {
+    const ctx = makeContext({
+      content: "",
+      relativePath: "notes/empty.md",
+    });
+    const md = theme.render(ctx);
+    expect(md).toBe("# empty\n\n");
+  });
+
+  it("preserves frontmatter in rendered output when H1 exists", () => {
+    const content = "---\ntitle: Test\ntags: [a, b]\n---\n\n# Test\n\nContent.";
+    const ctx = makeContext({ content, relativePath: "notes/test.md" });
+    const md = theme.render(ctx);
+    expect(md).toContain("---\ntitle: Test");
+    expect(md).toContain("# Test");
   });
 });

--- a/packages/crawlers/src/obsidian/crawler.ts
+++ b/packages/crawlers/src/obsidian/crawler.ts
@@ -220,13 +220,16 @@ export class ObsidianCrawler implements Crawler {
     const tags = this.extractTags(frontmatter, body);
     const imageRefs = this.extractImageRefs(content);
 
-    // Build attachments from image references
+    // Build attachments from image references and track resolved paths
     const attachments: CrawlerEntityData["attachments"] = [];
     const seenPaths = new Set<string>();
+    const imageRefMap: Record<string, string> = {};
 
     for (const ref of imageRefs) {
       const attFile = attachmentLookup.get(ref);
-      if (!attFile || seenPaths.has(attFile.relativePath)) continue;
+      if (!attFile) continue;
+      imageRefMap[ref] = attFile.relativePath;
+      if (seenPaths.has(attFile.relativePath)) continue;
       seenPaths.add(attFile.relativePath);
 
       const ext = extname(attFile.relativePath).toLowerCase();
@@ -262,6 +265,7 @@ export class ObsidianCrawler implements Crawler {
         content,
         frontmatter,
         relativePath: file.relativePath,
+        imageRefMap,
         mtime: file.mtime,
         size: file.size,
       },

--- a/packages/crawlers/src/obsidian/theme.ts
+++ b/packages/crawlers/src/obsidian/theme.ts
@@ -1,16 +1,103 @@
 import type { Theme, ThemeRenderContext } from "@frozenink/core/theme";
+import { wikilink, embed } from "@frozenink/core/theme";
+import { posix } from "path";
 
 export class ObsidianTheme implements Theme {
   crawlerType = "obsidian";
 
   render(context: ThemeRenderContext): string {
-    // Obsidian vault files are already markdown — pass through as-is
     const content = context.entity.data.content as string;
-    return content;
+    const sourcePath = this.getFilePath(context);
+    const imageRefMap = (context.entity.data.imageRefMap ?? {}) as Record<string, string>;
+
+    let result = content;
+
+    // Convert Obsidian image embeds: ![[path]] → standard markdown image
+    result = result.replace(/!\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g, (_match, ref: string) => {
+      const resolvedPath = imageRefMap[ref] ?? ref;
+      return embed(resolvedPath, sourcePath);
+    });
+
+    // Convert Obsidian wikilinks: [[target|label]] and [[target]]
+    // Uses resolveWikilink for stem matching (bare names like [[Topic]] that
+    // may refer to files in different folders).
+    result = result.replace(
+      /\[\[([^\]|]+)\|([^\]]+)\]\]/g,
+      (_match, target: string, label: string) => {
+        const resolved = this.resolveTarget(target, context);
+        if (resolved) return wikilink(resolved, label, sourcePath);
+        // Unresolved — keep as plain text with label
+        return label;
+      },
+    );
+    result = result.replace(
+      /\[\[([^\]]+)\]\]/g,
+      (_match, target: string) => {
+        // Strip section anchors for resolution but keep for display
+        const cleanTarget = target.replace(/[#^].*$/, "").trim();
+        const label = cleanTarget.includes("/") ? cleanTarget.split("/").pop()! : cleanTarget;
+        const resolved = this.resolveTarget(cleanTarget, context);
+        if (resolved) return wikilink(resolved, label, sourcePath);
+        // Unresolved — render as plain text
+        return label;
+      },
+    );
+
+    // Add H1 header from filename if content doesn't have one
+    result = this.ensureH1(result, sourcePath);
+
+    return result;
   }
 
   getFilePath(context: ThemeRenderContext): string {
     // Preserve the original vault-relative path
     return context.entity.data.relativePath as string;
+  }
+
+  /**
+   * Resolve an Obsidian wikilink target to a markdown path (without .md extension).
+   * Tries the context's resolveWikilink (stem matching) first, then falls back
+   * to lookupEntityPath with common externalId patterns.
+   */
+  private resolveTarget(target: string, context: ThemeRenderContext): string | undefined {
+    if (context.resolveWikilink) {
+      return context.resolveWikilink(target);
+    }
+    // Fallback: try lookupEntityPath with .md suffix
+    const withMd = target.endsWith(".md") ? target : `${target}.md`;
+    return context.lookupEntityPath?.(withMd);
+  }
+
+  /**
+   * If the markdown content has no H1 heading (after frontmatter), prepend one
+   * derived from the filename.
+   */
+  private ensureH1(content: string, sourcePath: string): string {
+    let body = content;
+    let frontmatterBlock = "";
+
+    // Extract frontmatter if present
+    if (body.startsWith("---")) {
+      const endIdx = body.indexOf("---", 3);
+      if (endIdx !== -1) {
+        frontmatterBlock = body.slice(0, endIdx + 3);
+        body = body.slice(endIdx + 3);
+      }
+    }
+
+    // Strip fenced code blocks to avoid false H1 matches
+    const stripped = body.replace(/^(`{3,}|~{3,}).*\n[\s\S]*?\n\1\s*$/gm, "");
+    const hasH1 = /^#\s+.+$/m.test(stripped);
+
+    if (hasH1) return content;
+
+    // Derive title from filename
+    const filename = posix.basename(sourcePath, ".md");
+    const title = `# ${filename}\n\n`;
+
+    if (frontmatterBlock) {
+      return `${frontmatterBlock}\n\n${title}${body.trimStart()}`;
+    }
+    return `${title}${body.trimStart()}`;
   }
 }

--- a/packages/crawlers/src/obsidian/theme.ts
+++ b/packages/crawlers/src/obsidian/theme.ts
@@ -1,6 +1,5 @@
 import type { Theme, ThemeRenderContext } from "@frozenink/core/theme";
-import { wikilink, embed } from "@frozenink/core/theme";
-import { posix } from "path";
+import { wikilink, embed, basename } from "@frozenink/core/theme";
 
 export class ObsidianTheme implements Theme {
   crawlerType = "obsidian";
@@ -92,7 +91,7 @@ export class ObsidianTheme implements Theme {
     if (hasH1) return content;
 
     // Derive title from filename
-    const filename = posix.basename(sourcePath, ".md");
+    const filename = basename(sourcePath, ".md");
     const title = `# ${filename}\n\n`;
 
     if (frontmatterBlock) {

--- a/packages/mcp/src/tools/get-attachment.ts
+++ b/packages/mcp/src/tools/get-attachment.ts
@@ -20,14 +20,19 @@ import {
 function extractReferencePath(reference: string): string {
   const raw = reference.trim();
 
+  // Obsidian-style: ![[path]] (backward compat)
   const wikiMatch = raw.match(/^!\[\[(.+?)\]\]$/);
   if (wikiMatch) {
     return wikiMatch[1].split("|")[0].trim();
   }
 
+  // Standard markdown: ![alt](path)
   const mdMatch = raw.match(/^!\[[^\]]*\]\((.+?)\)$/);
   if (mdMatch) {
-    return mdMatch[1].trim();
+    let path = mdMatch[1].trim();
+    // Strip relative attachment prefix (../../attachments/ or attachments/)
+    path = path.replace(/^(?:\.\.\/)*attachments\//, "");
+    return path;
   }
 
   return raw;
@@ -94,7 +99,7 @@ export function registerGetAttachment(
         collection: z.string().describe("Collection name"),
         reference: z
           .string()
-          .describe("Attachment reference from markdown, e.g. ![[git/abc/logo.png]] or assets/git/abc/logo.png"),
+          .describe("Attachment reference from markdown, e.g. ![logo](../../attachments/git/abc/logo.png) or assets/git/abc/logo.png"),
         externalId: z
           .string()
           .optional()

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -971,6 +971,7 @@ export default function App() {
             <MarkdownView
               content={fileContent}
               collection={selectedCollection || ""}
+              filePath={selectedFile || undefined}
               allFiles={allFiles}
               onWikilinkClick={handleWikilinkNavigate}
             />

--- a/packages/ui/src/__tests__/MarkdownView.test.tsx
+++ b/packages/ui/src/__tests__/MarkdownView.test.tsx
@@ -120,6 +120,84 @@ describe("MarkdownView", () => {
     expect(img).toHaveAttribute("src", "/api/attachments/my-repo/screenshot.png");
   });
 
+  it("renders standard internal links as clickable wikilinks", async () => {
+    const user = userEvent.setup();
+    const onWikilinkClick = vi.fn();
+    render(
+      <MarkdownView
+        content="See [#42](issues/42.md) for details."
+        collection="test"
+        allFiles={["issues/42.md"]}
+        onWikilinkClick={onWikilinkClick}
+      />,
+    );
+
+    const link = screen.getByText("#42");
+    expect(link).toBeInTheDocument();
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveClass("wikilink");
+
+    await user.click(link);
+    expect(onWikilinkClick).toHaveBeenCalledWith("issues/42", false);
+  });
+
+  it("renders standard attachment images via API", () => {
+    render(
+      <MarkdownView
+        content="![logo](../../attachments/git/abc/logo.png)"
+        collection="my-repo"
+        allFiles={[]}
+        onWikilinkClick={() => {}}
+      />,
+    );
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("src", "/api/attachments/my-repo/git/abc/logo.png");
+  });
+
+  it("resolves cross-directory relative links with filePath", async () => {
+    const user = userEvent.setup();
+    const onWikilinkClick = vi.fn();
+    render(
+      <MarkdownView
+        content="See [abc](../commits/abc.md) for the commit."
+        collection="test"
+        filePath="branches/main.md"
+        allFiles={["commits/abc.md"]}
+        onWikilinkClick={onWikilinkClick}
+      />,
+    );
+
+    const link = screen.getByText("abc");
+    expect(link).toBeInTheDocument();
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveClass("wikilink");
+
+    await user.click(link);
+    // Should resolve ../commits/abc to commits/abc (root-relative)
+    expect(onWikilinkClick).toHaveBeenCalledWith("commits/abc", false);
+  });
+
+  it("resolves same-directory relative links with filePath", async () => {
+    const user = userEvent.setup();
+    const onWikilinkClick = vi.fn();
+    render(
+      <MarkdownView
+        content="Related: [def](def.md)"
+        collection="test"
+        filePath="commits/abc.md"
+        allFiles={["commits/def.md"]}
+        onWikilinkClick={onWikilinkClick}
+      />,
+    );
+
+    const link = screen.getByText("def");
+    expect(link).toHaveClass("wikilink");
+
+    await user.click(link);
+    // Should resolve def → commits/def (root-relative)
+    expect(onWikilinkClick).toHaveBeenCalledWith("commits/def", false);
+  });
+
   it("renders external links with target blank", () => {
     render(
       <MarkdownView

--- a/packages/ui/src/components/MarkdownView.tsx
+++ b/packages/ui/src/components/MarkdownView.tsx
@@ -8,11 +8,24 @@ const WIKILINK_PREFIX = "#wikilink/";
 interface MarkdownViewProps {
   content: string;
   collection: string;
+  filePath?: string;
   allFiles: string[];
   onWikilinkClick: (target: string, openNewTab?: boolean) => void;
 }
 
-function preprocessMarkdown(raw: string, collection: string): string {
+/** Resolve a relative path against a source file path to get a root-relative path. */
+function resolveRelativePath(sourcePath: string, target: string): string {
+  const sourceDir = sourcePath.includes("/") ? sourcePath.slice(0, sourcePath.lastIndexOf("/")) : "";
+  const parts = (sourceDir ? `${sourceDir}/${target}` : target).split("/");
+  const resolved: string[] = [];
+  for (const p of parts) {
+    if (p === "..") resolved.pop();
+    else if (p !== "." && p !== "") resolved.push(p);
+  }
+  return resolved.join("/");
+}
+
+function preprocessMarkdown(raw: string, collection: string, filePath?: string): string {
   let content = raw;
 
   // Strip frontmatter
@@ -23,7 +36,8 @@ function preprocessMarkdown(raw: string, collection: string): string {
     }
   }
 
-  // Replace image embeds: ![[path]] → ![path](/api/attachments/collection/path)
+  // Replace Obsidian image embeds: ![[path]] → ![path](/api/attachments/collection/path)
+  // (backward compatibility for Obsidian vault content)
   content = content.replace(
     /!\[\[([^\]]+)\]\]/g,
     (_match, path: string) =>
@@ -38,9 +52,8 @@ function preprocessMarkdown(raw: string, collection: string): string {
       `![${alt}](/api/attachments/${encodeURIComponent(collection)}/${path})`,
   );
 
-  // Replace wikilinks: [[target|label]] → [label](#wikilink/encoded-target)
-  // and [[target]] → [target](#wikilink/encoded-target)
-  // encodeURIComponent ensures spaces and special chars survive the URL round-trip.
+  // Replace Obsidian wikilinks: [[target|label]] and [[target]]
+  // (backward compatibility for Obsidian vault content)
   content = content.replace(
     /\[\[([^\]|]+)\|([^\]]+)\]\]/g,
     (_match, target: string, label: string) =>
@@ -50,6 +63,20 @@ function preprocessMarkdown(raw: string, collection: string): string {
     /\[\[([^\]]+)\]\]/g,
     (_match, target: string) => {
       const label = target.includes("/") ? target.split("/").pop()! : target;
+      return `[${label}](${WIKILINK_PREFIX}${encodeURIComponent(target)})`;
+    },
+  );
+
+  // Rewrite standard internal links: [label](target.md) → [label](#wikilink/target)
+  // Resolves relative paths to root-relative targets for navigation.
+  // Excludes external URLs, anchors, and already-processed wikilinks.
+  content = content.replace(
+    /\[([^\]]+)\]\((?!https?:\/\/|mailto:|#)([^)]+)\.md(?:#[^)]*)?\)/g,
+    (_match, label: string, rawTarget: string) => {
+      let target = rawTarget;
+      if (filePath && (target.startsWith("../") || !target.includes("/"))) {
+        target = resolveRelativePath(filePath, target);
+      }
       return `[${label}](${WIKILINK_PREFIX}${encodeURIComponent(target)})`;
     },
   );
@@ -88,12 +115,13 @@ function resolveWikilink(target: string, allFiles: string[]): string | null {
 export default function MarkdownView({
   content,
   collection,
+  filePath,
   allFiles,
   onWikilinkClick,
 }: MarkdownViewProps) {
   const processed = useMemo(
-    () => preprocessMarkdown(content, collection),
-    [content, collection],
+    () => preprocessMarkdown(content, collection, filePath),
+    [content, collection, filePath],
   );
 
   const components: ComponentProps<typeof ReactMarkdown>["components"] = useMemo(


### PR DESCRIPTION
## Summary

- **Standard markdown links**: All internal links now use `[label](relative/path.md)` instead of `[[target|label]]`, with correct relative paths computed via `posix.relative()` between source and target files
- **Obsidian vault wikilink resolution**: Bare `[[Topic]]` references resolve via stem matching across the entire vault (finds `subfolder/Topic.md` from any folder), converted to proper relative paths
- **H1 header injection**: Obsidian notes without an `# H1` heading get one prepended from the filename (after frontmatter if present)
- **Image embed conversion**: `![[image.png]]` converted to `![image](../../attachments/resolved/path.png)` using `imageRefMap` for short-form resolution
- **Backward compatibility**: MarkdownView preprocessor still handles `[[]]` syntax from existing Obsidian vault content

### Key changes across 21 files

| Area | Change |
|------|--------|
| `core/theme/obsidian.ts` | `wikilink()` and `embed()` accept `sourcePath` for relative path computation |
| `core/theme/interface.ts` | Added `resolveWikilink` callback for stem matching |
| `core/crawler/sync-engine.ts` | `extractWikilinks()` resolves relative `.md` links; new `makeResolveWikilink()` with stem matching |
| `crawlers/obsidian/theme.ts` | Rewritten from passthrough to active conversion (wikilinks, embeds, H1 injection) |
| `crawlers/obsidian/crawler.ts` | Stores `imageRefMap` in entity data for image reference resolution |
| `crawlers/git,github,mantisbt` | All themes pass `sourcePath` to `wikilink()`/`embed()` for correct relative paths |
| `ui/MarkdownView.tsx` | New `filePath` prop enables relative path resolution in preprocessor |
| `cli/generate.ts` | Added `resolveWikilink` stem-matching support |

## Test plan

- [x] All 279 bun tests pass (includes 24 new tests for link resolution, stem matching, H1 injection, image embeds)
- [x] All 27 vitest UI tests pass (includes 4 new tests for relative path resolution in MarkdownView)
- [x] TypeScript typecheck passes
- [ ] Manual: verify links work in VS Code markdown preview
- [ ] Manual: verify links navigate correctly in web UI
- [ ] Manual: verify Obsidian vault sync produces standard markdown with working cross-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)