### PR TITLE
Show entity titles in file tree instead of slugified filenames

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -65,7 +65,11 @@ function getMimeType(filePath: string): string {
   return MIME_TYPES[ext] || "application/octet-stream";
 }
 
-function buildFileTree(dirPath: string, basePath: string = ""): object[] {
+function buildFileTree(
+  dirPath: string,
+  titleByPath: Map<string, string>,
+  basePath: string = "",
+): object[] {
   if (!existsSync(dirPath)) return [];
 
   const entries = readdirSync(dirPath, { withFileTypes: true });
@@ -79,14 +83,17 @@ function buildFileTree(dirPath: string, basePath: string = ""): object[] {
         name: entry.name,
         path: relativePath,
         type: "directory",
-        children: buildFileTree(join(dirPath, entry.name), relativePath),
+        children: buildFileTree(join(dirPath, entry.name), titleByPath, relativePath),
       });
     } else if (entry.name.endsWith(".md")) {
-      files.push({
+      const node: Record<string, unknown> = {
         name: entry.name,
         path: relativePath,
         type: "file",
-      });
+      };
+      const title = titleByPath.get(relativePath);
+      if (title) node.title = title;
+      files.push(node);
     }
   }
 
@@ -179,7 +186,27 @@ export function createApiServer(
         if (!col) return errorResponse("Collection not found", 404);
 
         const markdownDir = join(home, "collections", name, "markdown");
-        const tree = buildFileTree(markdownDir);
+
+        // Build a map from relative markdown path → entity title
+        const titleByPath = new Map<string, string>();
+        const dbPath = getCollectionDbPath(name);
+        if (existsSync(dbPath)) {
+          const colDb = getCollectionDb(dbPath);
+          const rows = colDb
+            .select({ markdownPath: entities.markdownPath, title: entities.title })
+            .from(entities)
+            .all();
+          const prefix = "markdown/";
+          for (const row of rows) {
+            if (!row.markdownPath || !row.title) continue;
+            const rel = row.markdownPath.startsWith(prefix)
+              ? row.markdownPath.slice(prefix.length)
+              : row.markdownPath;
+            titleByPath.set(rel, row.title);
+          }
+        }
+
+        const tree = buildFileTree(markdownDir, titleByPath);
         return jsonResponse(tree);
       }
 

--- a/packages/ui/src/components/FileTree.tsx
+++ b/packages/ui/src/components/FileTree.tsx
@@ -64,7 +64,7 @@ function TreeItem({ node, selectedFile, onSelect, depth }: TreeItemProps) {
         title={node.path}
       >
         <span className="tree-icon tree-file-icon">📄</span>
-        <span className="tree-name">{node.name.replace(/\.md$/, "")}</span>
+        <span className="tree-name">{node.title ?? node.name.replace(/\.md$/, "")}</span>
       </button>
     </li>
   );

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -12,6 +12,8 @@ export interface TreeNode {
   name: string;
   path: string;
   type: "file" | "directory";
+  /** Human-readable entity title; falls back to name (without .md) if absent */
+  title?: string;
   children?: TreeNode[];
 }
 

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -105,8 +105,25 @@ api.get("/api/collections/:name/tree", async (c) => {
   const listed = await c.env.BUCKET.list({ prefix });
   const paths = listed.objects.map((o) => o.key.slice(prefix.length)).filter((p) => p.endsWith(".md"));
 
+  // Fetch entity titles from D1 to display instead of raw filenames
+  const titleByPath = new Map<string, string>();
+  try {
+    const { results } = await c.env.DB.prepare(
+      "SELECT markdown_path, title FROM entities WHERE collection_name = ? AND markdown_path IS NOT NULL AND title IS NOT NULL",
+    ).bind(name).all<{ markdown_path: string; title: string }>();
+    const mdPrefix = "markdown/";
+    for (const row of results ?? []) {
+      const rel = row.markdown_path.startsWith(mdPrefix)
+        ? row.markdown_path.slice(mdPrefix.length)
+        : row.markdown_path;
+      titleByPath.set(rel, row.title);
+    }
+  } catch {
+    // If title lookup fails, fall back to filenames
+  }
+
   // Build tree from paths
-  const tree = buildTreeFromPaths(paths);
+  const tree = buildTreeFromPaths(paths, titleByPath);
   return c.json(tree);
 });
 
@@ -262,11 +279,12 @@ api.get("/api/attachments/:collection/*", async (c) => {
 });
 
 // Helper to build tree from flat file paths
-function buildTreeFromPaths(paths: string[]): object[] {
+function buildTreeFromPaths(paths: string[], titleByPath: Map<string, string> = new Map()): object[] {
   interface TreeNode {
     name: string;
     path: string;
     type: "directory" | "file";
+    title?: string;
     children?: TreeNode[];
   }
 
@@ -288,6 +306,10 @@ function buildTreeFromPaths(paths: string[]): object[] {
         const node: TreeNode = isFile
           ? { name: part, path: partialPath, type: "file" }
           : { name: part, path: partialPath, type: "directory", children: [] };
+        if (isFile) {
+          const title = titleByPath.get(partialPath);
+          if (title) node.title = title;
+        }
         current.push(node);
         if (!isFile) current = node.children!;
       }


### PR DESCRIPTION
## Summary

- Added `title?: string` to the `TreeNode` interface so file nodes can carry a human-readable label alongside their filesystem path
- The `/api/collections/:name/tree` endpoint (both local server and published worker) now queries the entity database for `(markdownPath, title)` pairs and attaches the title to each matching file node
- `FileTree.tsx` displays `node.title` when present, falling back to `node.name` (without `.md`) for nodes without a DB entry

## Why

The file tree was showing slugified filesystem names like `42-fix-login-bug` or `notes/daily-2024-01-15` instead of the stored entity title like "Fix login bug" or "Daily Notes". Entity titles are already stored correctly in the database by all crawlers (Obsidian uses H1 heading or filename-without-extension, GitHub uses issue/PR title, etc.) — this just wasn't surfaced in the tree view.

## Test plan

- [ ] Sync a GitHub collection and verify the file tree shows issue/PR titles instead of slug filenames
- [ ] Sync an Obsidian vault and verify note titles (H1 or filename) appear in the tree
- [ ] Verify that files without a DB entry (edge cases) still fall back gracefully to filename display
- [ ] Verify published worker tree also shows titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)