### PR TITLE
Optimize MCP tools for single vs multi-collection and expand test coverage

### DIFF
--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -141,6 +141,10 @@ async function setupClient(overrides?: Partial<McpServerOptions>) {
   await client.connect(clientTransport);
 }
 
+function parseResult(result: Awaited<ReturnType<typeof client.callTool>>) {
+  return JSON.parse((result.content as Array<{ text: string }>)[0].text);
+}
+
 beforeEach(() => {
   setupTestEnv();
 });
@@ -150,12 +154,16 @@ afterEach(() => {
   delete process.env.FROZENINK_HOME;
 });
 
+// ---------------------------------------------------------------------------
+// collection_list tool
+// ---------------------------------------------------------------------------
+
 describe("collection_list tool", () => {
   it("returns empty array when no collections configured", async () => {
     await setupClient();
 
     const result = await client.callTool({ name: "collection_list" });
-    const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    const data = parseResult(result);
 
     expect(data).toEqual([]);
   });
@@ -171,7 +179,7 @@ describe("collection_list tool", () => {
 
     await setupClient();
     const result = await client.callTool({ name: "collection_list" });
-    const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    const data = parseResult(result);
 
     expect(data).toHaveLength(1);
     expect(data[0].name).toBe("my-repo");
@@ -182,19 +190,50 @@ describe("collection_list tool", () => {
     expect(data[0].lastSyncStatus).toBe("completed");
   });
 
+  it("returns null lastSyncTime and lastSyncStatus when no sync runs", async () => {
+    addCollection("no-sync-col");
+
+    await setupClient();
+    const result = await client.callTool({ name: "collection_list" });
+    const data = parseResult(result);
+
+    expect(data).toHaveLength(1);
+    expect(data[0].lastSyncTime).toBeNull();
+    expect(data[0].lastSyncStatus).toBeNull();
+  });
+
+  it("lists disabled collections", async () => {
+    addCollection("active-col", { enabled: true });
+    addCollection("disabled-col", { enabled: false });
+
+    await setupClient();
+    const result = await client.callTool({ name: "collection_list" });
+    const data = parseResult(result);
+
+    expect(data).toHaveLength(2);
+    const disabled = data.find((c: { name: string }) => c.name === "disabled-col");
+    expect(disabled.enabled).toBe(false);
+  });
+
   it("respects allowedCollections filter", async () => {
     addCollection("allowed-col");
     addCollection("blocked-col");
 
-    await setupClient({ allowedCollections: ["allowed-col"] });
+    // Two entries keeps multi-collection mode active while still filtering.
+    // "nonexistent-col" is not configured so only "allowed-col" comes back.
+    await setupClient({ allowedCollections: ["allowed-col", "nonexistent-col"] });
 
     const result = await client.callTool({ name: "collection_list" });
-    const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    const data = parseResult(result);
 
     expect(data).toHaveLength(1);
     expect(data[0].name).toBe("allowed-col");
   });
 });
+
+// ---------------------------------------------------------------------------
+// entity_search tool
+// ---------------------------------------------------------------------------
 
 describe("entity_search tool", () => {
   it("returns matching results from FTS index", async () => {
@@ -213,7 +252,7 @@ describe("entity_search tool", () => {
 
     await setupClient();
     const result = await client.callTool({ name: "entity_search", arguments: { query: "authentication" } });
-    const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    const data = parseResult(result);
 
     expect(data).toHaveLength(1);
     expect(data[0].externalId).toBe("issue-42");
@@ -238,12 +277,116 @@ describe("entity_search tool", () => {
 
     await setupClient();
     const result = await client.callTool({ name: "entity_search", arguments: { query: "widget", collection: "repo-a" } });
-    const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    const data = parseResult(result);
 
     expect(data).toHaveLength(1);
     expect(data[0].collection).toBe("repo-a");
   });
+
+  it("returns results from multiple collections when no collection filter", async () => {
+    const { dbPath: dbPath1 } = addCollection("multi-a");
+    const { dbPath: dbPath2 } = addCollection("multi-b");
+
+    const id1 = addEntity(dbPath1, { externalId: "e-1", entityType: "issue", title: "Shared topic alpha", data: {} });
+    const id2 = addEntity(dbPath2, { externalId: "e-2", entityType: "issue", title: "Shared topic beta", data: {} });
+
+    const idx1 = new SearchIndexer(dbPath1);
+    idx1.updateIndex({ id: id1, externalId: "e-1", entityType: "issue", title: "Shared topic alpha", content: "shared content", tags: [] });
+    idx1.close();
+
+    const idx2 = new SearchIndexer(dbPath2);
+    idx2.updateIndex({ id: id2, externalId: "e-2", entityType: "issue", title: "Shared topic beta", content: "shared content", tags: [] });
+    idx2.close();
+
+    await setupClient();
+    const result = await client.callTool({ name: "entity_search", arguments: { query: "shared" } });
+    const data = parseResult(result);
+
+    expect(data.length).toBeGreaterThanOrEqual(2);
+    const collections = data.map((r: { collection: string }) => r.collection);
+    expect(collections).toContain("multi-a");
+    expect(collections).toContain("multi-b");
+  });
+
+  it("returns denied error when collection filter is disallowed", async () => {
+    addCollection("private-col");
+    addCollection("public-col");
+
+    // Two entries to stay in multi-collection mode.
+    await setupClient({ allowedCollections: ["public-col", "other-allowed"] });
+    const result = await client.callTool({
+      name: "entity_search",
+      arguments: { query: "anything", collection: "private-col" },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("not allowed");
+  });
+
+  it("filters by entityType", async () => {
+    const { dbPath } = addCollection("typed-col");
+
+    const issueId = addEntity(dbPath, { externalId: "issue-1", entityType: "issue", title: "Login bug", data: {} });
+    const prId = addEntity(dbPath, { externalId: "pr-1", entityType: "pull_request", title: "Login fix", data: {} });
+
+    const indexer = new SearchIndexer(dbPath);
+    indexer.updateIndex({ id: issueId, externalId: "issue-1", entityType: "issue", title: "Login bug", content: "login problem", tags: [] });
+    indexer.updateIndex({ id: prId, externalId: "pr-1", entityType: "pull_request", title: "Login fix", content: "login fix", tags: [] });
+    indexer.close();
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_search",
+      arguments: { query: "login", entityType: "issue" },
+    });
+    const data = parseResult(result);
+
+    expect(data.every((r: { entityType: string }) => r.entityType === "issue")).toBe(true);
+  });
+
+  it("respects limit parameter", async () => {
+    const { dbPath } = addCollection("limit-col");
+
+    const indexer = new SearchIndexer(dbPath);
+    for (let i = 1; i <= 10; i++) {
+      const id = addEntity(dbPath, { externalId: `issue-${i}`, entityType: "issue", title: `Pagination item ${i}`, data: {} });
+      indexer.updateIndex({ id, externalId: `issue-${i}`, entityType: "issue", title: `Pagination item ${i}`, content: "paginate results", tags: [] });
+    }
+    indexer.close();
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_search",
+      arguments: { query: "paginate", limit: 3 },
+    });
+    const data = parseResult(result);
+
+    expect(data).toHaveLength(3);
+  });
+
+  it("returns empty array when collection DB does not exist", async () => {
+    // Register collection in context but do not create the DB
+    coreAddCollection("ghost-col", {
+      crawler: "github",
+      config: { owner: "test", repo: "ghost-col" },
+      credentials: { token: "tok" },
+      enabled: true,
+    });
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_search",
+      arguments: { query: "anything", collection: "ghost-col" },
+    });
+    const data = parseResult(result);
+
+    expect(data).toEqual([]);
+  });
 });
+
+// ---------------------------------------------------------------------------
+// entity_get_data tool
+// ---------------------------------------------------------------------------
 
 describe("entity_get_data tool", () => {
   it("returns full entity data with tags", async () => {
@@ -260,7 +403,7 @@ describe("entity_get_data tool", () => {
 
     await setupClient();
     const result = await client.callTool({ name: "entity_get_data", arguments: { collection: "get-test", externalId: "issue-5" } });
-    const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    const data = parseResult(result);
 
     expect(data.externalId).toBe("issue-5");
     expect(data.entityType).toBe("issue");
@@ -269,6 +412,73 @@ describe("entity_get_data tool", () => {
     expect(data.data.state).toBe("open");
     expect(data.url).toBe("https://github.com/test/get-test/issues/5");
     expect(data.tags).toEqual(["bug", "critical"]);
+  });
+
+  it("includes markdown content when markdownPath exists on disk", async () => {
+    const { dbPath } = addCollection("with-md");
+    const collectionDir = join(TEST_DIR, "collections", "with-md");
+    const mdContent = "# Issue 7\n\nBody here.";
+    const mdPath = "markdown/issues/7-test.md";
+
+    mkdirSync(join(collectionDir, "markdown", "issues"), { recursive: true });
+    writeFileSync(join(collectionDir, mdPath), mdContent);
+
+    addEntity(dbPath, {
+      externalId: "issue-7",
+      entityType: "issue",
+      title: "Issue with markdown",
+      data: {},
+      markdownPath: mdPath,
+    });
+
+    await setupClient();
+    const result = await client.callTool({ name: "entity_get_data", arguments: { collection: "with-md", externalId: "issue-7" } });
+    const data = parseResult(result);
+
+    expect(data.markdown).toBe(mdContent);
+  });
+
+  it("returns null markdown when markdownPath is set but file is missing", async () => {
+    const { dbPath } = addCollection("missing-md");
+
+    addEntity(dbPath, {
+      externalId: "issue-8",
+      entityType: "issue",
+      title: "Issue missing markdown file",
+      data: {},
+      markdownPath: "markdown/issues/8-missing.md",
+    });
+
+    await setupClient();
+    const result = await client.callTool({ name: "entity_get_data", arguments: { collection: "missing-md", externalId: "issue-8" } });
+    const data = parseResult(result);
+
+    expect(data.externalId).toBe("issue-8");
+    expect(data.markdown).toBeNull();
+  });
+
+  it("returns error when entity is not found", async () => {
+    addCollection("empty-col");
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_data",
+      arguments: { collection: "empty-col", externalId: "nonexistent" },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("not found");
+  });
+
+  it("returns error when collection is not found", async () => {
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_data",
+      arguments: { collection: "does-not-exist", externalId: "issue-1" },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("not found");
   });
 
   it("denies access to disallowed collection", async () => {
@@ -280,16 +490,21 @@ describe("entity_get_data tool", () => {
       data: {},
     });
 
-    await setupClient({ allowedCollections: ["other-col"] });
+    // Two entries to stay in multi-collection mode.
+    await setupClient({ allowedCollections: ["other-col", "another-col"] });
     const result = await client.callTool({
       name: "entity_get_data",
       arguments: { collection: "private-col", externalId: "issue-1" },
     });
-    const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    const data = parseResult(result);
 
     expect(data.error).toContain("not allowed");
   });
 });
+
+// ---------------------------------------------------------------------------
+// entity_get_markdown tool
+// ---------------------------------------------------------------------------
 
 describe("entity_get_markdown tool", () => {
   it("returns rendered markdown when available", async () => {
@@ -305,11 +520,77 @@ describe("entity_get_markdown tool", () => {
 
     await setupClient();
     const result = await client.callTool({ name: "entity_get_markdown", arguments: { collection: "md-test", externalId: "issue-3" } });
-    const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    const data = parseResult(result);
 
     expect(data.markdown).toBe(mdContent);
   });
+
+  it("denies access to disallowed collection", async () => {
+    const { dbPath } = addCollection("locked-col");
+    addEntity(dbPath, { externalId: "issue-1", entityType: "issue", title: "Hidden", data: {}, markdownPath: "markdown/1.md" });
+
+    // Two entries to stay in multi-collection mode.
+    await setupClient({ allowedCollections: ["other-col", "another-col"] });
+    const result = await client.callTool({
+      name: "entity_get_markdown",
+      arguments: { collection: "locked-col", externalId: "issue-1" },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("not allowed");
+  });
+
+  it("returns error when entity is not found", async () => {
+    addCollection("md-empty");
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_markdown",
+      arguments: { collection: "md-empty", externalId: "nonexistent" },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("not found");
+  });
+
+  it("returns error when entity has no markdownPath", async () => {
+    const { dbPath } = addCollection("no-md-col");
+    addEntity(dbPath, { externalId: "issue-10", entityType: "issue", title: "No markdown", data: {} });
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_markdown",
+      arguments: { collection: "no-md-col", externalId: "issue-10" },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("no rendered markdown");
+  });
+
+  it("returns error when markdown file is missing on disk", async () => {
+    const { dbPath } = addCollection("ghost-md-col");
+    addEntity(dbPath, {
+      externalId: "issue-11",
+      entityType: "issue",
+      title: "Missing file",
+      data: {},
+      markdownPath: "markdown/issues/11-missing.md",
+    });
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_markdown",
+      arguments: { collection: "ghost-md-col", externalId: "issue-11" },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("not found");
+  });
 });
+
+// ---------------------------------------------------------------------------
+// entity_get_attachment tool
+// ---------------------------------------------------------------------------
 
 describe("entity_get_attachment tool", () => {
   it("returns base64 content for wiki-style reference", async () => {
@@ -335,14 +616,180 @@ describe("entity_get_attachment tool", () => {
       name: "entity_get_attachment",
       arguments: { collection: "attach-col", externalId: "commit-1", reference: "![[git/abc123/logo.png]]" },
     });
-    const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    const data = parseResult(result);
 
     expect(data.filename).toBe("logo.png");
     expect(data.mimeType).toBe("image/png");
     expect(data.resolvedStoragePath).toBe("attachments/git/abc123/logo.png");
     expect(data.contentBase64).toBe(Buffer.from("fake-png-bytes").toString("base64"));
   }, 15000);
+
+  it("resolves standard markdown image syntax", async () => {
+    const { dbPath } = addCollection("md-attach-col");
+    const entityId = addEntity(dbPath, {
+      externalId: "issue-20",
+      entityType: "issue",
+      title: "Issue with diagram",
+      data: {},
+      markdownPath: "markdown/issues/20.md",
+    });
+
+    addAttachment("md-attach-col", dbPath, {
+      entityId,
+      filename: "diagram.png",
+      mimeType: "image/png",
+      storagePath: "attachments/git/def456/diagram.png",
+      content: "fake-diagram-bytes",
+    });
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_attachment",
+      arguments: {
+        collection: "md-attach-col",
+        externalId: "issue-20",
+        reference: "![diagram](../../attachments/git/def456/diagram.png)",
+      },
+    });
+    const data = parseResult(result);
+
+    expect(data.filename).toBe("diagram.png");
+    expect(data.contentBase64).toBe(Buffer.from("fake-diagram-bytes").toString("base64"));
+  });
+
+  it("resolves attachment via externalId relative path", async () => {
+    const { dbPath } = addCollection("rel-attach-col");
+    const entityId = addEntity(dbPath, {
+      externalId: "commit-rel",
+      entityType: "commit",
+      title: "Commit with relative image",
+      data: {},
+      markdownPath: "markdown/commits/commit-rel.md",
+    });
+
+    addAttachment("rel-attach-col", dbPath, {
+      entityId,
+      filename: "screenshot.png",
+      mimeType: "image/png",
+      storagePath: "attachments/git/xyz/screenshot.png",
+      content: "screenshot-data",
+    });
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_attachment",
+      arguments: {
+        collection: "rel-attach-col",
+        externalId: "commit-rel",
+        reference: "screenshot.png",
+      },
+    });
+    const data = parseResult(result);
+
+    expect(data.filename).toBe("screenshot.png");
+    expect(data.sizeBytes).toBe(Buffer.from("screenshot-data").length);
+  });
+
+  it("denies access to disallowed collection", async () => {
+    addCollection("private-attach-col");
+
+    // Two entries to stay in multi-collection mode.
+    await setupClient({ allowedCollections: ["other-col", "another-col"] });
+    const result = await client.callTool({
+      name: "entity_get_attachment",
+      arguments: { collection: "private-attach-col", reference: "![[some/file.png]]" },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("not allowed");
+  });
+
+  it("returns error when entity externalId is not found", async () => {
+    addCollection("attach-missing-entity");
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_attachment",
+      arguments: {
+        collection: "attach-missing-entity",
+        externalId: "nonexistent",
+        reference: "![[some/file.png]]",
+      },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("not found");
+  });
+
+  it("returns error when attachment is not in DB", async () => {
+    const { dbPath } = addCollection("no-attach-col");
+    addEntity(dbPath, { externalId: "issue-30", entityType: "issue", title: "No attachment", data: {} });
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_attachment",
+      arguments: {
+        collection: "no-attach-col",
+        reference: "![[missing/file.png]]",
+      },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("Attachment not found");
+    expect(data.candidates).toBeDefined();
+  });
+
+  it("returns error when attachment file is in DB but missing on disk", async () => {
+    const { dbPath } = addCollection("disk-missing-col");
+    const entityId = addEntity(dbPath, {
+      externalId: "commit-2",
+      entityType: "commit",
+      title: "Commit missing file",
+      data: {},
+    });
+
+    // Insert DB record but do NOT write the file to disk
+    const colDb = getCollectionDb(dbPath);
+    colDb.insert(assets).values({
+      entityId,
+      filename: "ghost.png",
+      mimeType: "image/png",
+      storagePath: "attachments/git/zzz/ghost.png",
+    }).run();
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_attachment",
+      arguments: {
+        collection: "disk-missing-col",
+        reference: "![[git/zzz/ghost.png]]",
+      },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("not found on disk");
+  });
+
+  it("rejects HTTP reference as not a local path", async () => {
+    addCollection("http-ref-col");
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_attachment",
+      arguments: {
+        collection: "http-ref-col",
+        reference: "![image](https://example.com/image.png)",
+      },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("not a local attachment path");
+  });
 });
+
+// ---------------------------------------------------------------------------
+// MCP resources
+// ---------------------------------------------------------------------------
 
 describe("MCP resources", () => {
   it("lists all resources including collections", async () => {
@@ -411,11 +858,350 @@ describe("MCP resources", () => {
     addCollection("allow-one");
     addCollection("allow-two");
 
-    await setupClient({ allowedCollections: ["allow-one"] });
+    // Two entries to stay in multi-collection mode while still filtering.
+    await setupClient({ allowedCollections: ["allow-one", "nonexistent-col"] });
     const result = await client.readResource({ uri: "frozenink://collections" });
     const data = JSON.parse(result.contents[0].text as string);
 
     expect(data).toHaveLength(1);
     expect(data[0].name).toBe("allow-one");
+  });
+
+  it("returns error for entity resource with non-existent entity", async () => {
+    addCollection("ent-missing-col");
+
+    await setupClient();
+    const result = await client.readResource({ uri: "frozenink://entities/ent-missing-col/nonexistent-id" });
+
+    const data = JSON.parse(result.contents[0].text as string);
+    expect(data.error).toContain("not found");
+  });
+
+  it("returns error for entity resource with disallowed collection", async () => {
+    addCollection("blocked-ent-col");
+
+    await setupClient({ allowedCollections: ["other-col"] });
+    const result = await client.readResource({ uri: "frozenink://entities/blocked-ent-col/issue-1" });
+
+    const data = JSON.parse(result.contents[0].text as string);
+    expect(data.error).toContain("not allowed");
+  });
+
+  it("returns error for markdown resource when file is missing", async () => {
+    addCollection("md-missing-res-col");
+
+    await setupClient();
+    const result = await client.readResource({ uri: "frozenink://markdown/md-missing-res-col/markdown/issues/99-missing.md" });
+
+    expect(result.contents[0].text).toContain("not found");
+  });
+
+  it("returns error for markdown resource with disallowed collection", async () => {
+    addCollection("blocked-md-col");
+
+    await setupClient({ allowedCollections: ["other-col"] });
+    const result = await client.readResource({ uri: "frozenink://markdown/blocked-md-col/markdown/issues/1.md" });
+
+    expect(result.contents[0].text).toContain("not allowed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single-collection mode
+// ---------------------------------------------------------------------------
+
+describe("single-collection mode (allowedCollections with one entry)", () => {
+  it("does not register collection_list tool", async () => {
+    addCollection("solo-col");
+
+    await setupClient({ allowedCollections: ["solo-col"] });
+    const tools = await client.listTools();
+    const names = tools.tools.map((t) => t.name);
+
+    expect(names).not.toContain("collection_list");
+  });
+
+  it("entity_search has no collection parameter in schema", async () => {
+    addCollection("solo-search");
+
+    await setupClient({ allowedCollections: ["solo-search"] });
+    const tools = await client.listTools();
+    const searchTool = tools.tools.find((t) => t.name === "entity_search");
+
+    expect(searchTool).toBeDefined();
+    expect(searchTool!.inputSchema.properties).not.toHaveProperty("collection");
+  });
+
+  it("entity_get_data has no collection parameter in schema", async () => {
+    addCollection("solo-get");
+
+    await setupClient({ allowedCollections: ["solo-get"] });
+    const tools = await client.listTools();
+    const tool = tools.tools.find((t) => t.name === "entity_get_data");
+
+    expect(tool).toBeDefined();
+    expect(tool!.inputSchema.properties).not.toHaveProperty("collection");
+  });
+
+  it("entity_get_markdown has no collection parameter in schema", async () => {
+    addCollection("solo-md-schema");
+
+    await setupClient({ allowedCollections: ["solo-md-schema"] });
+    const tools = await client.listTools();
+    const tool = tools.tools.find((t) => t.name === "entity_get_markdown");
+
+    expect(tool).toBeDefined();
+    expect(tool!.inputSchema.properties).not.toHaveProperty("collection");
+  });
+
+  it("entity_get_attachment has no collection parameter in schema", async () => {
+    addCollection("solo-attach-schema");
+
+    await setupClient({ allowedCollections: ["solo-attach-schema"] });
+    const tools = await client.listTools();
+    const tool = tools.tools.find((t) => t.name === "entity_get_attachment");
+
+    expect(tool).toBeDefined();
+    expect(tool!.inputSchema.properties).not.toHaveProperty("collection");
+  });
+
+  it("entity_search works without collection parameter", async () => {
+    const { dbPath } = addCollection("solo-search-col");
+
+    const id = addEntity(dbPath, {
+      externalId: "issue-solo",
+      entityType: "issue",
+      title: "Solo search result",
+      data: {},
+    });
+
+    const indexer = new SearchIndexer(dbPath);
+    indexer.updateIndex({ id, externalId: "issue-solo", entityType: "issue", title: "Solo search result", content: "solo content", tags: [] });
+    indexer.close();
+
+    await setupClient({ allowedCollections: ["solo-search-col"] });
+    const result = await client.callTool({
+      name: "entity_search",
+      arguments: { query: "solo" },
+    });
+    const data = parseResult(result);
+
+    expect(data).toHaveLength(1);
+    expect(data[0].externalId).toBe("issue-solo");
+    expect(data[0].collection).toBe("solo-search-col");
+  });
+
+  it("entity_get_data works without collection parameter", async () => {
+    const { dbPath } = addCollection("solo-get-col");
+    addEntity(dbPath, {
+      externalId: "issue-solo-get",
+      entityType: "issue",
+      title: "Solo entity",
+      data: { number: 1 },
+      tags: ["solo"],
+    });
+
+    await setupClient({ allowedCollections: ["solo-get-col"] });
+    const result = await client.callTool({
+      name: "entity_get_data",
+      arguments: { externalId: "issue-solo-get" },
+    });
+    const data = parseResult(result);
+
+    expect(data.externalId).toBe("issue-solo-get");
+    expect(data.title).toBe("Solo entity");
+    expect(data.tags).toEqual(["solo"]);
+  });
+
+  it("entity_get_markdown works without collection parameter", async () => {
+    const { dbPath } = addCollection("solo-md-col");
+    const collectionDir = join(TEST_DIR, "collections", "solo-md-col");
+    const mdContent = "# Solo Issue\n\nContent.";
+    const mdPath = "markdown/issues/solo.md";
+
+    mkdirSync(join(collectionDir, "markdown", "issues"), { recursive: true });
+    writeFileSync(join(collectionDir, mdPath), mdContent);
+
+    addEntity(dbPath, {
+      externalId: "issue-solo-md",
+      entityType: "issue",
+      title: "Solo markdown",
+      data: {},
+      markdownPath: mdPath,
+    });
+
+    await setupClient({ allowedCollections: ["solo-md-col"] });
+    const result = await client.callTool({
+      name: "entity_get_markdown",
+      arguments: { externalId: "issue-solo-md" },
+    });
+    const data = parseResult(result);
+
+    expect(data.markdown).toBe(mdContent);
+  });
+
+  it("entity_get_attachment works without collection parameter", async () => {
+    const { dbPath } = addCollection("solo-attach-col");
+    const entityId = addEntity(dbPath, {
+      externalId: "commit-solo",
+      entityType: "commit",
+      title: "Solo attachment",
+      data: {},
+    });
+
+    addAttachment("solo-attach-col", dbPath, {
+      entityId,
+      filename: "solo.png",
+      mimeType: "image/png",
+      storagePath: "attachments/git/solo/solo.png",
+      content: "solo-bytes",
+    });
+
+    await setupClient({ allowedCollections: ["solo-attach-col"] });
+    const result = await client.callTool({
+      name: "entity_get_attachment",
+      arguments: { reference: "![[git/solo/solo.png]]" },
+    });
+    const data = parseResult(result);
+
+    expect(data.filename).toBe("solo.png");
+    expect(data.contentBase64).toBe(Buffer.from("solo-bytes").toString("base64"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-collection mode: optional collection (search all when omitted)
+// ---------------------------------------------------------------------------
+
+describe("multi-collection mode: optional collection parameter", () => {
+  it("entity_get_data has optional collection in schema", async () => {
+    await setupClient();
+    const tools = await client.listTools();
+    const tool = tools.tools.find((t) => t.name === "entity_get_data");
+
+    expect(tool).toBeDefined();
+    expect(tool!.inputSchema.properties).toHaveProperty("collection");
+    // collection must not be in required list
+    const required: string[] = (tool!.inputSchema as any).required ?? [];
+    expect(required).not.toContain("collection");
+  });
+
+  it("entity_get_markdown has optional collection in schema", async () => {
+    await setupClient();
+    const tools = await client.listTools();
+    const tool = tools.tools.find((t) => t.name === "entity_get_markdown");
+
+    expect(tool).toBeDefined();
+    const required: string[] = (tool!.inputSchema as any).required ?? [];
+    expect(required).not.toContain("collection");
+  });
+
+  it("entity_get_attachment has optional collection in schema", async () => {
+    await setupClient();
+    const tools = await client.listTools();
+    const tool = tools.tools.find((t) => t.name === "entity_get_attachment");
+
+    expect(tool).toBeDefined();
+    const required: string[] = (tool!.inputSchema as any).required ?? [];
+    expect(required).not.toContain("collection");
+  });
+
+  it("entity_get_data finds entity across collections when collection is omitted", async () => {
+    const { dbPath: dbPath1 } = addCollection("multi-find-a");
+    const { dbPath: dbPath2 } = addCollection("multi-find-b");
+
+    addEntity(dbPath1, { externalId: "shared-issue", entityType: "issue", title: "In collection A", data: {} });
+    addEntity(dbPath2, { externalId: "other-issue", entityType: "issue", title: "In collection B", data: {} });
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_data",
+      arguments: { externalId: "shared-issue" },
+    });
+    const data = parseResult(result);
+
+    expect(data.externalId).toBe("shared-issue");
+    expect(data.collection).toBe("multi-find-a");
+    expect(data.title).toBe("In collection A");
+  });
+
+  it("entity_get_data returns error when entity not found in any collection", async () => {
+    addCollection("no-match-a");
+    addCollection("no-match-b");
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_data",
+      arguments: { externalId: "does-not-exist" },
+    });
+    const data = parseResult(result);
+
+    expect(data.error).toContain("not found");
+    expect(data.error).toContain("any collection");
+  });
+
+  it("entity_get_markdown finds entity across collections when collection is omitted", async () => {
+    const { dbPath: dbPath1 } = addCollection("md-multi-a");
+    const { dbPath: dbPath2 } = addCollection("md-multi-b");
+    const collectionDirB = join(TEST_DIR, "collections", "md-multi-b");
+    const mdContent = "# Found in B";
+    const mdPath = "markdown/issues/found-b.md";
+
+    // Entity only exists in collection B with markdown
+    addEntity(dbPath1, { externalId: "other-entity", entityType: "issue", title: "Other", data: {} });
+    mkdirSync(join(collectionDirB, "markdown", "issues"), { recursive: true });
+    writeFileSync(join(collectionDirB, mdPath), mdContent);
+    addEntity(dbPath2, { externalId: "cross-md-entity", entityType: "issue", title: "Found", data: {}, markdownPath: mdPath });
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_markdown",
+      arguments: { externalId: "cross-md-entity" },
+    });
+    const data = parseResult(result);
+
+    expect(data.markdown).toBe(mdContent);
+    expect(data.collection).toBe("md-multi-b");
+  });
+
+  it("entity_get_attachment finds attachment across collections when collection is omitted", async () => {
+    const { dbPath: dbPath1 } = addCollection("att-multi-a");
+    const { dbPath: dbPath2 } = addCollection("att-multi-b");
+
+    // Attachment only exists in collection B
+    addEntity(dbPath1, { externalId: "other-commit", entityType: "commit", title: "Other", data: {} });
+    const entityId = addEntity(dbPath2, { externalId: "cross-commit", entityType: "commit", title: "With attachment", data: {} });
+    addAttachment("att-multi-b", dbPath2, {
+      entityId,
+      filename: "cross.png",
+      mimeType: "image/png",
+      storagePath: "attachments/git/cross/cross.png",
+      content: "cross-bytes",
+    });
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_attachment",
+      arguments: { reference: "![[git/cross/cross.png]]" },
+    });
+    const data = parseResult(result);
+
+    expect(data.filename).toBe("cross.png");
+    expect(data.collection).toBe("att-multi-b");
+    expect(data.contentBase64).toBe(Buffer.from("cross-bytes").toString("base64"));
+  });
+
+  it("entity_get_data includes collection name in response", async () => {
+    const { dbPath } = addCollection("named-col");
+    addEntity(dbPath, { externalId: "issue-named", entityType: "issue", title: "Named", data: {} });
+
+    await setupClient();
+    const result = await client.callTool({
+      name: "entity_get_data",
+      arguments: { collection: "named-col", externalId: "issue-named" },
+    });
+    const data = parseResult(result);
+
+    expect(data.collection).toBe("named-col");
   });
 });

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -11,28 +11,49 @@ import { registerEntityResources } from "./resources/entity";
 export interface McpServerOptions {
   frozeninkHome: string;
   allowedCollections?: string[];
+  /**
+   * Automatically set by createMcpServer when allowedCollections has exactly
+   * one entry. When set, collection_list is omitted and entity tools drop the
+   * `collection` parameter (it is inferred from this value).
+   */
+  singleCollectionName?: string;
 }
 
 export function createMcpServer(options: McpServerOptions): McpServer {
+  // Derive single-collection mode: when exactly one collection is in scope the
+  // `collection` parameter on every entity tool is redundant, and listing
+  // collections provides no value.
+  const singleCollectionName =
+    options.allowedCollections?.length === 1
+      ? options.allowedCollections[0]
+      : undefined;
+
+  const effectiveOptions: McpServerOptions = { ...options, singleCollectionName };
+
   const server = new McpServer(
     {
       name: "frozenink",
       version: "0.1.0",
     },
     {
-      instructions:
-        "Frozen Ink MCP server. Provides collection and entity retrieval tools over synced collections for LLM clients.",
+      instructions: singleCollectionName
+        ? `Frozen Ink MCP server scoped to the "${singleCollectionName}" collection. Use the entity tools to search and retrieve content.`
+        : "Frozen Ink MCP server. Provides collection and entity retrieval tools over synced collections for LLM clients.",
     },
   );
 
-  registerListCollections(server, options);
-  registerSearch(server, options);
-  registerGetEntity(server, options);
-  registerGetMarkdown(server, options);
-  registerGetAttachment(server, options);
+  // collection_list is only useful when there are multiple collections.
+  if (!singleCollectionName) {
+    registerListCollections(server, effectiveOptions);
+  }
 
-  registerCollectionResources(server, options);
-  registerEntityResources(server, options);
+  registerSearch(server, effectiveOptions);
+  registerGetEntity(server, effectiveOptions);
+  registerGetMarkdown(server, effectiveOptions);
+  registerGetAttachment(server, effectiveOptions);
+
+  registerCollectionResources(server, effectiveOptions);
+  registerEntityResources(server, effectiveOptions);
 
   return server;
 }

--- a/packages/mcp/src/tools/get-attachment.ts
+++ b/packages/mcp/src/tools/get-attachment.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "fs";
 import { basename, join, posix } from "path";
 import {
   contextExists,
+  listCollections,
   getCollection,
   getCollectionDb,
   getCollectionDbPath,
@@ -14,8 +15,15 @@ import { and, eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
 import {
   buildCollectionDeniedError,
+  filterAllowedCollections,
   isCollectionAllowed,
 } from "../collection-scope";
+
+function textErr(message: string) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }],
+  };
+}
 
 function extractReferencePath(reference: string): string {
   const raw = reference.trim();
@@ -57,8 +65,15 @@ function normalizePath(p: string): string {
 function buildCandidates(refPath: string, markdownPath: string | null): string[] {
   const candidates = new Set<string>();
 
-  const clean = normalizePath(refPath);
-  if (!clean || clean.startsWith("http://") || clean.startsWith("https://") || clean.startsWith("data:")) {
+  // Check the raw path for external URLs before normalization, since
+  // posix.normalize collapses "https://" → "https:/" which bypasses string checks.
+  const trimmed = refPath.trim();
+  if (!trimmed || trimmed.startsWith("http://") || trimmed.startsWith("https://") || trimmed.startsWith("data:")) {
+    return [];
+  }
+
+  const clean = normalizePath(trimmed);
+  if (!clean) {
     return [];
   }
 
@@ -85,236 +100,202 @@ function buildCandidates(refPath: string, markdownPath: string | null): string[]
   return Array.from(candidates).filter((c) => !c.startsWith(".."));
 }
 
+/** Searches for an attachment within a single collection DB. Returns the row or undefined. */
+function findAttachmentInDb(
+  colDb: ReturnType<typeof getCollectionDb>,
+  candidates: string[],
+  extracted: string,
+  sourceEntityId: number | null,
+): { id: number; entityId: number; filename: string; mimeType: string; storagePath: string } | undefined {
+  for (const candidate of candidates) {
+    const rows = sourceEntityId
+      ? colDb
+          .select()
+          .from(assets)
+          .where(and(eq(assets.storagePath, candidate), eq(assets.entityId, sourceEntityId)))
+          .all()
+      : colDb.select().from(assets).where(eq(assets.storagePath, candidate)).all();
+
+    if (rows.length > 0) return rows[0];
+  }
+
+  // Fallback: match by filename alone
+  const fileName = basename(extracted);
+  const byFilename = sourceEntityId
+    ? colDb
+        .select()
+        .from(assets)
+        .where(and(eq(assets.filename, fileName), eq(assets.entityId, sourceEntityId)))
+        .all()
+    : colDb.select().from(assets).where(eq(assets.filename, fileName)).all();
+
+  return byFilename.length === 1 ? byFilename[0] : undefined;
+}
+
+async function handleGetAttachment(
+  collectionName: string | undefined,
+  reference: string,
+  externalId: string | undefined,
+  options: McpServerOptions,
+) {
+  if (!contextExists()) {
+    return textErr("Frozen Ink not initialized");
+  }
+
+  // Validate reference is local before any DB work.
+  const extracted = extractReferencePath(reference);
+  const candidates = buildCandidates(extracted, null); // no markdownPath yet — refined per collection below
+  if (candidates.length === 0) {
+    return textErr("Reference is not a local attachment path");
+  }
+
+  // Resolve which collections to search.
+  type ColRow = { name: string; dbPath: string };
+  let colRows: ColRow[];
+
+  if (collectionName) {
+    if (!isCollectionAllowed(options, collectionName)) {
+      return textErr(buildCollectionDeniedError(collectionName));
+    }
+    const col = getCollection(collectionName);
+    if (!col) return textErr(`Collection "${collectionName}" not found`);
+    const dbPath = getCollectionDbPath(collectionName);
+    if (!existsSync(dbPath)) return textErr("Collection database not found");
+    colRows = [{ name: collectionName, dbPath }];
+  } else {
+    colRows = filterAllowedCollections(options, listCollections())
+      .map((col) => ({ name: col.name, dbPath: getCollectionDbPath(col.name) }))
+      .filter((row) => existsSync(row.dbPath));
+  }
+
+  for (const { name: colName, dbPath } of colRows) {
+    const colDb = getCollectionDb(dbPath);
+
+    // Resolve source entity for relative-path candidate generation.
+    let sourceEntityId: number | null = null;
+    let sourceMarkdownPath: string | null = null;
+    if (externalId) {
+      const [sourceEntity] = colDb
+        .select()
+        .from(entities)
+        .where(eq(entities.externalId, externalId))
+        .all();
+
+      if (!sourceEntity) {
+        // Entity not found in this collection — skip when searching all,
+        // but surface the error when a specific collection was requested.
+        if (collectionName) {
+          return textErr(`Entity "${externalId}" not found in "${collectionName}"`);
+        }
+        continue;
+      }
+
+      sourceEntityId = sourceEntity.id;
+      sourceMarkdownPath = sourceEntity.markdownPath;
+    }
+
+    const effectiveCandidates = buildCandidates(extracted, sourceMarkdownPath);
+    const attachmentRow = findAttachmentInDb(colDb, effectiveCandidates, extracted, sourceEntityId);
+
+    if (!attachmentRow) continue;
+
+    const collectionDir = join(options.frozeninkHome, "collections", colName);
+    const fullPath = join(collectionDir, attachmentRow.storagePath);
+    const normalizedCollectionDir = join(collectionDir, "/");
+    if (!join(fullPath, "/").startsWith(normalizedCollectionDir)) {
+      return textErr("Resolved attachment path is outside collection directory");
+    }
+
+    if (!existsSync(fullPath)) {
+      return textErr(`Attachment file not found on disk: ${attachmentRow.storagePath}`);
+    }
+
+    const content = readFileSync(fullPath);
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            collection: colName,
+            reference,
+            resolvedStoragePath: attachmentRow.storagePath,
+            filename: attachmentRow.filename,
+            mimeType: attachmentRow.mimeType,
+            entityId: attachmentRow.entityId,
+            sizeBytes: content.length,
+            contentBase64: content.toString("base64"),
+          }),
+        },
+      ],
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          error: "Attachment not found for reference",
+          reference,
+          candidates,
+        }),
+      },
+    ],
+  };
+}
+
 export function registerGetAttachment(
   server: McpServer,
   options: McpServerOptions,
 ): void {
-  server.registerTool(
-    "entity_get_attachment",
-    {
-      title: "Get Entity Attachment",
-      description:
-        "Returns base64 encoded attachment content from a markdown reference",
-      inputSchema: {
-        collection: z.string().describe("Collection name"),
-        reference: z
-          .string()
-          .describe("Attachment reference from markdown, e.g. ![logo](../../attachments/git/abc/logo.png) or assets/git/abc/logo.png"),
-        externalId: z
-          .string()
-          .optional()
-          .describe("Optional entity external ID for resolving relative references"),
+  const { singleCollectionName } = options;
+
+  if (singleCollectionName) {
+    server.registerTool(
+      "entity_get_attachment",
+      {
+        title: "Get Entity Attachment",
+        description:
+          "Returns base64 encoded attachment content from a markdown reference",
+        inputSchema: {
+          reference: z
+            .string()
+            .describe("Attachment reference from markdown, e.g. ![logo](../../attachments/git/abc/logo.png) or assets/git/abc/logo.png"),
+          externalId: z
+            .string()
+            .optional()
+            .describe("Optional entity external ID for resolving relative references"),
+        },
+        annotations: { readOnlyHint: true },
       },
-      annotations: { readOnlyHint: true },
-    },
-    async (args) => {
-      if (!contextExists()) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
-            },
-          ],
-        };
-      }
-
-      if (!isCollectionAllowed(options, args.collection)) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: buildCollectionDeniedError(args.collection),
-              }),
-            },
-          ],
-        };
-      }
-
-      const col = getCollection(args.collection);
-      if (!col) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: `Collection "${args.collection}" not found`,
-              }),
-            },
-          ],
-        };
-      }
-
-      const dbPath = getCollectionDbPath(args.collection);
-      if (!existsSync(dbPath)) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ error: "Collection database not found" }),
-            },
-          ],
-        };
-      }
-
-      const colDb = getCollectionDb(dbPath);
-
-      let sourceEntityId: number | null = null;
-      let sourceMarkdownPath: string | null = null;
-      if (args.externalId) {
-        const [sourceEntity] = colDb
-          .select()
-          .from(entities)
-          .where(eq(entities.externalId, args.externalId))
-          .all();
-
-        if (!sourceEntity) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: JSON.stringify({
-                  error: `Entity "${args.externalId}" not found in "${args.collection}"`,
-                }),
-              },
-            ],
-          };
-        }
-
-        sourceEntityId = sourceEntity.id;
-        sourceMarkdownPath = sourceEntity.markdownPath;
-      }
-
-      const extracted = extractReferencePath(args.reference);
-      const candidates = buildCandidates(extracted, sourceMarkdownPath);
-      if (candidates.length === 0) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: "Reference is not a local attachment path",
-              }),
-            },
-          ],
-        };
-      }
-
-      let attachmentRow:
-        | {
-            id: number;
-            entityId: number;
-            filename: string;
-            mimeType: string;
-            storagePath: string;
-          }
-        | undefined;
-
-      for (const candidate of candidates) {
-        const rows = sourceEntityId
-          ? colDb
-            .select()
-            .from(assets)
-            .where(
-              and(
-                eq(assets.storagePath, candidate),
-                eq(assets.entityId, sourceEntityId),
-              ),
-            )
-            .all()
-          : colDb
-            .select()
-            .from(assets)
-            .where(eq(assets.storagePath, candidate))
-            .all();
-
-        if (rows.length > 0) {
-          attachmentRow = rows[0];
-          break;
-        }
-      }
-
-      if (!attachmentRow) {
-        const fileName = basename(extracted);
-        const byFilename = sourceEntityId
-          ? colDb
-            .select()
-            .from(assets)
-            .where(and(eq(assets.filename, fileName), eq(assets.entityId, sourceEntityId)))
-            .all()
-          : colDb
-            .select()
-            .from(assets)
-            .where(eq(assets.filename, fileName))
-            .all();
-
-        if (byFilename.length === 1) {
-          attachmentRow = byFilename[0];
-        }
-      }
-
-      if (!attachmentRow) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: "Attachment not found for reference",
-                reference: args.reference,
-                candidates,
-              }),
-            },
-          ],
-        };
-      }
-
-      const collectionDir = join(options.frozeninkHome, "collections", args.collection);
-      const fullPath = join(collectionDir, attachmentRow.storagePath);
-      const normalizedCollectionDir = join(collectionDir, "/");
-      if (!join(fullPath, "/").startsWith(normalizedCollectionDir)) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ error: "Resolved attachment path is outside collection directory" }),
-            },
-          ],
-        };
-      }
-
-      if (!existsSync(fullPath)) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: `Attachment file not found on disk: ${attachmentRow.storagePath}`,
-              }),
-            },
-          ],
-        };
-      }
-
-      const content = readFileSync(fullPath);
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({
-              collection: args.collection,
-              reference: args.reference,
-              resolvedStoragePath: attachmentRow.storagePath,
-              filename: attachmentRow.filename,
-              mimeType: attachmentRow.mimeType,
-              entityId: attachmentRow.entityId,
-              sizeBytes: content.length,
-              contentBase64: content.toString("base64"),
-            }),
-          },
-        ],
-      };
-    },
-  );
+      async (args) =>
+        handleGetAttachment(singleCollectionName, args.reference, args.externalId, options),
+    );
+  } else {
+    server.registerTool(
+      "entity_get_attachment",
+      {
+        title: "Get Entity Attachment",
+        description:
+          "Returns base64 encoded attachment content from a markdown reference. When collection is omitted all allowed collections are searched.",
+        inputSchema: {
+          reference: z
+            .string()
+            .describe("Attachment reference from markdown, e.g. ![logo](../../attachments/git/abc/logo.png) or assets/git/abc/logo.png"),
+          collection: z
+            .string()
+            .optional()
+            .describe("Collection to search in. Omit to search all allowed collections."),
+          externalId: z
+            .string()
+            .optional()
+            .describe("Optional entity external ID for resolving relative references"),
+        },
+        annotations: { readOnlyHint: true },
+      },
+      async (args) =>
+        handleGetAttachment(args.collection, args.reference, args.externalId, options),
+    );
+  }
 }

--- a/packages/mcp/src/tools/get-entity.ts
+++ b/packages/mcp/src/tools/get-entity.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import {
   contextExists,
+  listCollections,
   getCollection,
   getCollectionDb,
   getCollectionDbPath,
@@ -15,133 +16,133 @@ import { eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
 import {
   buildCollectionDeniedError,
+  filterAllowedCollections,
   isCollectionAllowed,
 } from "../collection-scope";
+
+function textErr(message: string) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }],
+  };
+}
+
+async function handleGetEntity(
+  collectionName: string | undefined,
+  externalId: string,
+  options: McpServerOptions,
+) {
+  if (!contextExists()) {
+    return textErr("Frozen Ink not initialized");
+  }
+
+  // Resolve which collections to search.
+  type ColRow = { name: string; dbPath: string };
+  let colRows: ColRow[];
+
+  if (collectionName) {
+    if (!isCollectionAllowed(options, collectionName)) {
+      return textErr(buildCollectionDeniedError(collectionName));
+    }
+    const col = getCollection(collectionName);
+    if (!col) return textErr(`Collection "${collectionName}" not found`);
+    const dbPath = getCollectionDbPath(collectionName);
+    if (!existsSync(dbPath)) return textErr("Collection database not found");
+    colRows = [{ name: collectionName, dbPath }];
+  } else {
+    colRows = filterAllowedCollections(options, listCollections())
+      .map((col) => ({ name: col.name, dbPath: getCollectionDbPath(col.name) }))
+      .filter((row) => existsSync(row.dbPath));
+  }
+
+  for (const { name: colName, dbPath } of colRows) {
+    const colDb = getCollectionDb(dbPath);
+    const [entity] = colDb
+      .select()
+      .from(entities)
+      .where(eq(entities.externalId, externalId))
+      .all();
+
+    if (!entity) continue;
+
+    const entityTagRows = colDb
+      .select({ name: tags.name })
+      .from(entityTags)
+      .innerJoin(tags, eq(entityTags.tagId, tags.id))
+      .where(eq(entityTags.entityId, entity.id))
+      .all()
+      .map((t: any) => t.name);
+
+    let markdown: string | null = null;
+    if (entity.markdownPath) {
+      const mdPath = join(options.frozeninkHome, "collections", colName, entity.markdownPath);
+      if (existsSync(mdPath)) {
+        markdown = readFileSync(mdPath, "utf-8");
+      }
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            id: entity.id,
+            externalId: entity.externalId,
+            collection: colName,
+            entityType: entity.entityType,
+            title: entity.title,
+            data: entity.data,
+            url: entity.url,
+            tags: entityTagRows,
+            markdown,
+            createdAt: entity.createdAt,
+            updatedAt: entity.updatedAt,
+          }),
+        },
+      ],
+    };
+  }
+
+  const scope = collectionName ? `"${collectionName}"` : "any collection";
+  return textErr(`Entity "${externalId}" not found in ${scope}`);
+}
 
 export function registerGetEntity(
   server: McpServer,
   options: McpServerOptions,
 ): void {
-  server.registerTool(
-    "entity_get_data",
-    {
-      title: "Get Entity",
-      description:
-        "Returns full entity data and rendered markdown by collection name and external ID",
-      inputSchema: {
-        collection: z.string().describe("Collection name"),
-        externalId: z.string().describe("External ID of the entity"),
+  const { singleCollectionName } = options;
+
+  if (singleCollectionName) {
+    server.registerTool(
+      "entity_get_data",
+      {
+        title: "Get Entity",
+        description:
+          "Returns full entity data and rendered markdown by external ID",
+        inputSchema: {
+          externalId: z.string().describe("External ID of the entity"),
+        },
+        annotations: { readOnlyHint: true },
       },
-      annotations: { readOnlyHint: true },
-    },
-    async (args) => {
-      if (!contextExists()) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
-            },
-          ],
-        };
-      }
-
-      if (!isCollectionAllowed(options, args.collection)) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: buildCollectionDeniedError(args.collection),
-              }),
-            },
-          ],
-        };
-      }
-
-      const col = getCollection(args.collection);
-      if (!col) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: `Collection "${args.collection}" not found`,
-              }),
-            },
-          ],
-        };
-      }
-
-      const dbPath = getCollectionDbPath(args.collection);
-      if (!existsSync(dbPath)) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ error: "Collection database not found" }),
-            },
-          ],
-        };
-      }
-
-      const colDb = getCollectionDb(dbPath);
-      const [entity] = colDb
-        .select()
-        .from(entities)
-        .where(eq(entities.externalId, args.externalId))
-        .all();
-
-      if (!entity) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: `Entity "${args.externalId}" not found in "${args.collection}"`,
-              }),
-            },
-          ],
-        };
-      }
-
-      const entityTagRows = colDb
-        .select({ name: tags.name })
-        .from(entityTags)
-        .innerJoin(tags, eq(entityTags.tagId, tags.id))
-        .where(eq(entityTags.entityId, entity.id))
-        .all()
-        .map((t: any) => t.name);
-
-      let markdown: string | null = null;
-      if (entity.markdownPath) {
-        const collectionDir = join(
-          options.frozeninkHome,
-          "collections",
-          args.collection,
-        );
-        const mdPath = join(collectionDir, entity.markdownPath);
-        if (existsSync(mdPath)) {
-          markdown = readFileSync(mdPath, "utf-8");
-        }
-      }
-
-      const result = {
-        id: entity.id,
-        externalId: entity.externalId,
-        entityType: entity.entityType,
-        title: entity.title,
-        data: entity.data,
-        url: entity.url,
-        tags: entityTagRows,
-        markdown,
-        createdAt: entity.createdAt,
-        updatedAt: entity.updatedAt,
-      };
-
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(result) }],
-      };
-    },
-  );
+      async (args) => handleGetEntity(singleCollectionName, args.externalId, options),
+    );
+  } else {
+    server.registerTool(
+      "entity_get_data",
+      {
+        title: "Get Entity",
+        description:
+          "Returns full entity data and rendered markdown by external ID. When collection is omitted all allowed collections are searched.",
+        inputSchema: {
+          externalId: z.string().describe("External ID of the entity"),
+          collection: z
+            .string()
+            .optional()
+            .describe("Collection to search in. Omit to search all allowed collections."),
+        },
+        annotations: { readOnlyHint: true },
+      },
+      async (args) => handleGetEntity(args.collection, args.externalId, options),
+    );
+  }
 }

--- a/packages/mcp/src/tools/get-markdown.ts
+++ b/packages/mcp/src/tools/get-markdown.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import {
   contextExists,
+  listCollections,
   getCollection,
   getCollectionDb,
   getCollectionDbPath,
@@ -13,142 +14,125 @@ import { eq } from "drizzle-orm";
 import type { McpServerOptions } from "../server";
 import {
   buildCollectionDeniedError,
+  filterAllowedCollections,
   isCollectionAllowed,
 } from "../collection-scope";
+
+function textErr(message: string) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }],
+  };
+}
+
+async function handleGetMarkdown(
+  collectionName: string | undefined,
+  externalId: string,
+  options: McpServerOptions,
+) {
+  if (!contextExists()) {
+    return textErr("Frozen Ink not initialized");
+  }
+
+  // Resolve which collections to search.
+  type ColRow = { name: string; dbPath: string };
+  let colRows: ColRow[];
+
+  if (collectionName) {
+    if (!isCollectionAllowed(options, collectionName)) {
+      return textErr(buildCollectionDeniedError(collectionName));
+    }
+    const col = getCollection(collectionName);
+    if (!col) return textErr(`Collection "${collectionName}" not found`);
+    const dbPath = getCollectionDbPath(collectionName);
+    if (!existsSync(dbPath)) return textErr("Collection database not found");
+    colRows = [{ name: collectionName, dbPath }];
+  } else {
+    colRows = filterAllowedCollections(options, listCollections())
+      .map((col) => ({ name: col.name, dbPath: getCollectionDbPath(col.name) }))
+      .filter((row) => existsSync(row.dbPath));
+  }
+
+  for (const { name: colName, dbPath } of colRows) {
+    const colDb = getCollectionDb(dbPath);
+    const [entity] = colDb
+      .select()
+      .from(entities)
+      .where(eq(entities.externalId, externalId))
+      .all();
+
+    if (!entity) continue;
+
+    if (!entity.markdownPath) {
+      return textErr(`Entity "${externalId}" has no rendered markdown`);
+    }
+
+    const collectionDir = join(options.frozeninkHome, "collections", colName);
+    const markdownPath = join(collectionDir, entity.markdownPath);
+
+    if (!existsSync(markdownPath)) {
+      return textErr(`Markdown file not found: ${entity.markdownPath}`);
+    }
+
+    const markdown = readFileSync(markdownPath, "utf-8");
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            collection: colName,
+            externalId: entity.externalId,
+            title: entity.title,
+            markdownPath: entity.markdownPath,
+            markdown,
+            updatedAt: entity.updatedAt,
+          }),
+        },
+      ],
+    };
+  }
+
+  const scope = collectionName ? `"${collectionName}"` : "any collection";
+  return textErr(`Entity "${externalId}" not found in ${scope}`);
+}
 
 export function registerGetMarkdown(
   server: McpServer,
   options: McpServerOptions,
 ): void {
-  server.registerTool(
-    "entity_get_markdown",
-    {
-      title: "Get Entity Markdown",
-      description:
-        "Returns rendered markdown content for an entity by collection name and external ID",
-      inputSchema: {
-        collection: z.string().describe("Collection name"),
-        externalId: z.string().describe("External ID of the entity"),
+  const { singleCollectionName } = options;
+
+  if (singleCollectionName) {
+    server.registerTool(
+      "entity_get_markdown",
+      {
+        title: "Get Entity Markdown",
+        description:
+          "Returns rendered markdown content for an entity by external ID",
+        inputSchema: {
+          externalId: z.string().describe("External ID of the entity"),
+        },
+        annotations: { readOnlyHint: true },
       },
-      annotations: { readOnlyHint: true },
-    },
-    async (args) => {
-      if (!contextExists()) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
-            },
-          ],
-        };
-      }
-
-      if (!isCollectionAllowed(options, args.collection)) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: buildCollectionDeniedError(args.collection),
-              }),
-            },
-          ],
-        };
-      }
-
-      const col = getCollection(args.collection);
-      if (!col) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: `Collection "${args.collection}" not found`,
-              }),
-            },
-          ],
-        };
-      }
-
-      const dbPath = getCollectionDbPath(args.collection);
-      if (!existsSync(dbPath)) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ error: "Collection database not found" }),
-            },
-          ],
-        };
-      }
-
-      const colDb = getCollectionDb(dbPath);
-      const [entity] = colDb
-        .select()
-        .from(entities)
-        .where(eq(entities.externalId, args.externalId))
-        .all();
-
-      if (!entity) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: `Entity "${args.externalId}" not found in "${args.collection}"`,
-              }),
-            },
-          ],
-        };
-      }
-
-      if (!entity.markdownPath) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: `Entity "${args.externalId}" has no rendered markdown`,
-              }),
-            },
-          ],
-        };
-      }
-
-      const collectionDir = join(options.frozeninkHome, "collections", args.collection);
-      const markdownPath = join(collectionDir, entity.markdownPath);
-
-      if (!existsSync(markdownPath)) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: `Markdown file not found: ${entity.markdownPath}`,
-              }),
-            },
-          ],
-        };
-      }
-
-      const markdown = readFileSync(markdownPath, "utf-8");
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({
-              collection: args.collection,
-              externalId: entity.externalId,
-              title: entity.title,
-              markdownPath: entity.markdownPath,
-              markdown,
-              updatedAt: entity.updatedAt,
-            }),
-          },
-        ],
-      };
-    },
-  );
+      async (args) => handleGetMarkdown(singleCollectionName, args.externalId, options),
+    );
+  } else {
+    server.registerTool(
+      "entity_get_markdown",
+      {
+        title: "Get Entity Markdown",
+        description:
+          "Returns rendered markdown content for an entity by external ID. When collection is omitted all allowed collections are searched.",
+        inputSchema: {
+          externalId: z.string().describe("External ID of the entity"),
+          collection: z
+            .string()
+            .optional()
+            .describe("Collection to search in. Omit to search all allowed collections."),
+        },
+        annotations: { readOnlyHint: true },
+      },
+      async (args) => handleGetMarkdown(args.collection, args.externalId, options),
+    );
+  }
 }

--- a/packages/mcp/src/tools/search.ts
+++ b/packages/mcp/src/tools/search.ts
@@ -16,96 +16,127 @@ import {
   isCollectionAllowed,
 } from "../collection-scope";
 
+async function runSearch(
+  options: McpServerOptions,
+  query: string,
+  collectionFilter: string | undefined,
+  entityType: string | undefined,
+  limit: number,
+) {
+  if (!contextExists()) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({ error: "Frozen Ink not initialized" }),
+        },
+      ],
+    };
+  }
+
+  if (collectionFilter && !isCollectionAllowed(options, collectionFilter)) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            error: buildCollectionDeniedError(collectionFilter),
+          }),
+        },
+      ],
+    };
+  }
+
+  const collectionRows = collectionFilter
+    ? (() => {
+        const col = getCollection(collectionFilter);
+        return col ? [col] : [];
+      })()
+    : filterAllowedCollections(options, listCollections());
+
+  const allResults: Array<SearchResult & { collection: string }> = [];
+
+  for (const col of collectionRows) {
+    const dbPath = getCollectionDbPath(col.name);
+    if (!existsSync(dbPath)) continue;
+
+    const indexer = new SearchIndexer(dbPath);
+    try {
+      const results = indexer.search(query, { entityType });
+      for (const r of results) {
+        allResults.push({ ...r, collection: col.name });
+      }
+    } finally {
+      indexer.close();
+    }
+  }
+
+  allResults.sort((a, b) => a.rank - b.rank);
+  const limited = allResults.slice(0, limit);
+
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(limited) }],
+  };
+}
+
 export function registerSearch(
   server: McpServer,
   options: McpServerOptions,
 ): void {
-  server.registerTool(
-    "entity_search",
-    {
-      title: "Search Entities",
-      description:
-        "Performs FTS5 full-text search across synced entities with optional collection, type, and tag filters",
-      inputSchema: {
-        query: z.string().describe("Full-text search query"),
-        collection: z
-          .string()
-          .optional()
-          .describe("Filter to a specific collection"),
-        entityType: z
-          .string()
-          .optional()
-          .describe("Filter by entity type (e.g., issue, pull_request)"),
-        limit: z
-          .number()
-          .int()
-          .positive()
-          .optional()
-          .default(20)
-          .describe("Maximum number of results"),
+  const { singleCollectionName } = options;
+
+  if (singleCollectionName) {
+    server.registerTool(
+      "entity_search",
+      {
+        title: "Search Entities",
+        description: `Performs FTS5 full-text search across synced entities`,
+        inputSchema: {
+          query: z.string().describe("Full-text search query"),
+          entityType: z
+            .string()
+            .optional()
+            .describe("Filter by entity type (e.g., issue, pull_request)"),
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .default(20)
+            .describe("Maximum number of results"),
+        },
+        annotations: { readOnlyHint: true },
       },
-      annotations: { readOnlyHint: true },
-    },
-    async (args) => {
-      if (!contextExists()) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ error: "Frozen Ink not initialized" }),
-            },
-          ],
-        };
-      }
-
-      const collectionRows = args.collection
-        ? (() => {
-            if (!isCollectionAllowed(options, args.collection)) {
-              return [];
-            }
-            const col = getCollection(args.collection);
-            return col ? [col] : [];
-          })()
-        : filterAllowedCollections(options, listCollections());
-
-      if (args.collection && !isCollectionAllowed(options, args.collection)) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: buildCollectionDeniedError(args.collection),
-              }),
-            },
-          ],
-        };
-      }
-
-      const allResults: Array<SearchResult & { collection: string }> = [];
-
-      for (const col of collectionRows) {
-        const dbPath = getCollectionDbPath(col.name);
-        if (!existsSync(dbPath)) continue;
-
-        const indexer = new SearchIndexer(dbPath);
-        try {
-          const results = indexer.search(args.query, {
-            entityType: args.entityType,
-          });
-          for (const r of results) {
-            allResults.push({ ...r, collection: col.name });
-          }
-        } finally {
-          indexer.close();
-        }
-      }
-
-      allResults.sort((a, b) => a.rank - b.rank);
-      const limited = allResults.slice(0, args.limit);
-
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(limited) }],
-      };
-    },
-  );
+      async (args) => runSearch(options, args.query, singleCollectionName, args.entityType, args.limit),
+    );
+  } else {
+    server.registerTool(
+      "entity_search",
+      {
+        title: "Search Entities",
+        description:
+          "Performs FTS5 full-text search across synced entities with optional collection, type, and tag filters",
+        inputSchema: {
+          query: z.string().describe("Full-text search query"),
+          collection: z
+            .string()
+            .optional()
+            .describe("Filter to a specific collection"),
+          entityType: z
+            .string()
+            .optional()
+            .describe("Filter by entity type (e.g., issue, pull_request)"),
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .default(20)
+            .describe("Maximum number of results"),
+        },
+        annotations: { readOnlyHint: true },
+      },
+      async (args) => runSearch(options, args.query, args.collection, args.entityType, args.limit),
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- **Single-collection mode** (when `allowedCollections` has exactly one entry): `collection_list` is not registered, and the `collection` parameter is dropped from all entity tool schemas — it's implicit and advertising it would confuse LLM clients
- **Multi-collection mode**: `collection` is now optional on `entity_get_data`, `entity_get_markdown`, and `entity_get_attachment`; when omitted all allowed collections are searched in order and the first match is returned (response always includes which collection matched)
- **Bug fix**: `get-attachment` had a path-traversal bypass where `posix.normalize` collapsed `https://` → `https:/` before the URL guard ran
- **Test coverage**: expanded from 16 → 58 tests covering error paths, access-control denial, entityType/limit filters, standard markdown image syntax, relative-path resolution, and the new single/multi-collection schema and behavior differences

## Test plan

- [x] `bun run ci` passes fully (lint, typecheck, 349 tests across core/crawlers/mcp/ui, UI build, worker build)
- [x] Single-collection mode: `collection_list` absent, entity tool schemas have no `collection` param
- [x] Multi-collection mode: `collection` optional, omitting it searches across all allowed collections
- [x] Access-control denial tested for every entity tool
- [x] All error/not-found paths tested for every tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)