### PR TITLE
Add codex-cli/chatgpt-desktop MCP options and alias handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,12 @@ Exposes 5 tools and 4 resources for AI assistants:
 # Link one collection
 fink mcp add --tool claude-code my-github
 
+# Link via Codex CLI (canonical name)
+fink mcp add --tool codex-cli my-github
+
+# Legacy Codex alias (still supported)
+fink mcp add --tool codex my-github
+
 # Link multiple collections (still one connection per collection)
 fink mcp add --tool claude-code my-github my-notes
 
@@ -346,7 +352,9 @@ Connection count semantics:
 
 TUI path: `fink` -> `Collections` -> select collection -> `[m]` MCP config.
 
+`--tool codex-cli` is the canonical Codex option; `--tool codex` remains a legacy alias.
 Codex MCP support is best-effort and available only when `codex mcp` CLI commands are detected.
+ChatGPT Desktop uses a remote MCP endpoint flow. `fink mcp add --tool chatgpt-desktop` returns setup guidance for published `/mcp` endpoints instead of writing local client config.
 
 ## Development
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -151,12 +151,18 @@ Published sites include:
 
 ## MCP Server
 
-Frozen Ink includes an MCP server for AI tools (Claude, etc.):
+Frozen Ink includes an MCP server for AI tools (Claude, Codex CLI, etc.):
 
 ```bash
 # Link one or more collections to Claude Code
 fink mcp add --tool claude-code my-repo
 fink mcp add --tool claude-code my-notes
+
+# Link to Codex CLI (canonical name)
+fink mcp add --tool codex-cli my-repo
+
+# Legacy alias (still supported)
+fink mcp add --tool codex my-repo
 
 # Or add both in one command
 fink mcp add --tool claude-code my-repo my-notes
@@ -183,7 +189,9 @@ Behavior notes:
 - One MCP connection is created per `(tool, collection)`:
   - Add `my-repo` then `my-notes` => 2 connections
   - Add `my-repo my-notes` together => also 2 connections
-- Codex tool support is best-effort and shown only when `codex mcp` commands are detected.
+- `--tool codex-cli` is the canonical Codex option; `--tool codex` remains a legacy alias.
+- Codex CLI support is best-effort and shown only when `codex mcp` commands are detected.
+- ChatGPT Desktop uses a remote MCP endpoint flow. `fink mcp add --tool chatgpt-desktop` returns setup guidance instead of writing local client config.
 
 TUI path: open `fink` -> `Collections` -> select a collection -> press `[m]` for MCP actions.
 

--- a/packages/cli/src/__tests__/mcp-command.test.ts
+++ b/packages/cli/src/__tests__/mcp-command.test.ts
@@ -90,4 +90,37 @@ describe("mcp command", () => {
 
     expect(listArg).toBe("claude-code");
   });
+
+  it("accepts codex-cli as the canonical Codex tool name", async () => {
+    const { addCollection } = await import("@frozenink/core");
+    addCollection("collection-a", { crawler: "github", config: {}, credentials: {} });
+
+    const { mcpCommand } = await import("../commands/mcp");
+    await mcpCommand.parseAsync([
+      "add",
+      "--tool",
+      "codex-cli",
+      "collection-a",
+    ], { from: "user" });
+
+    expect(addArgs).toEqual({
+      tool: "codex-cli",
+      collections: ["collection-a"],
+      description: undefined,
+    });
+  });
+
+  it("accepts chatgpt-desktop tool name", async () => {
+    const { mcpCommand } = await import("../commands/mcp");
+    await mcpCommand.parseAsync(["list", "--tool", "chatgpt-desktop"], { from: "user" });
+
+    expect(listArg).toBe("chatgpt-desktop");
+  });
+
+  it("normalizes legacy codex alias to codex-cli", async () => {
+    const { mcpCommand } = await import("../commands/mcp");
+    await mcpCommand.parseAsync(["list", "--tool", "codex"], { from: "user" });
+
+    expect(listArg).toBe("codex-cli");
+  });
 });

--- a/packages/cli/src/__tests__/mcp-tools.test.ts
+++ b/packages/cli/src/__tests__/mcp-tools.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { getConnectionName, getMcpServeCommandArgs } from "../mcp/tools";
+import {
+  MCP_TOOL_CANONICAL_NAMES,
+  MCP_TOOL_NAMES,
+  getConnectionName,
+  getMcpServeCommandArgs,
+  normalizeMcpToolName,
+} from "../mcp/tools";
 
 describe("MCP tool naming and command shape", () => {
   it("uses deterministic per-collection connection names", () => {
@@ -11,5 +17,21 @@ describe("MCP tool naming and command shape", () => {
     const args = getMcpServeCommandArgs("collection-a");
     expect(args).toEqual(["fink", "mcp", "serve", "--collection", "collection-a"]);
     expect(args.join(" ")).not.toContain("bun run");
+  });
+
+  it("exposes canonical tool names and legacy aliases", () => {
+    expect(MCP_TOOL_CANONICAL_NAMES).toEqual([
+      "claude-code",
+      "claude-desktop",
+      "codex-cli",
+      "chatgpt-desktop",
+      "anythingllm",
+    ]);
+    expect(MCP_TOOL_NAMES).toContain("codex");
+  });
+
+  it("normalizes legacy codex alias to codex-cli", () => {
+    expect(normalizeMcpToolName("codex")).toBe("codex-cli");
+    expect(normalizeMcpToolName("codex-cli")).toBe("codex-cli");
   });
 });

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -6,9 +6,10 @@ import {
 } from "@frozenink/core";
 import { startStdioServer } from "@frozenink/mcp";
 import {
-  MCP_TOOL_NAMES,
+  MCP_TOOL_CANONICAL_NAMES,
   isMcpToolName,
-  type McpToolName,
+  normalizeMcpToolName,
+  type McpToolCanonicalName,
 } from "../mcp/tools";
 import {
   addMcpConnections,
@@ -16,11 +17,15 @@ import {
   removeMcpConnections,
 } from "../mcp/manager";
 
-function parseTool(value: string): McpToolName {
-  if (!isMcpToolName(value)) {
-    throw new Error(`Unsupported MCP tool "${value}". Use one of: ${MCP_TOOL_NAMES.join(", ")}`);
+function parseTool(value: string): McpToolCanonicalName {
+  const normalized = value.trim().toLowerCase();
+  if (!isMcpToolName(normalized)) {
+    throw new Error(
+      `Unsupported MCP tool "${value}". Use one of: ${MCP_TOOL_CANONICAL_NAMES.join(", ")} ` +
+      "(legacy alias: codex -> codex-cli)",
+    );
   }
-  return value;
+  return normalizeMcpToolName(normalized);
 }
 
 function requireInitialized(): void {
@@ -32,6 +37,9 @@ function requireInitialized(): void {
 
 export const mcpCommand = new Command("mcp")
   .description("Manage MCP tool registrations and run collection-scoped MCP stdio server");
+
+const TOOL_HELP =
+  `${MCP_TOOL_CANONICAL_NAMES.join(", ")} (legacy alias: codex -> codex-cli)`;
 
 mcpCommand
   .command("serve")
@@ -58,21 +66,22 @@ mcpCommand
 mcpCommand
   .command("add")
   .description("Add MCP tool links for one or more collections")
-  .requiredOption("--tool <tool>", `Target MCP client tool (${MCP_TOOL_NAMES.join(", ")})`)
+  .requiredOption("--tool <tool>", `Target MCP client tool (${TOOL_HELP})`)
   .option("--description <text>", "Optional tool description to store on collection(s)")
   .argument("<collections...>", "Collection names")
   .action(async (collectionNames: string[], opts: { tool: string; description?: string }) => {
     requireInitialized();
+    const tool = parseTool(opts.tool);
 
     try {
       const results = await addMcpConnections({
-        tool: parseTool(opts.tool),
+        tool,
         collections: collectionNames,
         description: opts.description,
       });
 
       for (const row of results) {
-        console.log(`Linked ${row.collection} -> ${opts.tool} (${row.connectionName})`);
+        console.log(`Linked ${row.collection} -> ${tool} (${row.connectionName})`);
       }
       console.log(`Added ${results.length} MCP link(s).`);
     } catch (err) {
@@ -85,19 +94,20 @@ mcpCommand
 mcpCommand
   .command("remove")
   .description("Remove MCP tool links for one or more collections")
-  .requiredOption("--tool <tool>", `Target MCP client tool (${MCP_TOOL_NAMES.join(", ")})`)
+  .requiredOption("--tool <tool>", `Target MCP client tool (${TOOL_HELP})`)
   .argument("<collections...>", "Collection names")
   .action(async (collectionNames: string[], opts: { tool: string }) => {
     requireInitialized();
+    const tool = parseTool(opts.tool);
 
     try {
       const results = await removeMcpConnections({
-        tool: parseTool(opts.tool),
+        tool,
         collections: collectionNames,
       });
 
       for (const row of results) {
-        console.log(`Removed ${row.collection} from ${opts.tool} (${row.connectionName})`);
+        console.log(`Removed ${row.collection} from ${tool} (${row.connectionName})`);
       }
       console.log(`Removed ${results.length} MCP link(s).`);
     } catch (err) {
@@ -110,7 +120,7 @@ mcpCommand
 mcpCommand
   .command("list")
   .description("List MCP tool links by collection")
-  .option("--tool <tool>", `Filter by tool (${MCP_TOOL_NAMES.join(", ")})`)
+  .option("--tool <tool>", `Filter by tool (${TOOL_HELP})`)
   .action(async (opts: { tool?: string }) => {
     requireInitialized();
 

--- a/packages/cli/src/mcp/manager.ts
+++ b/packages/cli/src/mcp/manager.ts
@@ -8,11 +8,11 @@ import {
   getConnectionName,
   getMcpToolAdapter,
   listMcpToolAdapters,
-  type McpToolName,
+  type McpToolCanonicalName,
 } from "./tools";
 
 export interface AvailableToolInfo {
-  tool: McpToolName;
+  tool: McpToolCanonicalName;
   displayName: string;
   available: boolean;
   reason?: string;
@@ -37,7 +37,7 @@ export interface ToolCollectionLink {
 }
 
 export interface ToolLinkStatus {
-  tool: McpToolName;
+  tool: McpToolCanonicalName;
   displayName: string;
   available: boolean;
   reason?: string;
@@ -58,7 +58,7 @@ async function ensureFinkOnPath(): Promise<void> {
   }
 }
 
-async function ensureToolAvailable(tool: McpToolName): Promise<void> {
+async function ensureToolAvailable(tool: McpToolCanonicalName): Promise<void> {
   const adapter = getMcpToolAdapter(tool);
   const availability = await adapter.isAvailable();
   if (!availability.available) {
@@ -86,11 +86,14 @@ export async function listAvailableMcpTools(): Promise<AvailableToolInfo[]> {
 }
 
 export async function addMcpConnections(params: {
-  tool: McpToolName;
+  tool: McpToolCanonicalName;
   collections: string[];
   description?: string;
 }): Promise<AddMcpResult[]> {
-  await ensureFinkOnPath();
+  // Remote-only integrations (for example ChatGPT Desktop) don't spawn local stdio subprocesses.
+  if (params.tool !== "chatgpt-desktop") {
+    await ensureFinkOnPath();
+  }
   await ensureToolAvailable(params.tool);
 
   const adapter = getMcpToolAdapter(params.tool);
@@ -127,7 +130,7 @@ export async function addMcpConnections(params: {
 }
 
 export async function removeMcpConnections(params: {
-  tool: McpToolName;
+  tool: McpToolCanonicalName;
   collections: string[];
 }): Promise<RemoveMcpResult[]> {
   await ensureToolAvailable(params.tool);
@@ -149,7 +152,7 @@ export async function removeMcpConnections(params: {
   return results;
 }
 
-export async function listMcpConnections(tool?: McpToolName): Promise<ToolLinkStatus[]> {
+export async function listMcpConnections(tool?: McpToolCanonicalName): Promise<ToolLinkStatus[]> {
   const adapters = tool
     ? [getMcpToolAdapter(tool)]
     : listMcpToolAdapters();

--- a/packages/cli/src/mcp/tools/chatgpt-desktop.ts
+++ b/packages/cli/src/mcp/tools/chatgpt-desktop.ts
@@ -1,0 +1,36 @@
+import type { McpToolAdapter, ToolConnectionSpec } from "./types";
+
+function getChatGptRemediationMessage(): string {
+  return [
+    "ChatGPT Desktop does not currently expose a stable local MCP config file for `fink mcp add` integration.",
+    "Use Frozen Ink's remote MCP flow instead:",
+    "1) Publish collections: `fink publish <collections...> --name <name> --password <password>`",
+    "2) In ChatGPT, add the deployment MCP endpoint: `https://<name>.workers.dev/mcp`",
+    "3) Provide `Authorization: Bearer <password>` in the connector configuration.",
+  ].join(" ");
+}
+
+export const chatgptDesktopAdapter: McpToolAdapter = {
+  tool: "chatgpt-desktop",
+  displayName: "ChatGPT Desktop",
+
+  async isAvailable() {
+    return { available: true };
+  },
+
+  async addConnection(_spec: ToolConnectionSpec): Promise<void> {
+    throw new Error(getChatGptRemediationMessage());
+  },
+
+  async removeConnection(_connectionName: string): Promise<void> {
+    throw new Error(
+      "Local `fink mcp remove` is not supported for ChatGPT Desktop because links are managed in the ChatGPT app. " +
+      "Remove the remote MCP connector from ChatGPT settings directly.",
+    );
+  },
+
+  async listConnectionNames(): Promise<Set<string>> {
+    // ChatGPT Desktop MCP connectors are remote-managed; no local deterministic list is available.
+    return new Set();
+  },
+};

--- a/packages/cli/src/mcp/tools/codex.ts
+++ b/packages/cli/src/mcp/tools/codex.ts
@@ -62,8 +62,8 @@ async function ensureSuccess(args: string[], operation: string): Promise<void> {
 }
 
 export const codexAdapter: McpToolAdapter = {
-  tool: "codex",
-  displayName: "Codex",
+  tool: "codex-cli",
+  displayName: "Codex CLI",
 
   async isAvailable() {
     try {

--- a/packages/cli/src/mcp/tools/index.ts
+++ b/packages/cli/src/mcp/tools/index.ts
@@ -2,31 +2,45 @@ import { claudeCodeAdapter } from "./claude-code";
 import { claudeDesktopAdapter } from "./claude-desktop";
 import { codexAdapter } from "./codex";
 import { anythingllmAdapter } from "./anythingllm";
+import { chatgptDesktopAdapter } from "./chatgpt-desktop";
 import {
+  MCP_TOOL_ALIAS_MAP,
+  MCP_TOOL_CANONICAL_NAMES,
   MCP_TOOL_NAMES,
   type McpToolAdapter,
+  type McpToolAliasName,
+  type McpToolCanonicalName,
   type McpToolName,
 } from "./types";
 
 const adapterMap: Record<McpToolName, McpToolAdapter> = {
   "claude-code": claudeCodeAdapter,
   "claude-desktop": claudeDesktopAdapter,
-  codex: codexAdapter,
+  "codex-cli": codexAdapter,
+  "chatgpt-desktop": chatgptDesktopAdapter,
   anythingllm: anythingllmAdapter,
+  codex: codexAdapter,
 };
 
 export { MCP_TOOL_NAMES };
-export type { McpToolAdapter, McpToolName } from "./types";
+export { MCP_TOOL_CANONICAL_NAMES };
+export type { McpToolAdapter, McpToolCanonicalName, McpToolName } from "./types";
 export { getConnectionName, getMcpServeCommandArgs } from "./types";
 
 export function isMcpToolName(value: string): value is McpToolName {
   return MCP_TOOL_NAMES.includes(value as McpToolName);
 }
 
+export function normalizeMcpToolName(tool: McpToolName): McpToolCanonicalName {
+  return tool in MCP_TOOL_ALIAS_MAP
+    ? MCP_TOOL_ALIAS_MAP[tool as McpToolAliasName]
+    : (tool as McpToolCanonicalName);
+}
+
 export function getMcpToolAdapter(tool: McpToolName): McpToolAdapter {
-  return adapterMap[tool];
+  return adapterMap[normalizeMcpToolName(tool)];
 }
 
 export function listMcpToolAdapters(): McpToolAdapter[] {
-  return MCP_TOOL_NAMES.map((tool) => adapterMap[tool]);
+  return MCP_TOOL_CANONICAL_NAMES.map((tool) => adapterMap[tool]);
 }

--- a/packages/cli/src/mcp/tools/types.ts
+++ b/packages/cli/src/mcp/tools/types.ts
@@ -1,6 +1,27 @@
-export const MCP_TOOL_NAMES = ["claude-code", "claude-desktop", "codex", "anythingllm"] as const;
+export const MCP_TOOL_CANONICAL_NAMES = [
+  "claude-code",
+  "claude-desktop",
+  "codex-cli",
+  "chatgpt-desktop",
+  "anythingllm",
+] as const;
 
-export type McpToolName = (typeof MCP_TOOL_NAMES)[number];
+export const MCP_TOOL_ALIAS_MAP = {
+  codex: "codex-cli",
+} as const;
+
+export const MCP_TOOL_NAMES = [
+  "claude-code",
+  "claude-desktop",
+  "codex-cli",
+  "chatgpt-desktop",
+  "anythingllm",
+  "codex",
+] as const;
+
+export type McpToolCanonicalName = (typeof MCP_TOOL_CANONICAL_NAMES)[number];
+export type McpToolAliasName = keyof typeof MCP_TOOL_ALIAS_MAP;
+export type McpToolName = McpToolCanonicalName | McpToolAliasName;
 
 export interface ToolConnectionSpec {
   collection: string;
@@ -9,7 +30,7 @@ export interface ToolConnectionSpec {
 }
 
 export interface McpToolAdapter {
-  tool: McpToolName;
+  tool: McpToolCanonicalName;
   displayName: string;
   isAvailable(): Promise<{ available: boolean; reason?: string }>;
   addConnection(spec: ToolConnectionSpec): Promise<void>;

--- a/packages/cli/src/tui/components/McpConfigView.tsx
+++ b/packages/cli/src/tui/components/McpConfigView.tsx
@@ -8,7 +8,7 @@ import {
   removeMcpConnections,
   type AvailableToolInfo,
 } from "../../mcp/manager";
-import type { McpToolName } from "../../mcp/tools";
+import { normalizeMcpToolName, type McpToolName } from "../../mcp/tools";
 import { TextInput } from "./TextInput.js";
 
 type Mode = "menu" | "edit-description" | "busy";
@@ -46,7 +46,7 @@ export function McpConfigView({
       return;
     }
 
-    const statuses = await listMcpConnections(tool);
+    const statuses = await listMcpConnections(normalizeMcpToolName(tool));
     const row = statuses[0]?.links.find((link) => link.collection === collectionName);
     setLinked(!!row?.linked);
   }, [collectionName]);

--- a/packages/website/src/docs/anythingllm-mcp.ts
+++ b/packages/website/src/docs/anythingllm-mcp.ts
@@ -23,7 +23,7 @@ export const anythingllmMcpPage = renderDocsPage({
   </div>
 
   <h1 class="page-title">AnythingLLM MCP Setup</h1>
-  <p class="page-lead">AnythingLLM supports the Model Context Protocol natively. Once linked, any model you run in AnythingLLM can search and read your Frozen Ink collections — entirely on your machine, no cloud required.</p>
+  <p class="page-lead">AnythingLLM supports the Model Context Protocol natively. Once linked, any local model you run — Llama, Mistral, Qwen, Gemma, and more — can search and read your Frozen Ink collections instantly, with no rate limits and no data leaving your machine.</p>
 
   <h2 id="overview">Overview</h2>
   <p>AnythingLLM reads a JSON config file (<code>anythingllm_mcp_servers.json</code>) to discover which MCP servers to expose to models in its Agent mode. Frozen Ink writes entries directly into that file, so you don't need to edit it manually.</p>
@@ -32,12 +32,17 @@ export const anythingllmMcpPage = renderDocsPage({
     <div class="feature-card">
       <div class="feature-card-icon">🤖</div>
       <h4>Any local model</h4>
-      <p>Works with any model AnythingLLM supports — Ollama, LM Studio, local Llama, Mistral, Qwen, Gemma, and more. Your knowledge base is available regardless of which model is active.</p>
+      <p>Works with any model AnythingLLM supports — Ollama, LM Studio, Llama, Mistral, Qwen, Gemma, and more. Give your local model a rich, searchable knowledge base without a cloud subscription.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-icon">⚡</div>
+      <h4>Instant, unlimited queries</h4>
+      <p>stdio transport queries the local SQLite index with no HTTP overhead — responses land in milliseconds. No API rate limits, no per-query cost, no throttling regardless of how many tool calls the model makes.</p>
     </div>
     <div class="feature-card">
       <div class="feature-card-icon">🔒</div>
       <h4>Fully local</h4>
-      <p>AnythingLLM spawns <code>fink mcp serve</code> as a subprocess when a tool call is made. Everything stays on your machine — no network calls, no cloud.</p>
+      <p>AnythingLLM spawns <code>fink mcp serve</code> as a subprocess on demand. Model, data, and retrieval all stay on your machine — nothing touches the cloud.</p>
     </div>
   </div>
 
@@ -181,9 +186,9 @@ fink --version</code></pre>
   <pre><code>fink sync my-vault</code></pre>
 
   <div class="docs-pagination">
-    <a href="/docs/local-mcp" class="docs-pagination-card">
+    <a href="/docs/chatgpt-desktop" class="docs-pagination-card">
       <span class="docs-pagination-label">← Previous</span>
-      <span class="docs-pagination-title">Local MCP Setup</span>
+      <span class="docs-pagination-title">ChatGPT Desktop Integration</span>
     </a>
     <a href="/docs/publishing" class="docs-pagination-card next">
       <span class="docs-pagination-label">Next →</span>

--- a/packages/website/src/docs/chatgpt-desktop.ts
+++ b/packages/website/src/docs/chatgpt-desktop.ts
@@ -1,0 +1,267 @@
+import { renderDocsPage } from "./layout";
+
+export const chatgptDesktopPage = renderDocsPage({
+  title: "ChatGPT Desktop Integration",
+  description:
+    "Connect Frozen Ink to ChatGPT Desktop via a published cloud MCP endpoint so ChatGPT can search and read your knowledge base.",
+  activePath: "/docs/chatgpt-desktop",
+  tocLinks: [
+    { id: "overview", title: "Overview" },
+    { id: "how-it-works", title: "How it works" },
+    { id: "prerequisites", title: "Prerequisites" },
+    { id: "publish-collection", title: "Publish your collection" },
+    { id: "connect-in-chatgpt", title: "Connect in ChatGPT Desktop" },
+    { id: "authentication", title: "Authentication" },
+    { id: "available-tools", title: "Available MCP tools" },
+    { id: "multiple-collections", title: "Multiple collections" },
+    { id: "update-content", title: "Updating content" },
+    { id: "troubleshooting", title: "Troubleshooting" },
+  ],
+  content: `
+  <div class="docs-breadcrumb">
+    <a href="/docs">Docs</a>
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+    <span>ChatGPT Desktop Integration</span>
+  </div>
+
+  <h1 class="page-title">ChatGPT Desktop Integration</h1>
+  <p class="page-lead">ChatGPT Desktop connects to MCP servers over HTTP rather than stdio. To give ChatGPT access to your Frozen Ink collections, publish them to Cloudflare first, then add the published endpoint as an MCP connector in ChatGPT Desktop settings.</p>
+
+  <h2 id="overview">Overview</h2>
+  <p>Unlike Claude Code and Claude Desktop (which use stdio-based MCP), ChatGPT Desktop uses a remote HTTP connector flow. Frozen Ink's published Cloudflare deployment exposes an <code>/mcp</code> endpoint that ChatGPT Desktop can connect to directly.</p>
+
+  <div class="feature-grid">
+    <div class="feature-card">
+      <div class="feature-card-icon">☁️</div>
+      <h4>Cloud-based connection</h4>
+      <p>ChatGPT connects to your published Frozen Ink deployment on Cloudflare's edge. No local server needs to be running during ChatGPT sessions.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-icon">🔒</div>
+      <h4>Password protected</h4>
+      <p>Every request to the MCP endpoint is authenticated with the password you set when publishing. Unauthenticated requests are rejected.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-icon">🔍</div>
+      <h4>Full knowledge access</h4>
+      <p>A single endpoint gives ChatGPT access to all collections in the deployment — search across notes, issues, commits, and more in one conversation.</p>
+    </div>
+  </div>
+
+  <h2 id="how-it-works">How it works</h2>
+  <p>Publishing a collection to Cloudflare deploys a Frozen Ink Worker that exposes an MCP endpoint at <code>/mcp</code>. ChatGPT Desktop connects to this endpoint over HTTP + SSE and calls the same tools available to local MCP clients.</p>
+
+  <p>The flow is:</p>
+  <ol>
+    <li>You sync your collections locally with <code>fink sync</code></li>
+    <li>You publish to Cloudflare with <code>fink publish</code>, which uploads the data and deploys the Worker</li>
+    <li>You add the <code>/mcp</code> URL in ChatGPT Desktop as an MCP connector</li>
+    <li>ChatGPT calls tools against the cloud endpoint in any conversation</li>
+  </ol>
+
+  <div class="callout callout-info">
+    <div class="callout-icon">ℹ️</div>
+    <div class="callout-body">
+      <strong>Why no local stdio for ChatGPT Desktop?</strong>
+      <p>ChatGPT Desktop's MCP connector system uses HTTP-based remote connections and does not expose a stable local config file for stdio subprocess registration. The cloud MCP flow is the supported path for ChatGPT Desktop integration.</p>
+    </div>
+  </div>
+
+  <h2 id="prerequisites">Prerequisites</h2>
+  <ul>
+    <li><strong>Frozen Ink CLI installed</strong> — verify with <code>fink --version</code>. Install via <code>npm install -g @vboctor/fink</code>.</li>
+    <li><strong>Cloudflare account</strong> — free tier is sufficient. Sign up at <a href="https://cloudflare.com">cloudflare.com</a>.</li>
+    <li><strong>Wrangler authenticated</strong> — run <code>wrangler login</code> to authenticate with your Cloudflare account.</li>
+    <li><strong>At least one collection synced</strong> — check with <code>fink status</code>. See <a href="/docs/managing-collections">Managing Collections</a> if you haven't set one up yet.</li>
+    <li><strong>ChatGPT Desktop installed</strong> — with a plan that supports MCP connectors (check your plan's settings for a Connectors or Plugins section).</li>
+  </ul>
+
+  <h2 id="publish-collection">Publish your collection</h2>
+  <p>Before connecting ChatGPT, publish your collection(s) to Cloudflare. The <code>fink publish</code> command creates a Cloudflare Worker, D1 database, and R2 bucket, then uploads your data:</p>
+
+  <div class="steps">
+    <div class="step">
+      <div class="step-num">1</div>
+      <div class="step-body">
+        <h4>Sync your collection</h4>
+        <pre><code>fink sync my-vault
+fink status</code></pre>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">2</div>
+      <div class="step-body">
+        <h4>Publish to Cloudflare</h4>
+        <pre><code>fink publish my-vault \
+  <span class="flag">--password</span> your-secret-password \
+  <span class="flag">--name</span>     my-vault-pub</code></pre>
+        <p>Choose a strong password — it's required to authenticate every MCP request. The <code>--name</code> becomes part of the deployment URL.</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">3</div>
+      <div class="step-body">
+        <h4>Note your deployment URL</h4>
+        <p>After publishing, you'll see output like:</p>
+        <pre><code>Deployed: https://my-vault-pub.your-account.workers.dev</code></pre>
+        <p>Your MCP endpoint is:</p>
+        <pre><code>https://my-vault-pub.your-account.workers.dev/mcp</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <p>See <a href="/docs/publishing">Publishing to Cloudflare</a> for the full publishing guide, including multiple collections, updating content, and managing deployments.</p>
+
+  <h2 id="connect-in-chatgpt">Connect in ChatGPT Desktop</h2>
+  <p>Once your deployment is live, add it as an MCP connector in ChatGPT Desktop:</p>
+
+  <div class="steps">
+    <div class="step">
+      <div class="step-num">1</div>
+      <div class="step-body">
+        <h4>Open Connectors settings</h4>
+        <p>In ChatGPT Desktop, go to <strong>Settings → Connectors</strong> (the exact label may vary by version — look for "MCP", "Plugins", or "Connected Apps").</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">2</div>
+      <div class="step-body">
+        <h4>Add a new connector</h4>
+        <p>Click <strong>Add</strong> or <strong>Connect new server</strong> and enter:</p>
+        <ul>
+          <li><strong>Name:</strong> Frozen Ink — My Vault (or any descriptive label)</li>
+          <li><strong>URL:</strong> <code>https://my-vault-pub.your-account.workers.dev/mcp</code></li>
+          <li><strong>Authentication:</strong> Bearer token — enter your deployment password</li>
+        </ul>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">3</div>
+      <div class="step-body">
+        <h4>Save and enable</h4>
+        <p>Save the connector and toggle it on. ChatGPT will connect to the endpoint and discover the available tools. You should see the Frozen Ink tools listed.</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">4</div>
+      <div class="step-body">
+        <h4>Start a conversation</h4>
+        <p>Open a new chat. The Frozen Ink MCP connector is now active. Try: <em>"Search my knowledge base for anything about our API design"</em>.</p>
+      </div>
+    </div>
+  </div>
+
+  <h2 id="authentication">Authentication</h2>
+  <p>The MCP endpoint accepts the deployment password in two forms:</p>
+
+  <h3>Bearer token (recommended)</h3>
+  <p>Pass the password as a Bearer token in the <code>Authorization</code> header — this is what ChatGPT Desktop uses when you enter the password in the connector settings:</p>
+  <pre><code>Authorization: Bearer your-deployment-password</code></pre>
+
+  <h3>Query parameter</h3>
+  <p>If your ChatGPT configuration doesn't support custom headers, append the password as a query parameter:</p>
+  <pre><code>https://my-vault-pub.your-account.workers.dev/mcp?token=your-deployment-password</code></pre>
+
+  <div class="callout callout-warning">
+    <div class="callout-icon">⚠️</div>
+    <div class="callout-body">
+      <strong>Keep your password private</strong>
+      <p>The deployment password grants full read access to all collections in the deployment. Treat it like an API key — don't share it publicly or commit it to version control.</p>
+    </div>
+  </div>
+
+  <h2 id="available-tools">Available MCP tools</h2>
+  <p>The cloud MCP endpoint exposes the same tools as local connections, but searches across <em>all</em> collections in the deployment simultaneously:</p>
+
+  <table>
+    <thead>
+      <tr><th>Tool</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>collection_list</code></td>
+        <td>Lists all collections in the deployment with metadata.</td>
+      </tr>
+      <tr>
+        <td><code>entity_search</code></td>
+        <td>Full-text search across all entities in all published collections. Returns ranked results with entity IDs and snippets.</td>
+      </tr>
+      <tr>
+        <td><code>entity_get_data</code></td>
+        <td>Retrieves structured data for a specific entity (e.g. a GitHub issue's fields). Returns JSON.</td>
+      </tr>
+      <tr>
+        <td><code>entity_get_markdown</code></td>
+        <td>Retrieves rendered markdown for a specific entity — ideal for ChatGPT to read and reference.</td>
+      </tr>
+      <tr>
+        <td><code>entity_get_attachment</code></td>
+        <td>Retrieves a binary attachment (image, PDF, etc.) for a specific entity.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2 id="multiple-collections">Multiple collections</h2>
+  <p>You can publish multiple collections into a single deployment. ChatGPT's <code>entity_search</code> will search across all of them:</p>
+  <pre><code>fink publish my-vault my-project-issues architecture-notes \
+  <span class="flag">--password</span> your-secret-password \
+  <span class="flag">--name</span>     team-kb</code></pre>
+
+  <p>The single MCP endpoint <code>https://team-kb.your-account.workers.dev/mcp</code> then covers all three collections.</p>
+
+  <p>Alternatively, create separate deployments with separate passwords for different audiences:</p>
+  <pre><code><span class="cmt"># Personal notes — private</span>
+fink publish my-vault <span class="flag">--password</span> private123 <span class="flag">--name</span> my-notes
+
+<span class="cmt"># Team knowledge base — shared</span>
+fink publish team-docs <span class="flag">--password</span> team456 <span class="flag">--name</span> team-kb</code></pre>
+
+  <h2 id="update-content">Updating content</h2>
+  <p>Published data is a snapshot. When your local collections change (new notes, synced issues, etc.), re-publish to update what ChatGPT sees:</p>
+  <pre><code><span class="cmt"># Sync locally first</span>
+fink sync my-vault
+
+<span class="cmt"># Re-publish (same command as initial publish)</span>
+fink publish my-vault \
+  <span class="flag">--password</span> your-secret-password \
+  <span class="flag">--name</span>     my-vault-pub</code></pre>
+
+  <p>After re-publishing, the next ChatGPT tool call will return the updated content. No changes to the ChatGPT connector configuration are needed.</p>
+
+  <div class="callout callout-tip">
+    <div class="callout-icon">💡</div>
+    <div class="callout-body">
+      <strong>Keep content fresh</strong>
+      <p>Run <code>fink daemon start</code> to auto-sync collections in the background, then re-publish on a schedule — or whenever you need the latest data in ChatGPT.</p>
+    </div>
+  </div>
+
+  <h2 id="troubleshooting">Troubleshooting</h2>
+
+  <h3>ChatGPT can't connect to the MCP endpoint</h3>
+  <p>Verify the deployment is live by opening the URL in a browser. A password prompt or JSON response indicates the Worker is running. If you get a 404 or error, re-publish:</p>
+  <pre><code>fink publish my-vault --password your-secret-password --name my-vault-pub</code></pre>
+
+  <h3>Authentication errors (401 Unauthorized)</h3>
+  <p>Double-check the password you entered in ChatGPT Desktop matches the one you used with <code>--password</code> during publishing. Passwords are case-sensitive. You can change the password by re-publishing with a new value.</p>
+
+  <h3>Stale or missing results</h3>
+  <p>Sync locally and re-publish to refresh the data in the cloud deployment:</p>
+  <pre><code>fink sync my-vault
+fink publish my-vault --password your-secret-password --name my-vault-pub</code></pre>
+
+  <h3>Connector doesn't appear in ChatGPT settings</h3>
+  <p>MCP connector support in ChatGPT Desktop may require a specific plan tier. Check your OpenAI account's feature availability. The Frozen Ink MCP endpoint is fully compatible with any ChatGPT plan that supports remote MCP connectors.</p>
+
+  <div class="docs-pagination">
+    <a href="/docs/codex-cli" class="docs-pagination-card">
+      <span class="docs-pagination-label">← Previous</span>
+      <span class="docs-pagination-title">Codex CLI Integration</span>
+    </a>
+    <a href="/docs/anythingllm-mcp" class="docs-pagination-card next">
+      <span class="docs-pagination-label">Next →</span>
+      <span class="docs-pagination-title">AnythingLLM Integration</span>
+    </a>
+  </div>
+  `,
+});

--- a/packages/website/src/docs/claude-code.ts
+++ b/packages/website/src/docs/claude-code.ts
@@ -3,20 +3,22 @@ import { renderDocsPage } from "./layout";
 export const claudeCodePage = renderDocsPage({
   title: "Claude Code Integration",
   description:
-    "Add collection folders and browse your knowledge base from Claude Code, the desktop app, or the terminal TUI.",
+    "Connect Frozen Ink collections to Claude Code via local stdio MCP or a published cloud MCP endpoint, and browse your knowledge base from the built-in web UI.",
   activePath: "/docs/claude-code",
   tocLinks: [
     { id: "overview", title: "Overview" },
+    { id: "local-mcp", title: "Local MCP setup" },
+    { id: "local-link-collections", title: "Link collections", indent: true },
+    { id: "local-multiple", title: "Multiple collections", indent: true },
+    { id: "cloud-mcp", title: "Cloud MCP access" },
     { id: "add-collection-folder", title: "Add a collection folder" },
     { id: "obsidian-vault", title: "Obsidian vault", indent: true },
     { id: "git-repo", title: "Git repository", indent: true },
     { id: "sync-and-serve", title: "Sync & serve" },
     { id: "browsing-in-claude", title: "Browsing in Claude Code" },
-    { id: "quick-reference", title: "Quick reference" },
-    { id: "desktop-app", title: "Using the desktop app" },
-    { id: "combine-with-mcp", title: "Combine with MCP" },
-    { id: "claude-cowork", title: "Claude Cowork" },
     { id: "collection-description", title: "Collection descriptions" },
+    { id: "quick-reference", title: "Quick reference" },
+    { id: "troubleshooting", title: "Troubleshooting" },
   ],
   content: `
   <div class="docs-breadcrumb">
@@ -26,82 +28,154 @@ export const claudeCodePage = renderDocsPage({
   </div>
 
   <h1 class="page-title">Claude Code Integration</h1>
-  <p class="page-lead">Frozen Ink works naturally alongside Claude Code. Add your Obsidian vaults, local Git repos, or any other source as Frozen Ink collections, and your knowledge becomes instantly searchable — from the web UI, from the terminal, and via MCP so Claude can query it too.</p>
+  <p class="page-lead">Frozen Ink integrates with Claude Code via the Model Context Protocol. Link your collections locally so Claude can query them over stdio, or connect to a published cloud deployment over HTTP. Either way, Claude can search your notes, read documents, and access your knowledge base without copy-paste.</p>
 
   <h2 id="overview">Overview</h2>
-  <p>There are two complementary ways to use Frozen Ink with Claude Code:</p>
-
   <div class="feature-grid">
     <div class="feature-card">
-      <div class="feature-card-icon">📂</div>
-      <h4>Collection folders</h4>
-      <p>Point Frozen Ink at your local folders — an Obsidian vault, a Git repository, a project directory. Sync them into the local index so you can browse and search them from the web UI or terminal.</p>
+      <div class="feature-card-icon">🖥️</div>
+      <h4>Local MCP</h4>
+      <p>Claude Code spawns <code>fink mcp serve</code> over stdio — direct process communication with no HTTP overhead. Responses are instant, there are no rate limits, and your data never leaves the machine.</p>
     </div>
     <div class="feature-card">
-      <div class="feature-card-icon">🤖</div>
-      <h4>MCP for Claude</h4>
-      <p>Link collections to Claude Code via the Model Context Protocol. Claude can then search and read your knowledge base without you copying and pasting content into the conversation.</p>
+      <div class="feature-card-icon">☁️</div>
+      <h4>Cloud MCP</h4>
+      <p>Connect Claude Code to a published Frozen Ink deployment over HTTP. Useful when you need the same knowledge base across multiple machines or want to share it with teammates.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-icon">📂</div>
+      <h4>Web UI browser</h4>
+      <p>Run <code>fink serve</code> to open a local web UI at <code>localhost:3000</code>. Browse, search, and read your collections side-by-side with Claude Code in any browser.</p>
     </div>
   </div>
 
-  <p>This page covers adding collection folders and browsing your knowledge base. For the MCP integration that lets Claude query collections, see <a href="/docs/local-mcp">Local MCP Setup</a>.</p>
+  <h2 id="local-mcp">Local MCP setup</h2>
+  <p>Local MCP uses a <strong>per-collection, stdio-based transport</strong>. When Claude calls a tool, Claude Code spawns <code>fink mcp serve --collection &lt;name&gt;</code> as a subprocess and communicates over stdio — direct process I/O with no network round-trip. Tool responses land in single-digit milliseconds, and since everything runs locally, there are no API rate limits or per-query costs to worry about.</p>
 
-  <h2 id="add-collection-folder">Add a collection folder</h2>
-  <p>A "collection folder" is simply a Frozen Ink collection that points at a local directory. The two most common cases are an Obsidian vault and a Git repository.</p>
+  <h3 id="local-link-collections">Link collections</h3>
 
-  <h3 id="obsidian-vault">Obsidian vault</h3>
-  <p>If your notes live in an Obsidian vault, add it as an <code>obsidian</code> collection. Frozen Ink understands Obsidian's wiki-link syntax, callout blocks, embedded images, and YAML frontmatter:</p>
-  <pre><code>fink add obsidian \
-  <span class="flag">--name</span> my-vault \
-  <span class="flag">--path</span> ~/Documents/MyVault</code></pre>
-
-  <p>This creates a collection named <code>my-vault</code> that points at your vault. The name is used in all subsequent commands:</p>
-  <pre><code>fink sync my-vault
+  <div class="steps">
+    <div class="step">
+      <div class="step-num">1</div>
+      <div class="step-body">
+        <h4>Ensure the collection is synced</h4>
+        <pre><code>fink sync my-vault
 fink status</code></pre>
+        <p>Claude queries the local SQLite database at tool-call time, so the collection needs data before linking.</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">2</div>
+      <div class="step-body">
+        <h4>Link to Claude Code</h4>
+        <pre><code>fink mcp add <span class="flag">--tool</span> claude-code my-vault</code></pre>
+        <p>This writes an entry to <code>~/.claude/mcp_servers.json</code> that tells Claude Code to call <code>fink mcp serve --collection my-vault</code> when the MCP server is needed.</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">3</div>
+      <div class="step-body">
+        <h4>Verify</h4>
+        <pre><code>fink mcp list <span class="flag">--tool</span> claude-code</code></pre>
+        <p>You should see <code>my-vault</code> listed with status <strong>linked</strong>.</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">4</div>
+      <div class="step-body">
+        <h4>Start a conversation</h4>
+        <p>Open or restart Claude Code and start a new conversation. Claude now has access to your collection. Try: <em>"Search my knowledge base for anything about authentication"</em>.</p>
+      </div>
+    </div>
+  </div>
 
-  <h3 id="git-repo">Git repository</h3>
-  <p>Add a local code repository to get a searchable index of its commit history, branches, and tags:</p>
-  <pre><code>fink add git \
-  <span class="flag">--name</span> my-project \
-  <span class="flag">--path</span> ~/code/my-project</code></pre>
+  <div class="callout callout-info">
+    <div class="callout-icon">ℹ️</div>
+    <div class="callout-body">
+      <strong>fink must be on your PATH</strong>
+      <p>Claude Code spawns <code>fink mcp serve</code> as a subprocess. The <code>fink</code> binary must be on the system PATH — installing via npm (<code>npm install -g @vboctor/fink</code>) handles this automatically. If you installed a standalone binary, ensure it's in <code>/usr/local/bin/</code> or another standard PATH directory.</p>
+    </div>
+  </div>
 
-  <p>Add <code>--include-diffs</code> if you want the full diff of each commit included in the rendered markdown. This is useful for understanding what changed in a given commit:</p>
-  <pre><code>fink add git \
-  <span class="flag">--name</span>           my-project \
-  <span class="flag">--path</span>           ~/code/my-project \
-  <span class="flag">--include-diffs</span></code></pre>
+  <h3 id="local-multiple">Multiple collections</h3>
+  <p>Link multiple collections in one command or separately — the result is the same:</p>
+  <pre><code><span class="cmt"># Link two collections at once</span>
+fink mcp add <span class="flag">--tool</span> claude-code my-vault my-project-issues
+
+<span class="cmt"># Or one at a time</span>
+fink mcp add <span class="flag">--tool</span> claude-code my-vault
+fink mcp add <span class="flag">--tool</span> claude-code my-project-issues</code></pre>
+
+  <p>Each collection becomes a separate MCP connection. Claude sees them as distinct knowledge sources and can query them independently in the same conversation.</p>
+
+  <pre><code><span class="cmt"># Remove a collection link</span>
+fink mcp remove <span class="flag">--tool</span> claude-code my-vault
+
+<span class="cmt"># List all current links</span>
+fink mcp list <span class="flag">--tool</span> claude-code</code></pre>
+
+  <h2 id="cloud-mcp">Cloud MCP access</h2>
+  <p>If you've <a href="/docs/publishing">published a deployment to Cloudflare</a>, Claude Code can connect to it over HTTP. This is useful when you want the same knowledge base accessible from multiple machines, or when teammates need access without running Frozen Ink locally.</p>
+
+  <p>Cloud MCP uses the <code>streamable-http</code> transport. Add it manually to <code>~/.claude/mcp_servers.json</code>:</p>
+
+  <pre><code>{
+  "mcpServers": {
+    "frozen-ink-cloud": {
+      "transport": "http",
+      "url": "https://my-deployment.workers.dev/mcp",
+      "headers": {
+        "Authorization": "Bearer your-deployment-password"
+      }
+    }
+  }
+}</code></pre>
+
+  <p>Restart Claude Code for the change to take effect. The cloud connection appears alongside any local collection links you've configured — you can use both at the same time.</p>
 
   <div class="callout callout-tip">
     <div class="callout-icon">💡</div>
     <div class="callout-body">
-      <strong>Add multiple repos at once</strong>
-      <p>You can add as many collections as you want. They're indexed separately, but Frozen Ink's full-text search queries all of them simultaneously, so you don't have to choose which one to search.</p>
+      <strong>Local vs. cloud</strong>
+      <p>Local links give Claude per-collection access scoped to your machine — great for private notes. The cloud link gives access to everything in the published deployment, across any device. Combine them as needed.</p>
     </div>
   </div>
 
+  <h2 id="add-collection-folder">Add a collection folder</h2>
+  <p>A "collection folder" is a Frozen Ink collection pointing at a local directory. The two most common cases are an Obsidian vault and a Git repository.</p>
+
+  <h3 id="obsidian-vault">Obsidian vault</h3>
+  <p>Frozen Ink understands Obsidian's wiki-link syntax, callout blocks, embedded images, and YAML frontmatter:</p>
+  <pre><code>fink add obsidian \
+  <span class="flag">--name</span> my-vault \
+  <span class="flag">--path</span> ~/Documents/MyVault</code></pre>
+
+  <h3 id="git-repo">Git repository</h3>
+  <p>Get a searchable index of commit history, branches, and tags:</p>
+  <pre><code>fink add git \
+  <span class="flag">--name</span> my-project \
+  <span class="flag">--path</span> ~/code/my-project</code></pre>
+  <p>Add <code>--include-diffs</code> to include the full unified diff of each commit in the rendered markdown — useful for understanding what changed in any given commit.</p>
+
   <h2 id="sync-and-serve">Sync &amp; serve</h2>
-  <p>After adding your collections, sync them to pull data into the local index, then start the server:</p>
-  <pre><code><span class="cmt"># Sync all collections at once</span>
+  <p>After adding collections, sync them and start the local web UI:</p>
+  <pre><code><span class="cmt"># Sync all collections</span>
 fink sync "*"
 
-<span class="cmt"># Start the local web UI and API server (runs on port 3000)</span>
+<span class="cmt"># Start the local web UI (port 3000)</span>
 fink serve</code></pre>
 
-  <p>Open <a href="http://localhost:3000">http://localhost:3000</a> to browse your collections in the web UI.</p>
-
-  <p>To keep collections up to date automatically, start the background daemon:</p>
+  <p>Open <a href="http://localhost:3000">http://localhost:3000</a> to browse your collections. To keep everything up to date automatically, run the background daemon:</p>
   <pre><code>fink daemon start</code></pre>
 
   <h2 id="browsing-in-claude">Browsing in Claude Code</h2>
-  <p>With <code>fink serve</code> running, the web UI at <code>localhost:3000</code> is available anywhere in your browser, including side-by-side with Claude Code in a split window.</p>
-
-  <p>The web UI provides:</p>
+  <p>With <code>fink serve</code> running, the web UI is available in any browser — open it side-by-side with Claude Code in a split window. Features include:</p>
   <ul>
-    <li><strong>Collection picker</strong> — switch between your synced data sources</li>
-    <li><strong>File tree</strong> — browse all markdown files in a folder tree, resizable</li>
-    <li><strong>Tabs</strong> — open multiple notes simultaneously (<kbd>Cmd+W</kbd> to close)</li>
-    <li><strong>Backlinks panel</strong> — see which notes link to the current note (Obsidian-style)</li>
-    <li><strong>Quick switcher</strong> — press <kbd>Cmd+P</kbd> or <kbd>Cmd+K</kbd> for instant full-text search across all collections</li>
+    <li><strong>Collection picker</strong> — switch between data sources</li>
+    <li><strong>File tree</strong> — browse all markdown files in a resizable folder tree</li>
+    <li><strong>Tabs</strong> — open multiple notes simultaneously</li>
+    <li><strong>Backlinks panel</strong> — see which notes link to the current one</li>
+    <li><strong>Quick switcher</strong> — <kbd>Cmd+P</kbd> or <kbd>Cmd+K</kbd> for full-text search across all collections</li>
     <li><strong>6 display themes</strong> — Default Light, Minimal Light, Solarized Light, Nord Dark, Catppuccin Dark, Dracula Dark</li>
   </ul>
 
@@ -112,137 +186,76 @@ fink serve</code></pre>
     <tbody>
       <tr><td><kbd>Cmd+P</kbd> / <kbd>Cmd+K</kbd></td><td>Quick switcher / full-text search</td></tr>
       <tr><td><kbd>Cmd+W</kbd></td><td>Close current tab</td></tr>
-      <tr><td><kbd>Ctrl+Tab</kbd></td><td>Cycle to next tab</td></tr>
-      <tr><td><kbd>Ctrl+Shift+Tab</kbd></td><td>Cycle to previous tab</td></tr>
+      <tr><td><kbd>Ctrl+Tab</kbd></td><td>Next tab</td></tr>
+      <tr><td><kbd>Ctrl+Shift+Tab</kbd></td><td>Previous tab</td></tr>
       <tr><td><kbd>Alt+←</kbd> / <kbd>Cmd+[</kbd></td><td>Navigate back</td></tr>
       <tr><td><kbd>Alt+→</kbd> / <kbd>Cmd+]</kbd></td><td>Navigate forward</td></tr>
       <tr><td><kbd>Cmd+\\</kbd></td><td>Toggle sidebar</td></tr>
     </tbody>
   </table>
 
-  <h2 id="quick-reference">Quick reference</h2>
-  <p>Common commands when working with Claude Code and Frozen Ink together:</p>
-  <pre><code><span class="cmt"># First time setup</span>
-fink init
-fink add obsidian <span class="flag">--name</span> notes <span class="flag">--path</span> ~/Documents/MyVault
-fink add git <span class="flag">--name</span> myapp <span class="flag">--path</span> ~/code/myapp
-fink sync "*"
-fink serve
-
-<span class="cmt"># Daily workflow</span>
-fink daemon start          <span class="cmt"># auto-sync in background</span>
-fink serve                 <span class="cmt"># start web UI when needed</span>
-fink search "auth flow"    <span class="cmt"># quick terminal search</span>
-fink status                <span class="cmt"># check last sync times</span></code></pre>
-
-  <h2 id="desktop-app">Using the desktop app</h2>
-  <p>If you're on macOS, the Frozen Ink desktop app provides all the same functionality without the terminal. It adds:</p>
-  <ul>
-    <li><strong>Workspace management</strong> — multiple isolated workspaces, each with their own collections</li>
-    <li><strong>System tray icon</strong> — sync status, quick access to the UI, daemon control</li>
-    <li><strong>Management UI</strong> — add/edit/remove collections, trigger syncs, manage publications — all from a GUI</li>
-    <li><strong>Export panel</strong> — export collections as markdown or HTML files with one click</li>
-  </ul>
-
-  <p>Download the desktop app from the <a href="/#download">download page</a>. On first launch, create a workspace and add your first collection from the Collections screen.</p>
-
-  <div class="callout callout-info">
-    <div class="callout-icon">ℹ️</div>
-    <div class="callout-body">
-      <strong>CLI and desktop app share data</strong>
-      <p>The desktop app and the CLI both read from <code>~/.frozenink/</code>. Collections you add via the CLI are visible in the desktop app and vice versa, as long as you're using the same workspace.</p>
-    </div>
-  </div>
-
-  <h2 id="combine-with-mcp">Combine with MCP</h2>
-  <p>The most powerful Claude Code workflow combines collection folders with MCP. After adding and syncing your collections, link them to Claude Code so Claude can query them directly in any conversation:</p>
-  <pre><code>fink mcp add <span class="flag">--tool</span> claude-code notes myapp</code></pre>
-
-  <p>Now, when you're in a Claude Code conversation, you can ask:</p>
-  <ul>
-    <li><em>"What does my architecture note say about the caching strategy?"</em></li>
-    <li><em>"Search my notes for anything about rate limiting"</em></li>
-    <li><em>"Find commits in myapp that changed the auth module"</em></li>
-  </ul>
-
-  <p>Claude queries Frozen Ink via MCP and brings back exact content from your collections — no manual copy-paste needed.</p>
-
-  <p>See <a href="/docs/local-mcp">Local MCP Setup</a> for the full configuration guide.</p>
-
-  <h2 id="claude-cowork">Claude Cowork</h2>
-  <p>Claude Cowork is Anthropic's collaborative AI workspace that lets teams work alongside Claude in a shared environment. Unlike Claude Code (which runs in your terminal), Cowork runs in the browser and doesn't support stdio MCP connections.</p>
-  <p>You can still give Cowork access to your Frozen Ink knowledge base by <strong>adding your collections folder as a workspace folder</strong>. Claude Cowork can read files directly from your local filesystem when you share a folder with it.</p>
-
-  <div class="steps">
-    <div class="step">
-      <div class="step-num">1</div>
-      <div class="step-body">
-        <h4>Sync your collections</h4>
-        <p>Make sure your collections are synced locally. The markdown files in <code>~/.frozenink/collections/</code> are what Cowork will read:</p>
-        <pre><code>fink sync "*"</code></pre>
-      </div>
-    </div>
-    <div class="step">
-      <div class="step-num">2</div>
-      <div class="step-body">
-        <h4>Add the collections folder</h4>
-        <p>In Claude Cowork, open your workspace settings and add <code>~/.frozenink/collections/</code> as a shared folder. This gives Claude access to all your synced markdown files.</p>
-      </div>
-    </div>
-    <div class="step">
-      <div class="step-num">3</div>
-      <div class="step-body">
-        <h4>Ask questions naturally</h4>
-        <p>Claude Cowork can now read from your collections folder. Ask questions and Claude will reference your knowledge base:</p>
-        <ul>
-          <li><em>"Check my notes for anything about the authentication redesign"</em></li>
-          <li><em>"What open GitHub issues do I have tagged with 'performance'?"</em></li>
-          <li><em>"Summarize recent commits in my project"</em></li>
-        </ul>
-      </div>
-    </div>
-  </div>
-
-  <div class="callout callout-tip">
-    <div class="callout-icon">🔄</div>
-    <div class="callout-body">
-      <strong>Keep it fresh</strong>
-      <p>Run <code>fink daemon start</code> to keep your collections auto-syncing in the background. Cowork reads the latest files on disk, so syncing regularly ensures Claude sees up-to-date information.</p>
-    </div>
-  </div>
-
   <h2 id="collection-description">Collection descriptions</h2>
-  <p>A collection description tells AI assistants what the collection contains and when to consult it. It's included in the MCP server instructions that Claude receives when a collection is linked, making Claude much more effective at routing questions to the right source.</p>
+  <p>A collection description tells Claude what the collection contains and when to consult it. It's included in the MCP server instructions Claude receives, making it much more effective at routing questions to the right source.</p>
 
-  <p>Set a description when adding a collection:</p>
   <pre><code>fink add github \
   <span class="flag">--name</span>        backend-issues \
   <span class="flag">--repo</span>        acme/backend \
   <span class="flag">--token</span>       ghp_... \
-  <span class="flag">--description</span> "GitHub issues and PRs for the acme/backend repo. Search here for bug reports, feature requests, architecture decisions, and code review history."</code></pre>
+  <span class="flag">--description</span> "GitHub issues and PRs for the acme/backend repo. Search here for bug reports, feature requests, and code review history."</code></pre>
 
-  <p>Or update an existing collection:</p>
+  <p>Update an existing collection's description at any time:</p>
   <pre><code>fink collections update backend-issues \
   <span class="flag">--description</span> "GitHub issues and PRs for the acme/backend repo."</code></pre>
-
-  <p>In the desktop app, the description field appears on the Edit Collection form, below the Display Title. It accepts free-form text — write it as if you're explaining to a colleague what this collection is and what questions it can answer.</p>
 
   <div class="callout callout-tip">
     <div class="callout-icon">💡</div>
     <div class="callout-body">
       <strong>What makes a good description</strong>
-      <p>Include: the data source and project/repo/vault name, the kinds of entities it contains (issues, notes, commits), and the types of questions it can answer. For example: <em>"Obsidian vault for personal engineering notes. Contains architecture decisions, meeting notes, and reference docs. Consult this for design rationale and background context."</em></p>
+      <p>Include: the data source and project name, the kinds of entities it contains (issues, notes, commits), and the types of questions it can answer. For example: <em>"Obsidian vault for personal engineering notes. Contains architecture decisions, meeting notes, and reference docs. Consult for design rationale and background context."</em></p>
     </div>
   </div>
+
+  <h2 id="quick-reference">Quick reference</h2>
+  <pre><code><span class="cmt"># First-time setup</span>
+fink init
+fink add obsidian <span class="flag">--name</span> notes <span class="flag">--path</span> ~/Documents/MyVault
+fink add git <span class="flag">--name</span> myapp <span class="flag">--path</span> ~/code/myapp
+fink sync "*"
+fink mcp add <span class="flag">--tool</span> claude-code notes myapp
+
+<span class="cmt"># Daily workflow</span>
+fink daemon start              <span class="cmt"># auto-sync in background</span>
+fink serve                     <span class="cmt"># start web UI when needed</span>
+fink status                    <span class="cmt"># check last sync times</span>
+
+<span class="cmt"># Manage MCP links</span>
+fink mcp list <span class="flag">--tool</span> claude-code
+fink mcp remove <span class="flag">--tool</span> claude-code notes</code></pre>
+
+  <h2 id="troubleshooting">Troubleshooting</h2>
+
+  <h3>Claude doesn't seem to be using Frozen Ink</h3>
+  <pre><code>fink mcp list --tool claude-code</code></pre>
+  <p>If the collection shows as <strong>unlinked</strong> or missing, run <code>fink mcp add</code> again. If Claude Code was already open, start a new conversation.</p>
+
+  <h3>"fink: command not found" errors</h3>
+  <p>Claude Code spawns <code>fink mcp serve</code> using the system PATH. Verify:</p>
+  <pre><code>which fink      <span class="cmt"># should print /usr/local/bin/fink or similar</span>
+fink --version</code></pre>
+  <p>If <code>fink</code> is only on your shell's PATH (e.g. via NVM-managed Node), reinstall globally so it lands in a standard system directory: <code>npm install -g @vboctor/fink</code>.</p>
+
+  <h3>Stale results</h3>
+  <p>Sync the collection and the next MCP call will return fresh data:</p>
+  <pre><code>fink sync my-vault</code></pre>
 
   <div class="docs-pagination">
     <a href="/docs/managing-collections" class="docs-pagination-card">
       <span class="docs-pagination-label">← Previous</span>
       <span class="docs-pagination-title">Managing Collections</span>
     </a>
-    <a href="/docs/claude-desktop" class="docs-pagination-card next">
+    <a href="/docs/claude-cowork" class="docs-pagination-card next">
       <span class="docs-pagination-label">Next →</span>
-      <span class="docs-pagination-title">Claude Desktop Integration</span>
+      <span class="docs-pagination-title">Claude Cowork Integration</span>
     </a>
   </div>
   `,

--- a/packages/website/src/docs/claude-cowork.ts
+++ b/packages/website/src/docs/claude-cowork.ts
@@ -1,0 +1,146 @@
+import { renderDocsPage } from "./layout";
+
+export const claudeCoworkPage = renderDocsPage({
+  title: "Claude Cowork Integration",
+  description:
+    "Give Claude Cowork access to your Frozen Ink knowledge base by sharing your local collections folder as a workspace folder.",
+  activePath: "/docs/claude-cowork",
+  tocLinks: [
+    { id: "overview", title: "Overview" },
+    { id: "how-it-works", title: "How it works" },
+    { id: "setup", title: "Setup" },
+    { id: "what-claude-can-do", title: "What Claude can do" },
+    { id: "keep-it-fresh", title: "Keeping content fresh" },
+    { id: "collection-description", title: "Collection descriptions" },
+  ],
+  content: `
+  <div class="docs-breadcrumb">
+    <a href="/docs">Docs</a>
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+    <span>Claude Cowork Integration</span>
+  </div>
+
+  <h1 class="page-title">Claude Cowork Integration</h1>
+  <p class="page-lead">Claude Cowork is Anthropic's collaborative AI workspace that runs in the browser. It doesn't support stdio MCP connections, but you can give Claude access to your entire knowledge base by sharing your local Frozen Ink collections folder as a workspace folder.</p>
+
+  <h2 id="overview">Overview</h2>
+  <p>Claude Cowork can read files directly from your local filesystem when you share a folder with it. Frozen Ink stores all synced collection data as markdown files under <code>~/.frozenink/collections/</code> — one subfolder per collection. Sharing that directory with Cowork gives Claude access to every note, issue, commit, and document in your knowledge base.</p>
+
+  <div class="feature-grid">
+    <div class="feature-card">
+      <div class="feature-card-icon">📁</div>
+      <h4>No extra config</h4>
+      <p>No MCP setup required. Just point Cowork at your collections folder. Any collection you've synced is immediately available to Claude.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-icon">🔒</div>
+      <h4>Stays local</h4>
+      <p>Files are read from your disk, not uploaded to a server. Cowork accesses them the same way it accesses any other folder you share.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-icon">🗂️</div>
+      <h4>All sources at once</h4>
+      <p>GitHub issues, Obsidian notes, Git commits, MantisBT tickets — all visible to Claude in the same session as soon as they're synced locally.</p>
+    </div>
+  </div>
+
+  <h2 id="how-it-works">How it works</h2>
+  <p>When Frozen Ink syncs a collection, it writes each entity as a markdown file into a subfolder:</p>
+  <pre><code>~/.frozenink/collections/
+  my-vault/           <span class="cmt"># Obsidian vault</span>
+    note-one.md
+    note-two.md
+    ...
+  backend-issues/     <span class="cmt"># GitHub issues</span>
+    issue-1.md
+    issue-2.md
+    ...
+  my-project/         <span class="cmt"># Git commits</span>
+    commit-abc123.md
+    ...</code></pre>
+
+  <p>Claude Cowork reads these files as plain markdown, the same format Claude already understands. No special rendering or plugin is required.</p>
+
+  <h2 id="setup">Setup</h2>
+
+  <div class="steps">
+    <div class="step">
+      <div class="step-num">1</div>
+      <div class="step-body">
+        <h4>Sync your collections</h4>
+        <pre><code>fink sync "*"
+fink status</code></pre>
+        <p>Make sure the collections you want Claude to see are synced. The markdown files in <code>~/.frozenink/collections/</code> are what Cowork will read.</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">2</div>
+      <div class="step-body">
+        <h4>Add the collections folder in Cowork</h4>
+        <p>In Claude Cowork, open your workspace settings and add <code>~/.frozenink/collections/</code> as a shared folder. Claude can then read all synced collection files.</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">3</div>
+      <div class="step-body">
+        <h4>Start asking questions</h4>
+        <p>In any Cowork conversation, Claude can now reference your collections. See <a href="#what-claude-can-do">examples below</a>.</p>
+      </div>
+    </div>
+  </div>
+
+  <h2 id="what-claude-can-do">What Claude can do</h2>
+  <p>With the collections folder shared, you can ask Claude questions that span your entire knowledge base in a single conversation:</p>
+
+  <ul>
+    <li><em>"Check my notes for anything about the authentication redesign"</em></li>
+    <li><em>"What open GitHub issues do I have tagged with 'performance'?"</em></li>
+    <li><em>"Summarize recent commits that touched the payments module"</em></li>
+    <li><em>"Find my meeting notes from the Q3 architecture review"</em></li>
+    <li><em>"What does the runbook say about deploying to production?"</em></li>
+  </ul>
+
+  <p>Claude reads the markdown files directly and synthesizes answers from them — no MCP tool calls, no extra setup beyond the shared folder.</p>
+
+  <h2 id="keep-it-fresh">Keeping content fresh</h2>
+  <p>Cowork reads the files on disk at the time Claude accesses them. To ensure Claude sees up-to-date information, keep your collections synced:</p>
+
+  <pre><code><span class="cmt"># One-shot sync of all collections</span>
+fink sync "*"
+
+<span class="cmt"># Auto-sync in the background (recommended)</span>
+fink daemon start</code></pre>
+
+  <div class="callout callout-tip">
+    <div class="callout-icon">💡</div>
+    <div class="callout-body">
+      <strong>Run the daemon for always-fresh data</strong>
+      <p><code>fink daemon start</code> syncs all collections on a configurable interval in the background. With the daemon running, the files in <code>~/.frozenink/collections/</code> stay current automatically — no manual sync needed before each Cowork session.</p>
+    </div>
+  </div>
+
+  <h2 id="collection-description">Collection descriptions</h2>
+  <p>Each collection folder contains a <code>_collection.md</code> file with metadata about the source — name, type, description, and sync status. Claude reads this automatically when you share the collections folder, which helps it understand what each subfolder contains and route your questions appropriately.</p>
+
+  <p>Set a meaningful description when you create a collection so Claude knows what to look for:</p>
+  <pre><code>fink add obsidian \
+  <span class="flag">--name</span>        my-vault \
+  <span class="flag">--path</span>        ~/Documents/MyVault \
+  <span class="flag">--description</span> "Personal engineering notes: architecture decisions, meeting notes, and reference docs."</code></pre>
+
+  <p>Or update an existing collection:</p>
+  <pre><code>fink collections update my-vault \
+  <span class="flag">--description</span> "Personal engineering notes: architecture decisions, meeting notes, and reference docs."</code></pre>
+
+  <div class="docs-pagination">
+    <a href="/docs/claude-code" class="docs-pagination-card">
+      <span class="docs-pagination-label">← Previous</span>
+      <span class="docs-pagination-title">Claude Code Integration</span>
+    </a>
+    <a href="/docs/claude-desktop" class="docs-pagination-card next">
+      <span class="docs-pagination-label">Next →</span>
+      <span class="docs-pagination-title">Claude Desktop Integration</span>
+    </a>
+  </div>
+  `,
+});

--- a/packages/website/src/docs/claude-desktop.ts
+++ b/packages/website/src/docs/claude-desktop.ts
@@ -33,14 +33,19 @@ export const claudeDesktopPage = renderDocsPage({
 
   <div class="feature-grid">
     <div class="feature-card">
-      <div class="feature-card-icon">🔍</div>
-      <h4>Search from any conversation</h4>
-      <p>Ask Claude questions about your notes and repos. Claude calls Frozen Ink's MCP tools, fetches the relevant content, and incorporates it into its response — all inline, without switching apps.</p>
+      <div class="feature-card-icon">⚡</div>
+      <h4>Instant responses</h4>
+      <p>stdio transport means direct process I/O — no HTTP round-trip, no serialization overhead. Tool calls resolve in single-digit milliseconds against the local SQLite index.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-icon">♾️</div>
+      <h4>No rate limits</h4>
+      <p>Everything runs on your machine. No API quotas, no per-query cost, no throttling. Claude can call Frozen Ink tools as many times as needed in a conversation without hitting a wall.</p>
     </div>
     <div class="feature-card">
       <div class="feature-card-icon">🔒</div>
       <h4>Local and private</h4>
-      <p>MCP connections use stdio — Claude Desktop spawns <code>fink mcp serve</code> on demand and reads your local SQLite index. No background server, no network calls for local collections.</p>
+      <p>Claude Desktop spawns <code>fink mcp serve</code> on demand and reads your local SQLite index. No background server required, fully offline — data never leaves your machine.</p>
     </div>
   </div>
 
@@ -263,13 +268,13 @@ fink --version</code></pre>
   <pre><code>fink sync my-vault</code></pre>
 
   <div class="docs-pagination">
-    <a href="/docs/claude-code" class="docs-pagination-card">
+    <a href="/docs/claude-cowork" class="docs-pagination-card">
       <span class="docs-pagination-label">← Previous</span>
-      <span class="docs-pagination-title">Claude Code Integration</span>
+      <span class="docs-pagination-title">Claude Cowork Integration</span>
     </a>
-    <a href="/docs/local-mcp" class="docs-pagination-card next">
+    <a href="/docs/codex-cli" class="docs-pagination-card next">
       <span class="docs-pagination-label">Next →</span>
-      <span class="docs-pagination-title">Local MCP Setup</span>
+      <span class="docs-pagination-title">Codex CLI Integration</span>
     </a>
   </div>
   `,

--- a/packages/website/src/docs/codex-cli.ts
+++ b/packages/website/src/docs/codex-cli.ts
@@ -1,0 +1,191 @@
+import { renderDocsPage } from "./layout";
+
+export const codexCliPage = renderDocsPage({
+  title: "Codex CLI Integration",
+  description:
+    "Connect Frozen Ink collections to OpenAI Codex CLI via MCP so it can search and read your knowledge base during coding sessions.",
+  activePath: "/docs/codex-cli",
+  tocLinks: [
+    { id: "overview", title: "Overview" },
+    { id: "prerequisites", title: "Prerequisites" },
+    { id: "link-collections", title: "Link collections" },
+    { id: "multiple-collections", title: "Multiple collections" },
+    { id: "manage-links", title: "Managing links" },
+    { id: "available-tools", title: "Available MCP tools" },
+    { id: "troubleshooting", title: "Troubleshooting" },
+  ],
+  content: `
+  <div class="docs-breadcrumb">
+    <a href="/docs">Docs</a>
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+    <span>Codex CLI Integration</span>
+  </div>
+
+  <h1 class="page-title">Codex CLI Integration</h1>
+  <p class="page-lead">Frozen Ink integrates with OpenAI Codex CLI via the Model Context Protocol. Once linked, Codex can search your notes, read documents, and access your entire knowledge base in any coding session — without copy-pasting anything.</p>
+
+  <h2 id="overview">Overview</h2>
+  <p>Codex CLI has built-in MCP support via its <code>codex mcp add</code> command. Frozen Ink registers collections directly through that interface, creating a <strong>per-collection, stdio-based connection</strong> for each one.</p>
+
+  <div class="feature-grid">
+    <div class="feature-card">
+      <div class="feature-card-icon">⚡</div>
+      <h4>Fast by design</h4>
+      <p>stdio transport is direct process I/O — no HTTP overhead, no network latency. Frozen Ink queries hit the local SQLite index and return in single-digit milliseconds, keeping Codex sessions snappy.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-icon">♾️</div>
+      <h4>No rate limits</h4>
+      <p>Local execution means no API quotas and no per-query cost. Codex can call Frozen Ink tools as many times as needed without any throttling.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-icon">🔒</div>
+      <h4>Local and private</h4>
+      <p>Codex spawns <code>fink mcp serve</code> as a subprocess on demand. Your data never leaves the machine — no background server, fully offline.</p>
+    </div>
+  </div>
+
+  <h2 id="prerequisites">Prerequisites</h2>
+  <ul>
+    <li><strong>Frozen Ink CLI installed</strong> — verify with <code>fink --version</code>. Install via <code>npm install -g @vboctor/fink</code>.</li>
+    <li><strong>fink on your PATH</strong> — Codex spawns <code>fink mcp serve</code> as a subprocess. Confirm: <code>which fink</code></li>
+    <li><strong>Codex CLI installed</strong> — verify with <code>codex --version</code>. The <code>codex mcp</code> subcommand with <code>add</code>, <code>remove</code>, and <code>list</code> must be available.</li>
+    <li><strong>At least one collection synced</strong> — check with <code>fink status</code>. If you haven't added a collection yet, see <a href="/docs/managing-collections">Managing Collections</a>.</li>
+  </ul>
+
+  <h2 id="link-collections">Link collections</h2>
+
+  <div class="steps">
+    <div class="step">
+      <div class="step-num">1</div>
+      <div class="step-body">
+        <h4>Sync your collection</h4>
+        <pre><code>fink sync my-vault
+fink status</code></pre>
+        <p>Make sure the collection has data before linking. Codex queries the local SQLite database at tool-call time, so an unsynced collection won't return results.</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">2</div>
+      <div class="step-body">
+        <h4>Link to Codex CLI</h4>
+        <pre><code>fink mcp add <span class="flag">--tool</span> codex-cli my-vault</code></pre>
+        <p>This calls <code>codex mcp add fink-my-vault -- fink mcp serve --collection my-vault</code> under the hood, registering the connection in Codex's MCP configuration.</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">3</div>
+      <div class="step-body">
+        <h4>Verify the link</h4>
+        <pre><code>fink mcp list <span class="flag">--tool</span> codex-cli</code></pre>
+        <p>You should see <code>my-vault</code> listed with status <strong>linked</strong>.</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num">4</div>
+      <div class="step-body">
+        <h4>Start a Codex session</h4>
+        <p>Run <code>codex</code> to start a new session. The MCP connection is established on the first tool call. Try: <em>"Search my knowledge base for anything about authentication"</em>.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="callout callout-info">
+    <div class="callout-icon">ℹ️</div>
+    <div class="callout-body">
+      <strong><code>codex</code> alias</strong>
+      <p>The short alias <code>--tool codex</code> is equivalent to <code>--tool codex-cli</code> and is preserved for compatibility:</p>
+      <pre><code>fink mcp add <span class="flag">--tool</span> codex my-vault</code></pre>
+    </div>
+  </div>
+
+  <h2 id="multiple-collections">Multiple collections</h2>
+  <p>Link several collections at once or separately — each becomes its own MCP connection:</p>
+  <pre><code><span class="cmt"># Link two collections in one command</span>
+fink mcp add <span class="flag">--tool</span> codex-cli my-vault my-project-issues
+
+<span class="cmt"># Or add them one at a time</span>
+fink mcp add <span class="flag">--tool</span> codex-cli my-vault
+fink mcp add <span class="flag">--tool</span> codex-cli my-project-issues</code></pre>
+
+  <p>Codex sees each collection as a distinct knowledge source and can query them independently in the same session. Each link corresponds to one entry in Codex's MCP server list (e.g. <code>fink-my-vault</code>, <code>fink-my-project-issues</code>).</p>
+
+  <h2 id="manage-links">Managing links</h2>
+  <pre><code><span class="cmt"># Add a collection</span>
+fink mcp add <span class="flag">--tool</span> codex-cli my-vault
+
+<span class="cmt"># Remove a collection</span>
+fink mcp remove <span class="flag">--tool</span> codex-cli my-vault
+
+<span class="cmt"># List current links for Codex CLI</span>
+fink mcp list <span class="flag">--tool</span> codex-cli
+
+<span class="cmt"># List all MCP links across all tools</span>
+fink mcp list</code></pre>
+
+  <p>Changes take effect in the next Codex session. No restart is needed for already-running sessions to pick up new links.</p>
+
+  <h2 id="available-tools">Available MCP tools</h2>
+  <p>Each linked collection exposes the following tools to Codex:</p>
+
+  <table>
+    <thead>
+      <tr><th>Tool</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>collection_list</code></td>
+        <td>Returns metadata about the linked collection: name, type, entity count, last sync time.</td>
+      </tr>
+      <tr>
+        <td><code>entity_search</code></td>
+        <td>Full-text search across all entities in the collection. Returns ranked results with entity IDs and snippets. Supports natural language queries.</td>
+      </tr>
+      <tr>
+        <td><code>entity_get_data</code></td>
+        <td>Retrieves structured data for a specific entity (e.g. a GitHub issue's fields: title, body, labels, assignees, timestamps). Returns JSON.</td>
+      </tr>
+      <tr>
+        <td><code>entity_get_markdown</code></td>
+        <td>Retrieves the rendered markdown for a specific entity — the human-readable form ideal for the model to read and reference.</td>
+      </tr>
+      <tr>
+        <td><code>entity_get_attachment</code></td>
+        <td>Retrieves a binary attachment (image, PDF, etc.) for a specific entity.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2 id="troubleshooting">Troubleshooting</h2>
+
+  <h3>Codex doesn't seem to be using Frozen Ink</h3>
+  <pre><code>fink mcp list --tool codex-cli</code></pre>
+  <p>If the collection shows as <strong>unlinked</strong> or missing, run <code>fink mcp add</code> again. Also verify Codex sees the server:</p>
+  <pre><code>codex mcp list</code></pre>
+  <p>You should see entries named <code>fink-&lt;collection&gt;</code> in the output.</p>
+
+  <h3>"Codex CLI not found on PATH"</h3>
+  <p>Frozen Ink calls <code>codex mcp add</code> to register the connection. If <code>codex</code> isn't on your PATH, install or enable it first, then retry <code>fink mcp add</code>.</p>
+
+  <h3>"fink: command not found" errors in Codex</h3>
+  <p>Codex spawns <code>fink mcp serve</code> using the system PATH. Verify:</p>
+  <pre><code>which fink      <span class="cmt"># should print /usr/local/bin/fink or similar</span>
+fink --version</code></pre>
+  <p>If <code>fink</code> is only accessible from your shell's PATH (e.g. a user-local npm path), reinstall globally: <code>npm install -g @vboctor/fink</code>.</p>
+
+  <h3>Stale results</h3>
+  <p>The MCP server reads from the local SQLite database at query time. Sync the collection and the next tool call will reflect updated data:</p>
+  <pre><code>fink sync my-vault</code></pre>
+
+  <div class="docs-pagination">
+    <a href="/docs/claude-desktop" class="docs-pagination-card">
+      <span class="docs-pagination-label">← Previous</span>
+      <span class="docs-pagination-title">Claude Desktop Integration</span>
+    </a>
+    <a href="/docs/chatgpt-desktop" class="docs-pagination-card next">
+      <span class="docs-pagination-label">Next →</span>
+      <span class="docs-pagination-title">ChatGPT Desktop Integration</span>
+    </a>
+  </div>
+  `,
+});

--- a/packages/website/src/docs/desktop-app.ts
+++ b/packages/website/src/docs/desktop-app.ts
@@ -191,7 +191,7 @@ export const desktopAppPage = renderDocsPage({
       <tr><td>Full-text search</td><td>✅ <kbd>Cmd+P</kbd></td><td>✅ <code>fink search</code></td></tr>
       <tr><td>Publish to Cloudflare</td><td>✅ Publish panel</td><td>✅ <code>fink publish</code></td></tr>
       <tr><td>Export collections</td><td>✅ Export panel</td><td>✅ Via API</td></tr>
-      <tr><td>Configure MCP</td><td>✅ Collections panel</td><td>✅ <code>fink mcp add</code></td></tr>
+      <tr><td>Configure local MCP links</td><td>✅ Collections panel</td><td>✅ <code>fink mcp add --tool claude-code|codex-cli|...</code></td></tr>
       <tr><td>Multiple workspaces</td><td>✅ Built-in</td><td>⚠️ Manual directory switching</td></tr>
       <tr><td>Background sync</td><td>✅ System tray daemon</td><td>✅ <code>fink daemon</code></td></tr>
       <tr><td>Scripting / automation</td><td>❌</td><td>✅ Composable commands</td></tr>

--- a/packages/website/src/docs/getting-started.ts
+++ b/packages/website/src/docs/getting-started.ts
@@ -131,8 +131,8 @@ fink sync "*"</code></pre>
     </a>
     <a href="/docs/local-mcp" class="feature-card" style="text-decoration:none;">
       <div class="feature-card-icon">🤖</div>
-      <h4>Connect to Claude</h4>
-      <p>Link collections to Claude Code or Claude Desktop so AI assistants can query your knowledge base via MCP.</p>
+      <h4>Connect MCP Clients</h4>
+      <p>Link collections to Claude Code, Codex CLI, or other local MCP clients, and set up ChatGPT Desktop via published MCP endpoints.</p>
     </a>
     <a href="/docs/publishing" class="feature-card" style="text-decoration:none;">
       <div class="feature-card-icon">🌐</div>

--- a/packages/website/src/docs/key-scenarios.ts
+++ b/packages/website/src/docs/key-scenarios.ts
@@ -97,7 +97,7 @@ fink status</code></pre>
       <div class="step-num">3</div>
       <div class="step-body">
         <h4>Option A — Local MCP (private, zero-upload)</h4>
-        <p>Link the collection to Claude Code so it can query your notes locally, with no data leaving your machine:</p>
+        <p>Link the collection to a local MCP client (for example Claude Code or Codex CLI) so it can query your notes locally, with no data leaving your machine:</p>
         <pre><code>fink mcp add --tool claude-code my-vault</code></pre>
         <p>See <a href="/docs/local-mcp">Local MCP Setup</a> for the full configuration guide.</p>
       </div>
@@ -136,7 +136,7 @@ fink publish architecture-notes github-issues internal-docs \
   <span class="flag">--password</span> team-secret <span class="flag">--name</span> team-knowledge</code></pre>
 
   <h2 id="local-ai">Local AI assistant context</h2>
-  <p><strong>Situation:</strong> You use Claude Code for software development. When working on a feature, you want Claude to have instant access to your project's GitHub issues, git history, and design notes — without manually pasting content into every conversation.</p>
+  <p><strong>Situation:</strong> You use an MCP-enabled coding assistant (for example Claude Code or Codex CLI). When working on a feature, you want instant access to your project's GitHub issues, git history, and design notes — without manually pasting content into every conversation.</p>
 
   <p>Link all relevant collections to Claude Code:</p>
   <pre><code>fink mcp add <span class="flag">--tool</span> claude-code my-project-issues my-repo my-vault</code></pre>

--- a/packages/website/src/docs/layout.ts
+++ b/packages/website/src/docs/layout.ts
@@ -45,12 +45,13 @@ const NAV_SECTIONS = [
   {
     title: "Integrations",
     items: [
-      { label: "Claude Code Integration", href: "/docs/claude-code" },
-      { label: "Claude Desktop Integration", href: "/docs/claude-desktop" },
-      { label: "Local MCP Setup", href: "/docs/local-mcp" },
-      { label: "AnythingLLM MCP Setup", href: "/docs/anythingllm-mcp" },
+      { label: "Claude Code", href: "/docs/claude-code" },
+      { label: "Claude Cowork", href: "/docs/claude-cowork" },
+      { label: "Claude Desktop", href: "/docs/claude-desktop" },
+      { label: "Codex CLI", href: "/docs/codex-cli" },
+      { label: "ChatGPT Desktop", href: "/docs/chatgpt-desktop" },
+      { label: "AnythingLLM", href: "/docs/anythingllm-mcp" },
       { label: "Publishing to Cloudflare", href: "/docs/publishing" },
-      { label: "Cloud MCP Access", href: "/docs/cloud-mcp" },
     ],
   },
 ];

--- a/packages/website/src/docs/local-mcp.ts
+++ b/packages/website/src/docs/local-mcp.ts
@@ -3,13 +3,15 @@ import { renderDocsPage } from "./layout";
 export const localMcpPage = renderDocsPage({
   title: "Local MCP Setup",
   description:
-    "Link Frozen Ink collections to Claude Code and Claude Desktop via the Model Context Protocol for AI-powered knowledge queries.",
+    "Link Frozen Ink collections to Claude Code, Codex CLI, and other MCP clients, plus set up ChatGPT Desktop via remote MCP endpoints.",
   activePath: "/docs/local-mcp",
   tocLinks: [
     { id: "what-is-mcp", title: "What is MCP" },
     { id: "how-it-works", title: "How it works in Frozen Ink" },
     { id: "link-to-claude-code", title: "Link to Claude Code" },
     { id: "link-to-claude-desktop", title: "Link to Claude Desktop" },
+    { id: "link-to-codex-cli", title: "Link to Codex CLI" },
+    { id: "link-to-chatgpt-desktop", title: "Link to ChatGPT Desktop" },
     { id: "available-tools", title: "Available MCP tools" },
     { id: "available-resources", title: "Available MCP resources" },
     { id: "multiple-collections", title: "Multiple collections" },
@@ -25,14 +27,14 @@ export const localMcpPage = renderDocsPage({
   </div>
 
   <h1 class="page-title">Local MCP Setup</h1>
-  <p class="page-lead">The Model Context Protocol (MCP) lets AI assistants like Claude directly query your Frozen Ink collections. Once linked, Claude can search your notes, read specific documents, and access attachments — without you copying and pasting anything.</p>
+  <p class="page-lead">The Model Context Protocol (MCP) lets AI assistants directly query your Frozen Ink collections. Once linked, your MCP client can search notes, read specific documents, and access attachments without copy/paste.</p>
 
   <h2 id="what-is-mcp">What is MCP</h2>
-  <p>The <a href="https://modelcontextprotocol.io">Model Context Protocol</a> is an open standard that lets AI assistants connect to external data sources and tools. Think of it as a structured API between Claude and your local Frozen Ink knowledge base.</p>
-  <p>When a collection is linked via MCP, Claude can call Frozen Ink's search and retrieval tools during a conversation. Claude decides when to call them, fetches relevant content, and incorporates it into its response — all transparently.</p>
+  <p>The <a href="https://modelcontextprotocol.io">Model Context Protocol</a> is an open standard that lets AI assistants connect to external data sources and tools. Think of it as a structured API between your MCP client and your local Frozen Ink knowledge base.</p>
+  <p>When a collection is linked via MCP, the client can call Frozen Ink's search and retrieval tools during a conversation, fetch relevant content, and incorporate it into responses.</p>
 
   <h2 id="how-it-works">How it works in Frozen Ink</h2>
-  <p>Frozen Ink uses a <strong>per-collection, stdio-based MCP transport</strong>. Each collection link registers a separate MCP connection in the AI tool's configuration. When Claude needs to query a collection, it spawns <code>fink mcp serve --collection &lt;name&gt;</code> as a subprocess and communicates over stdio.</p>
+  <p>Frozen Ink uses a <strong>per-collection, stdio-based MCP transport</strong> for local clients like Claude Code, Claude Desktop, and Codex CLI. Each collection link registers a separate MCP connection. When the client queries a collection, it spawns <code>fink mcp serve --collection &lt;name&gt;</code> as a subprocess and communicates over stdio.</p>
 
   <p>This means:</p>
   <ul>
@@ -101,8 +103,26 @@ fink status</code></pre>
     </div>
   </div>
 
+  <h2 id="link-to-codex-cli">Link to Codex CLI</h2>
+  <p>Use the canonical Codex tool name:</p>
+  <pre><code>fink mcp add <span class="flag">--tool</span> codex-cli my-vault</code></pre>
+  <p>Legacy compatibility is preserved for older scripts:</p>
+  <pre><code>fink mcp add <span class="flag">--tool</span> codex my-vault</code></pre>
+  <p><code>codex</code> is treated as an alias for <code>codex-cli</code>.</p>
+
+  <h2 id="link-to-chatgpt-desktop">Link to ChatGPT Desktop</h2>
+  <p>ChatGPT Desktop uses a remote MCP connector flow rather than local per-collection stdio registration.</p>
+  <p>Publish your collection(s), then add the published MCP URL in ChatGPT:</p>
+  <pre><code>fink publish my-vault <span class="flag">--password</span> secret123 <span class="flag">--name</span> my-vault-pub
+
+<span class="cmt"># ChatGPT connector endpoint</span>
+https://my-vault-pub.workers.dev/mcp
+<span class="cmt"># Header</span>
+Authorization: Bearer secret123</code></pre>
+  <p>Running <code>fink mcp add --tool chatgpt-desktop ...</code> returns setup guidance because ChatGPT Desktop does not currently expose a stable local config file for automatic stdio link registration.</p>
+
   <h2 id="available-tools">Available MCP tools</h2>
-  <p>Each Frozen Ink MCP connection exposes the following tools to Claude:</p>
+  <p>Each Frozen Ink MCP connection exposes the following tools to your MCP client:</p>
 
   <table>
     <thead>
@@ -133,14 +153,14 @@ fink status</code></pre>
   </table>
 
   <h3>Example interaction</h3>
-  <p>In a Claude Code session with <code>my-vault</code> linked, you might say:</p>
+  <p>In an MCP-enabled session with <code>my-vault</code> linked, you might say:</p>
   <blockquote style="border-left:3px solid var(--border); padding: 12px 20px; margin: 16px 0; color: var(--text-secondary); font-style: italic;">
     "What does my note on the authentication architecture say about token refresh?"
   </blockquote>
-  <p>Claude calls <code>entity_search</code> with <code>"token refresh authentication"</code>, finds the relevant note, then calls <code>entity_get_markdown</code> to read it in full, and synthesizes the answer.</p>
+  <p>The assistant calls <code>entity_search</code> with <code>"token refresh authentication"</code>, finds the relevant note, then calls <code>entity_get_markdown</code> to read it in full, and synthesizes the answer.</p>
 
   <h2 id="available-resources">Available MCP resources</h2>
-  <p>In addition to tools (callable functions), Frozen Ink exposes these MCP resources — addressable content that Claude can reference:</p>
+  <p>In addition to tools (callable functions), Frozen Ink exposes these MCP resources — addressable content your assistant can reference:</p>
 
   <table>
     <thead>

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -10,11 +10,12 @@ import { whatIsFrozenInkPage } from "./docs/what-is-frozen-ink";
 import { keyScenariosPage } from "./docs/key-scenarios";
 import { managingCollectionsPage } from "./docs/managing-collections";
 import { claudeCodePage } from "./docs/claude-code";
+import { claudeCoworkPage } from "./docs/claude-cowork";
 import { claudeDesktopPage } from "./docs/claude-desktop";
-import { localMcpPage } from "./docs/local-mcp";
+import { codexCliPage } from "./docs/codex-cli";
+import { chatgptDesktopPage } from "./docs/chatgpt-desktop";
 import { anythingllmMcpPage } from "./docs/anythingllm-mcp";
 import { publishingPage } from "./docs/publishing";
-import { cloudMcpPage } from "./docs/cloud-mcp";
 import { desktopAppPage } from "./docs/desktop-app";
 import { connectorGithubPage } from "./docs/connector-github";
 import { connectorObsidianPage } from "./docs/connector-obsidian";
@@ -27,11 +28,12 @@ const DOC_PAGES: Record<string, string> = {
   "/docs/key-scenarios": keyScenariosPage,
   "/docs/managing-collections": managingCollectionsPage,
   "/docs/claude-code": claudeCodePage,
+  "/docs/claude-cowork": claudeCoworkPage,
   "/docs/claude-desktop": claudeDesktopPage,
-  "/docs/local-mcp": localMcpPage,
+  "/docs/codex-cli": codexCliPage,
+  "/docs/chatgpt-desktop": chatgptDesktopPage,
   "/docs/anythingllm-mcp": anythingllmMcpPage,
   "/docs/publishing": publishingPage,
-  "/docs/cloud-mcp": cloudMcpPage,
   "/docs/desktop-app": desktopAppPage,
   "/docs/connectors/github": connectorGithubPage,
   "/docs/connectors/obsidian": connectorObsidianPage,

--- a/packages/website/src/site.html
+++ b/packages/website/src/site.html
@@ -950,7 +950,7 @@
   <div class="docs-callout-inner">
     <div class="docs-callout-text">
       <h2>Everything you need to get started</h2>
-      <p>Step-by-step guides for installation, managing collections, connecting to Claude, and publishing your knowledge to the web.</p>
+      <p>Step-by-step guides for installation, managing collections, connecting MCP clients, and publishing your knowledge to the web.</p>
       <a href="/docs" class="btn btn-primary" style="margin-top:24px; display:inline-flex;">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>
         Browse the documentation


### PR DESCRIPTION
## Summary
- add canonical MCP tool names `codex-cli` and `chatgpt-desktop`
- keep `codex` as a legacy alias and normalize it to `codex-cli` in CLI parsing
- add a ChatGPT Desktop MCP adapter that returns clear remote-setup remediation guidance (publish + `/mcp` endpoint + bearer auth)
- rename Codex adapter display semantics to Codex CLI and wire new adapters in tool registry
- expand MCP command/tool tests for canonical names and alias compatibility
- update CLI + website docs to reflect local multi-client MCP flow vs ChatGPT remote flow

## Validation
- bun test packages/cli/src/__tests__/mcp-command.test.ts packages/cli/src/__tests__/mcp-tools.test.ts
- bun run typecheck *(fails in this environment due to missing `@types/react` type definition)*