### PR TITLE
Fix collection visibility, entity titles, attachment filtering, and MantisHub signed URLs

### DIFF
--- a/packages/cli/src/__tests__/daemon-serve.test.ts
+++ b/packages/cli/src/__tests__/daemon-serve.test.ts
@@ -46,7 +46,7 @@ function addTestCollection(
   const collectionDir = join(TEST_DIR, "collections", name);
   const dbPath = join(collectionDir, "db", "data.db");
   mkdirSync(collectionDir, { recursive: true });
-  mkdirSync(join(collectionDir, "markdown"), { recursive: true });
+  mkdirSync(join(collectionDir, "content"), { recursive: true });
 
   const colDb = getCollectionDb(dbPath);
 
@@ -65,7 +65,7 @@ function addTestCollection(
         title: "Test Issue One",
         data: { number: 1, body: "First test issue body" },
         url: "https://github.com/test/repo/issues/1",
-        markdownPath: "markdown/issues/issue-1.md",
+        markdownPath: "content/issues/issue-1.md",
       })
       .run();
 
@@ -77,7 +77,7 @@ function addTestCollection(
         title: "Test Pull Request",
         data: { number: 2, body: "PR description" },
         url: "https://github.com/test/repo/pull/2",
-        markdownPath: "markdown/pull-requests/pr-2.md",
+        markdownPath: "content/pull-requests/pr-2.md",
       })
       .run();
 
@@ -90,10 +90,10 @@ function addTestCollection(
     colDb.insert(entityTags).values({ entityId: entityRows[0].id, tagId: bugTag.id }).run();
     colDb.insert(entityTags).values({ entityId: entityRows[0].id, tagId: criticalTag.id }).run();
 
-    mkdirSync(join(collectionDir, "markdown", "issues"), { recursive: true });
-    mkdirSync(join(collectionDir, "markdown", "pull-requests"), { recursive: true });
-    writeFileSync(join(collectionDir, "markdown", "issues", "issue-1.md"), "# Test Issue One\nFirst test issue body");
-    writeFileSync(join(collectionDir, "markdown", "pull-requests", "pr-2.md"), "# Test Pull Request\nPR description");
+    mkdirSync(join(collectionDir, "content", "issues"), { recursive: true });
+    mkdirSync(join(collectionDir, "content", "pull-requests"), { recursive: true });
+    writeFileSync(join(collectionDir, "content", "issues", "issue-1.md"), "# Test Issue One\nFirst test issue body");
+    writeFileSync(join(collectionDir, "content", "pull-requests", "pr-2.md"), "# Test Pull Request\nPR description");
   }
 
   if (opts?.addAttachment) {

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -70,7 +70,7 @@ export const generateCommand = new Command("generate")
       const colDb = getCollectionDb(dbPath);
       const collectionDir = join(home, "collections", col.name);
       const storage = new LocalStorageBackend(collectionDir);
-      const markdownBasePath = "markdown";
+      const markdownBasePath = "content";
 
       // Build a lookup function for cross-entity wikilinks (used by some themes)
       const entityPathLookup = (externalId: string): string | undefined => {
@@ -135,7 +135,8 @@ export const generateCommand = new Command("generate")
           })
           .filter(Boolean);
 
-        const renderCtx = {
+        // Re-derive title from stored data (no API call needed).
+        const baseCtx = {
           entity: {
             externalId: entity.externalId,
             entityType: entity.entityType,
@@ -149,6 +150,10 @@ export const generateCommand = new Command("generate")
           lookupEntityPath: entityPathLookup,
           resolveWikilink,
         };
+        const derivedTitle = themeEngine.getTitle(baseCtx);
+        const title = derivedTitle ?? entity.title;
+
+        const renderCtx = derivedTitle ? { ...baseCtx, entity: { ...baseCtx.entity, title } } : baseCtx;
 
         const newPath = `${markdownBasePath}/${themeEngine.getFilePath(renderCtx)}`;
         const markdown = themeEngine.render(renderCtx);
@@ -167,10 +172,11 @@ export const generateCommand = new Command("generate")
         await storage.write(newPath, markdown);
         const fileStat = await storage.stat(newPath);
 
-        // Update entity record with new path and mtime
+        // Update entity record with new path, mtime, and re-derived title
         colDb
           .update(entities)
           .set({
+            title,
             markdownPath: newPath,
             markdownMtime: fileStat?.mtimeMs ?? null,
             markdownSize: fileStat?.size ?? null,
@@ -183,7 +189,7 @@ export const generateCommand = new Command("generate")
           id: entity.id,
           externalId: entity.externalId,
           entityType: entity.entityType,
-          title: entity.title,
+          title,
           content: markdown,
           tags: entityTagNames,
         });

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -55,7 +55,7 @@ export const indexCommand = new Command("index")
 
       const colDb = getCollectionDb(dbPath);
       const collectionDir = join(home, "collections", col.name);
-      const markdownBasePath = "markdown";
+      const markdownBasePath = "content";
 
       // Clear existing search index and links
       const indexer = new SearchIndexer(dbPath);

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -554,7 +554,7 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
         );
 
         const collectionDir = join(home, "collections", name);
-        mkdirSync(join(collectionDir, "markdown"), { recursive: true });
+        mkdirSync(join(collectionDir, "content"), { recursive: true });
         const storage = new LocalStorageBackend(collectionDir);
 
         // If full sync requested, reset cursor by deleting sync_state

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -186,9 +186,9 @@ export function createApiServer(
         const col = getCollection(name);
         if (!col) return errorResponse("Collection not found", 404);
 
-        const markdownDir = join(home, "collections", name, "markdown");
+        const contentDir = join(home, "collections", name, "content");
 
-        // Build a map from relative markdown path → entity title
+        // Build a map from relative content path → entity title
         const titleByPath = new Map<string, string>();
         const dbPath = getCollectionDbPath(name);
         if (existsSync(dbPath)) {
@@ -197,7 +197,7 @@ export function createApiServer(
             .select({ markdownPath: entities.markdownPath, title: entities.title })
             .from(entities)
             .all();
-          const prefix = "markdown/";
+          const prefix = "content/";
           for (const row of rows) {
             if (!row.markdownPath || !row.title) continue;
             const rel = row.markdownPath.startsWith(prefix)
@@ -207,7 +207,7 @@ export function createApiServer(
           }
         }
 
-        const tree = buildFileTree(markdownDir, titleByPath);
+        const tree = buildFileTree(contentDir, titleByPath);
         return jsonResponse(tree);
       }
 
@@ -232,7 +232,7 @@ export function createApiServer(
           .limit(1)
           .all();
 
-        const filePath = latest?.markdownPath?.replace(/^markdown\//, "") ?? null;
+        const filePath = latest?.markdownPath?.replace(/^content\//, "") ?? null;
         return jsonResponse({ file: filePath });
       }
 
@@ -244,7 +244,7 @@ export function createApiServer(
         const name = decodeURIComponent(markdownMatch[1]);
         const filePath = decodeURIComponent(markdownMatch[2]);
 
-        const fullPath = join(home, "collections", name, "markdown", filePath);
+        const fullPath = join(home, "collections", name, "content", filePath);
 
         // Prevent path traversal
         const collectionsBase = join(home, "collections", name);
@@ -283,8 +283,8 @@ export function createApiServer(
 
         const colDb = getCollectionDb(dbPath);
 
-        // Look up entity by markdown_path (try with and without markdown/ prefix)
-        const pathVariants = [`markdown/${filePath}`, filePath];
+        // Look up entity by markdown_path (try with and without content/ prefix)
+        const pathVariants = [`content/${filePath}`, filePath];
         let entity = null;
         for (const variant of pathVariants) {
           const [row] = colDb
@@ -461,14 +461,15 @@ export function createApiServer(
             });
             for (const r of results) {
               const [entity] = colDb
-                .select({ markdownPath: entities.markdownPath })
+                .select({ markdownPath: entities.markdownPath, title: entities.title })
                 .from(entities)
                 .where(eq(entities.id, r.entityId))
                 .all();
               const rawPath = entity?.markdownPath ?? null;
-              const markdownPath = rawPath ? rawPath.replace(/^markdown\//, "") : null;
+              const markdownPath = rawPath ? rawPath.replace(/^content\//, "") : null;
               allResults.push({
                 ...r,
+                title: entity?.title ?? r.title,
                 collection: col.name,
                 markdownPath,
                 snippet: r.snippet,
@@ -501,15 +502,15 @@ export function createApiServer(
         const colDb = getCollectionDb(dbPath);
 
         // Find the target entity by markdown path variants
-        const targetVariants = [targetFile, `markdown/${targetFile}`];
+        const targetVariants = [targetFile, `content/${targetFile}`];
         if (!targetFile.endsWith(".md")) {
-          targetVariants.push(`${targetFile}.md`, `markdown/${targetFile}.md`);
+          targetVariants.push(`${targetFile}.md`, `content/${targetFile}.md`);
         }
         const filename = targetFile.includes("/") ? targetFile.split("/").pop()! : null;
         if (filename) {
-          targetVariants.push(filename, `markdown/${filename}`);
+          targetVariants.push(filename, `content/${filename}`);
           if (!filename.endsWith(".md")) {
-            targetVariants.push(`${filename}.md`, `markdown/${filename}.md`);
+            targetVariants.push(`${filename}.md`, `content/${filename}.md`);
           }
         }
 
@@ -551,7 +552,7 @@ export function createApiServer(
               .all();
 
             if (entity) {
-              const relPath = entity.markdownPath?.replace(/^markdown\//, "");
+              const relPath = entity.markdownPath?.replace(/^content\//, "");
               const displayTitle = relPath
                 ? relPath.replace(/\.md$/, "").split("/").pop()!
                 : entity.title;
@@ -587,7 +588,7 @@ export function createApiServer(
         const colDb = getCollectionDb(dbPath);
 
         // Find source entity by markdown path variants
-        const sourceVariants = [sourceFile, `markdown/${sourceFile}`];
+        const sourceVariants = [sourceFile, `content/${sourceFile}`];
 
         // Resolve source entity IDs
         const sourceEntityIds = new Set<number>();
@@ -625,7 +626,7 @@ export function createApiServer(
 
             if (entity) {
               const relPath = entity.markdownPath
-                ? entity.markdownPath.replace(/^markdown\//, "")
+                ? entity.markdownPath.replace(/^content\//, "")
                 : null;
               const displayTitle = relPath
                 ? relPath.replace(/\.md$/, "").split("/").pop()!

--- a/packages/core/src/crawler/index.ts
+++ b/packages/core/src/crawler/index.ts
@@ -4,6 +4,7 @@ export type {
   SyncCursor,
   SyncResult,
   CrawlerEntityData,
+  AssetFilter,
 } from "./interface";
 export { CrawlerRegistry, type CrawlerFactory } from "./registry";
 export { SyncEngine, type SyncEngineOptions, extractWikilinks } from "./sync-engine";

--- a/packages/core/src/crawler/interface.ts
+++ b/packages/core/src/crawler/interface.ts
@@ -2,6 +2,13 @@ export interface SyncCursor {
   [key: string]: unknown;
 }
 
+export interface AssetFilter {
+  /** Maximum allowed file size in bytes. */
+  maxSizeBytes: number;
+  /** Allowed file extensions (lowercase, with dot, e.g. ".png"). */
+  allowedExtensions: Set<string>;
+}
+
 export interface CrawlerEntityData {
   externalId: string;
   entityType: string;
@@ -50,4 +57,10 @@ export interface Crawler {
     credentials: Record<string, unknown>,
   ): Promise<boolean>;
   dispose(): Promise<void>;
+  /**
+   * Optional: set the asset download filter before sync runs.
+   * Crawlers that support it will skip downloading attachments that don't
+   * match the filter, avoiding unnecessary network requests and errors.
+   */
+  setAssetFilter?(filter: AssetFilter): void;
 }

--- a/packages/core/src/crawler/sync-engine.ts
+++ b/packages/core/src/crawler/sync-engine.ts
@@ -165,6 +165,12 @@ export class SyncEngine {
     const startedAt = new Date().toISOString().replace("T", " ").replace("Z", "");
     const syncType = options?.syncType ?? "incremental";
 
+    // Pass asset filter to the crawler so it can skip downloads pre-emptively
+    this.crawler.setAssetFilter?.({
+      maxSizeBytes: this.maxAssetSizeBytes,
+      allowedExtensions: this.allowedExtensions,
+    });
+
     // Create sync_run record
     this.db
       .insert(syncRuns)
@@ -328,6 +334,19 @@ export class SyncEngine {
     if (existing) {
       // Compare hash — skip re-render if unchanged
       if (existing.contentHash === contentHash) {
+        // Still update title/url — cheap metadata that can change without content changing
+        // (e.g. title format updates, URL changes).
+        if (existing.title !== entityData.title || existing.url !== (entityData.url ?? null)) {
+          this.db
+            .update(entities)
+            .set({
+              title: entityData.title,
+              url: entityData.url ?? null,
+              updatedAt: new Date().toISOString().replace("T", " ").replace("Z", ""),
+            })
+            .where(eq(entities.id, existing.id))
+            .run();
+        }
         return { created: 0, updated: 0 };
       }
 
@@ -690,10 +709,24 @@ export class SyncEngine {
   private async reRenderAllEntities(crawlerType: string): Promise<void> {
     const allEntities = this.db.select().from(entities).all();
     for (const row of allEntities) {
+      // Re-derive title from stored data via the theme (no API call needed).
+      const derivedTitle = this.themeEngine.getTitle({
+        entity: {
+          externalId: row.externalId,
+          entityType: row.entityType,
+          title: row.title,
+          data: row.data as Record<string, unknown>,
+          url: row.url ?? undefined,
+        },
+        collectionName: this.collectionName,
+        crawlerType,
+      });
+      const title = derivedTitle ?? row.title;
+
       const entityData: CrawlerEntityData = {
         externalId: row.externalId,
         entityType: row.entityType,
-        title: row.title,
+        title,
         data: row.data,
         url: row.url ?? undefined,
       };
@@ -710,6 +743,7 @@ export class SyncEngine {
       this.db
         .update(entities)
         .set({
+          title,
           markdownPath: filePath,
           markdownMtime: stat?.mtimeMs ?? null,
           markdownSize: stat?.size ?? null,
@@ -725,7 +759,7 @@ export class SyncEngine {
         id: row.id,
         externalId: row.externalId,
         entityType: row.entityType,
-        title: row.title,
+        title,
         content: markdown,
         tags: [],
       });

--- a/packages/core/src/theme/engine.ts
+++ b/packages/core/src/theme/engine.ts
@@ -27,6 +27,11 @@ export class ThemeEngine {
     return theme.getFilePath(context);
   }
 
+  getTitle(context: ThemeRenderContext): string | undefined {
+    const theme = this.themes.get(context.crawlerType);
+    return theme?.getTitle?.(context);
+  }
+
   hasHtmlRenderer(crawlerType: string): boolean {
     const theme = this.themes.get(crawlerType);
     return !!theme?.renderHtml;

--- a/packages/core/src/theme/interface.ts
+++ b/packages/core/src/theme/interface.ts
@@ -34,4 +34,10 @@ export interface Theme {
    * Returns null/undefined if not supported for this entity.
    */
   renderHtml?(context: ThemeRenderContext): string | null;
+  /**
+   * Optional: derive the display title from stored entity data.
+   * Used during re-generation to update the title in the DB without re-fetching
+   * from the source API. Returns undefined if the theme cannot derive a title.
+   */
+  getTitle?(context: ThemeRenderContext): string | undefined;
 }

--- a/packages/crawlers/src/mantisbt/crawler.ts
+++ b/packages/crawlers/src/mantisbt/crawler.ts
@@ -4,6 +4,7 @@ import type {
   CrawlerEntityData,
   SyncCursor,
   SyncResult,
+  AssetFilter,
 } from "@frozenink/core";
 import { createCryptoHasher } from "@frozenink/core";
 import type {
@@ -93,7 +94,7 @@ export class MantisBTCrawler implements Crawler {
     displayName: "MantisBT Issue Tracker",
     description:
       "Crawls a MantisBT instance via its REST API, syncing issues from newest to oldest",
-    version: "3.1",
+    version: "3.2",
     configSchema: {
       url: {
         type: "string",
@@ -121,6 +122,19 @@ export class MantisBTCrawler implements Crawler {
   private mantisHubMode = false;
   private syncEntities?: MantisBTEntityType[];
   private fetchFn: typeof fetch = globalThis.fetch;
+  private assetFilter: AssetFilter | null = null;
+
+  setAssetFilter(filter: AssetFilter): void {
+    this.assetFilter = filter;
+  }
+
+  /** Returns true if the attachment should be downloaded based on extension and size. */
+  private shouldDownloadAttachment(filename: string, sizeBytes: number): boolean {
+    if (!this.assetFilter) return true;
+    const dot = filename.lastIndexOf(".");
+    const ext = dot === -1 ? "" : filename.slice(dot).toLowerCase();
+    return this.assetFilter.allowedExtensions.has(ext) && sizeBytes <= this.assetFilter.maxSizeBytes;
+  }
 
   /** Accept both new field names and legacy field names for backward compat. */
   private static resolveConfig(config: Record<string, unknown>): MantisBTConfig {
@@ -753,6 +767,8 @@ export class MantisBTCrawler implements Crawler {
       const storedName = assetFilename(file.id, file.name);
       const storagePath = `${assetPrefix}/${storedName}`;
 
+      if (!this.shouldDownloadAttachment(file.name, file.size)) continue;
+
       // The download_url from Pages is relative; make it absolute.
       let downloadUrl = file.download_url;
       if (downloadUrl && !downloadUrl.startsWith("http")) {
@@ -933,31 +949,40 @@ export class MantisBTCrawler implements Crawler {
     }
 
     // Download attachments; track storage paths that were successfully saved.
-    // Uses core MantisBT REST API first. On MantisHub instances, if the core
-    // API fails, falls back to the ApiX IssueViewPage for signed download URLs.
+    // On MantisHub instances, signed URLs (via ApiX IssueViewPage) are fetched
+    // upfront and used as the primary download method — more efficient than the
+    // MantisBT REST API which may not serve cloud-stored files. On plain MantisBT
+    // the REST API is used directly.
     const entityAttachments: CrawlerEntityData["attachments"] = [];
     const savedPaths = new Set<string>();
-    let mantisHubUrls: Map<number, AttachmentUrlInfo> | null = null;
     const assetPrefix = this.assetDir("issues", issue.project?.name);
+
+    // For MantisHub: eagerly fetch all signed URLs once for this issue.
+    const mantisHubUrls: Map<number, AttachmentUrlInfo> = this.mantisHubMode
+      ? await this.fetchMantisHubAttachmentUrls(issue.id)
+      : new Map();
 
     for (const file of issue.attachments ?? []) {
       const storedName = assetFilename(file.id, file.filename);
       const storagePath = `${assetPrefix}/${storedName}`;
-      let content = await this.downloadAttachment(
-        issue.id, file.id, file.download_url,
-        `issue ${issue.id} file "${file.filename}"`,
-      );
 
-      // MantisHub fallback: fetch signed URLs if core API failed
-      if (!content && this.mantisHubMode) {
-        if (!mantisHubUrls) {
-          mantisHubUrls = await this.fetchMantisHubAttachmentUrls(issue.id);
-        }
+      if (!this.shouldDownloadAttachment(file.filename, file.size)) continue;
+
+      let content: Buffer | null = null;
+      const label = `issue ${issue.id} file "${file.filename}"`;
+
+      if (this.mantisHubMode) {
+        // MantisHub: use signed URL first, fall back to REST API
         const urlInfo = mantisHubUrls.get(file.id);
         const signedUrl = urlInfo?.signedUrl ?? urlInfo?.url;
         if (signedUrl) {
-          content = await this.downloadBinary(signedUrl, `issue ${issue.id} file "${file.filename}" (MantisHub)`);
+          content = await this.downloadBinary(signedUrl, `${label} (MantisHub)`);
         }
+        if (!content) {
+          content = await this.downloadAttachment(issue.id, file.id, file.download_url, label);
+        }
+      } else {
+        content = await this.downloadAttachment(issue.id, file.id, file.download_url, label);
       }
 
       if (content) {
@@ -975,21 +1000,24 @@ export class MantisBTCrawler implements Crawler {
       for (const att of note.attachments ?? []) {
         const storedName = assetFilename(att.id, att.filename);
         const storagePath = `${assetPrefix}/${storedName}`;
-        let content = await this.downloadAttachment(
-          issue.id, att.id, att.download_url,
-          `issue ${issue.id} note ${note.id} file "${att.filename}"`,
-        );
 
-        // MantisHub fallback: fetch signed URLs if core API failed
-        if (!content && this.mantisHubMode) {
-          if (!mantisHubUrls) {
-            mantisHubUrls = await this.fetchMantisHubAttachmentUrls(issue.id);
-          }
+        if (!this.shouldDownloadAttachment(att.filename, att.size)) continue;
+
+        let content: Buffer | null = null;
+        const label = `issue ${issue.id} note ${note.id} file "${att.filename}"`;
+
+        if (this.mantisHubMode) {
+          // MantisHub: use signed URL first, fall back to REST API
           const urlInfo = mantisHubUrls.get(att.id);
           const signedUrl = urlInfo?.signedUrl ?? urlInfo?.url;
           if (signedUrl) {
-            content = await this.downloadBinary(signedUrl, `issue ${issue.id} note ${note.id} file "${att.filename}" (MantisHub)`);
+            content = await this.downloadBinary(signedUrl, `${label} (MantisHub)`);
           }
+          if (!content) {
+            content = await this.downloadAttachment(issue.id, att.id, att.download_url, label);
+          }
+        } else {
+          content = await this.downloadAttachment(issue.id, att.id, att.download_url, label);
         }
 
         if (content) {
@@ -1007,7 +1035,7 @@ export class MantisBTCrawler implements Crawler {
     return {
       externalId: `issue:${issue.id}`,
       entityType: "issue",
-      title: issue.summary,
+      title: `${padId(issue.id)}: ${issue.summary}`,
       contentHash,
       url: `${this.baseUrl}/view.php?id=${issue.id}`,
       data: {

--- a/packages/crawlers/src/mantisbt/theme.ts
+++ b/packages/crawlers/src/mantisbt/theme.ts
@@ -382,6 +382,27 @@ export class MantisBTTheme implements Theme {
     return this.renderIssueHtml(context);
   }
 
+  getTitle(context: ThemeRenderContext): string | undefined {
+    const d = context.entity.data;
+    switch (context.entity.entityType) {
+      case "issue":
+        return d.id != null && d.summary != null
+          ? `${padId(d.id as number)}: ${d.summary as string}`
+          : undefined;
+      case "page":
+        return ((d.title || d.name) as string) || undefined;
+      case "user": {
+        const realName = d.realName as string | null;
+        const name = d.name as string;
+        return realName ? `${realName} (@${name})` : name;
+      }
+      case "project":
+        return (d.name as string) || undefined;
+      default:
+        return undefined;
+    }
+  }
+
   private renderIssueHtml(context: ThemeRenderContext): string {
     const d = context.entity.data;
     const lookup = context.lookupEntityPath;
@@ -863,7 +884,7 @@ export class MantisBTTheme implements Theme {
 
     // Frontmatter
     const fm: Record<string, unknown> = {
-      title: d.summary,
+      title: `${padId(d.id as number)}: ${d.summary}`,
       type: "issue",
       id: d.id,
       status: status.name,

--- a/packages/mcp/src/tools/get-attachment.ts
+++ b/packages/mcp/src/tools/get-attachment.ts
@@ -90,7 +90,7 @@ function buildCandidates(refPath: string, markdownPath: string | null): string[]
       candidates.add(`assets/${relResolved}`);
     }
 
-    const relResolvedNoMd = posix.normalize(posix.join(markdownDir.replace(/^markdown\/?/, ""), clean));
+    const relResolvedNoMd = posix.normalize(posix.join(markdownDir.replace(/^content\/?/, ""), clean));
     candidates.add(relResolvedNoMd);
     if (!relResolvedNoMd.startsWith("assets/")) {
       candidates.add(`assets/${relResolvedNoMd}`);

--- a/packages/mcp/src/tools/search.ts
+++ b/packages/mcp/src/tools/search.ts
@@ -74,7 +74,7 @@ async function runSearch(
           .where(eq(entities.id, r.entityId))
           .all();
         const rawPath = entity?.markdownPath ?? null;
-        const filename = rawPath ? rawPath.replace(/^markdown\//, "") : null;
+        const filename = rawPath ? rawPath.replace(/^content\//, "") : null;
         allResults.push({ ...r, collection: col.name, filename });
       }
     } finally {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4,7 +4,7 @@ import CollectionPicker from "./components/CollectionPicker";
 import FileTree from "./components/FileTree";
 import MarkdownView from "./components/MarkdownView";
 import HtmlView from "./components/HtmlView";
-import SearchBar from "./components/SearchBar";
+import SearchBar, { type FileEntry } from "./components/SearchBar";
 import FullTextSearch from "./components/FullTextSearch";
 import ThemeSwitcher, { type ThemeId } from "./components/ThemeSwitcher";
 import ViewModeToggle, { type ViewMode } from "./components/ViewModeToggle";
@@ -222,6 +222,21 @@ export default function App() {
         if (node.children) paths.push(...flatten(node.children));
       }
       return paths;
+    }
+    return flatten(fileTree);
+  }, [fileTree]);
+
+  // File entries with titles for Cmd+P search
+  const fileEntries = useMemo(() => {
+    function flatten(nodes: TreeNode[]): FileEntry[] {
+      const out: FileEntry[] = [];
+      for (const node of nodes) {
+        if (node.type === "file") {
+          out.push({ path: node.path, title: node.title ?? node.name.replace(/\.md$/, "") });
+        }
+        if (node.children) out.push(...flatten(node.children));
+      }
+      return out;
     }
     return flatten(fileTree);
   }, [fileTree]);
@@ -1094,7 +1109,7 @@ export default function App() {
       />
       {searchOpen && (
         <SearchBar
-          files={allFiles}
+          files={fileEntries}
           collection={selectedCollection ?? ""}
           onClose={() => setSearchOpen(false)}
           onNavigate={handleSearchNavigate}

--- a/packages/ui/src/__tests__/SearchBar.test.tsx
+++ b/packages/ui/src/__tests__/SearchBar.test.tsx
@@ -4,8 +4,8 @@ import userEvent from "@testing-library/user-event";
 import SearchBar from "../components/SearchBar";
 
 const FILES = [
-  "issues/1-fix-login-bug.md",
-  "pull-requests/2-add-auth-feature.md",
+  { path: "issues/1-fix-login-bug.md", title: "1: Fix login bug" },
+  { path: "pull-requests/2-add-auth-feature.md", title: "2: Add auth feature" },
 ];
 
 beforeEach(() => {

--- a/packages/ui/src/components/BacklinksPanel.tsx
+++ b/packages/ui/src/components/BacklinksPanel.tsx
@@ -39,7 +39,7 @@ export default function BacklinksPanel({ backlinks, open, onNavigate }: Backlink
                 className="backlink-item"
                 onClick={() => {
                   if (bl.markdownPath) {
-                    const path = bl.markdownPath.replace(/^markdown\//, "");
+                    const path = bl.markdownPath.replace(/^content\//, "");
                     onNavigate(path);
                   }
                 }}

--- a/packages/ui/src/components/LinksPanel.tsx
+++ b/packages/ui/src/components/LinksPanel.tsx
@@ -90,7 +90,7 @@ export default function LinksPanel({ backlinks, outgoingLinks, open, onNavigate 
     .sort((a, b) => a.title.localeCompare(b.title))
     .map((bl) => ({
       title: bl.title,
-      markdownPath: bl.markdownPath ? bl.markdownPath.replace(/^markdown\//, "") : null,
+      markdownPath: bl.markdownPath ? bl.markdownPath.replace(/^content\//, "") : null,
     }));
 
   return (

--- a/packages/ui/src/components/SearchBar.tsx
+++ b/packages/ui/src/components/SearchBar.tsx
@@ -1,15 +1,15 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 
+export interface FileEntry {
+  path: string;
+  title: string;
+}
+
 interface SearchBarProps {
-  files: string[];
+  files: FileEntry[];
   collection: string;
   onClose: () => void;
   onNavigate: (collection: string, markdownPath: string, openNewTab?: boolean) => void;
-}
-
-/** Title from a file path: strip folders and .md extension. */
-function titleFromPath(filePath: string): string {
-  return filePath.replace(/\.md$/, "").split("/").pop() ?? filePath;
 }
 
 interface FuzzyMatch {
@@ -110,10 +110,9 @@ export default function SearchBar({ files, collection, onClose, onNavigate }: Se
     const q = query.trim();
     if (!q) return [];
     const matches: FuzzyMatch[] = [];
-    for (const filePath of files) {
-      const title = titleFromPath(filePath);
-      const m = fuzzyMatch(q, title);
-      if (m) matches.push({ filePath, title, indices: m.indices, score: m.score });
+    for (const file of files) {
+      const m = fuzzyMatch(q, file.title);
+      if (m) matches.push({ filePath: file.path, title: file.title, indices: m.indices, score: m.score });
     }
     matches.sort((a, b) => a.score - b.score);
     return matches.slice(0, 30);

--- a/packages/worker/src/db/client.ts
+++ b/packages/worker/src/db/client.ts
@@ -65,8 +65,8 @@ export async function getEntityByMarkdownPath(
   collectionName: string,
   markdownPath: string,
 ): Promise<Entity | null> {
-  // Try with and without "markdown/" prefix
-  const variants = [`markdown/${markdownPath}`, markdownPath];
+  // Try with and without "content/" prefix
+  const variants = [`content/${markdownPath}`, markdownPath];
   for (const variant of variants) {
     const result = await db
       .prepare("SELECT * FROM entities WHERE collection_name = ? AND markdown_path = ?")
@@ -87,7 +87,7 @@ export async function getEntityMarkdownPathByExternalId(
     .bind(collectionName, externalId)
     .first<{ markdown_path: string | null }>();
   if (!result?.markdown_path) return null;
-  const prefix = "markdown/";
+  const prefix = "content/";
   const rel = result.markdown_path.startsWith(prefix)
     ? result.markdown_path.slice(prefix.length)
     : result.markdown_path;

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -72,7 +72,7 @@ api.get("/api/collections/:name/html/*", async (c) => {
   const entityPathMap = new Map<string, string>();
   for (const row of allEntities) {
     if (!row.markdown_path) continue;
-    const prefix = "markdown/";
+    const prefix = "content/";
     const rel = row.markdown_path.startsWith(prefix) ? row.markdown_path.slice(prefix.length) : row.markdown_path;
     entityPathMap.set(row.external_id, rel.endsWith(".md") ? rel.slice(0, -3) : rel);
   }
@@ -100,7 +100,7 @@ api.get("/api/collections/:name/html/*", async (c) => {
 // GET /api/collections/:name/tree
 api.get("/api/collections/:name/tree", async (c) => {
   const name = c.req.param("name");
-  const prefix = `${name}/markdown/`;
+  const prefix = `${name}/content/`;
 
   const listed = await c.env.BUCKET.list({ prefix });
   const paths = listed.objects.map((o) => o.key.slice(prefix.length)).filter((p) => p.endsWith(".md"));
@@ -111,7 +111,7 @@ api.get("/api/collections/:name/tree", async (c) => {
     const { results } = await c.env.DB.prepare(
       "SELECT markdown_path, title FROM entities WHERE collection_name = ? AND markdown_path IS NOT NULL AND title IS NOT NULL",
     ).bind(name).all<{ markdown_path: string; title: string }>();
-    const mdPrefix = "markdown/";
+    const mdPrefix = "content/";
     for (const row of results ?? []) {
       const rel = row.markdown_path.startsWith(mdPrefix)
         ? row.markdown_path.slice(mdPrefix.length)
@@ -132,7 +132,7 @@ api.get("/api/collections/:name/default-file", async (c) => {
   const name = c.req.param("name");
   const entities = await getEntities(c.env.DB, name, { limit: 1 });
   const first = entities[0];
-  const filePath = first?.markdown_path?.replace(/^markdown\//, "") ?? null;
+  const filePath = first?.markdown_path?.replace(/^content\//, "") ?? null;
   return c.json({ file: filePath });
 });
 
@@ -142,7 +142,7 @@ api.get("/api/collections/:name/markdown/*", async (c) => {
   const filePath = c.req.path.replace(`/api/collections/${encodeURIComponent(name)}/markdown/`, "");
   const decoded = decodeURIComponent(filePath);
 
-  const r2Key = `${name}/markdown/${decoded}`;
+  const r2Key = `${name}/content/${decoded}`;
   const obj = await getR2Object(c.env.BUCKET, r2Key);
   if (!obj) return c.text("File not found", 404);
 
@@ -202,8 +202,8 @@ api.get("/api/search", async (c) => {
     results.map(async (r) => {
       const entity = await getEntityByExternalId(c.env.DB, r.collectionName, r.externalId);
       const rawPath = entity?.markdown_path ?? null;
-      const markdownPath = rawPath ? rawPath.replace(/^markdown\//, "") : null;
-      return { ...r, collection: r.collectionName, markdownPath, snippet: r.snippet };
+      const markdownPath = rawPath ? rawPath.replace(/^content\//, "") : null;
+      return { ...r, title: entity?.title ?? r.title, collection: r.collectionName, markdownPath, snippet: r.snippet };
     }),
   );
 
@@ -221,7 +221,7 @@ api.get("/api/collections/:name/backlinks/:externalId", async (c) => {
   const links = await getBacklinks(c.env.DB, name, targetEntity.id);
 
   const results = links.map(({ entity }) => {
-    const relPath = entity.markdown_path?.replace(/^markdown\//, "");
+    const relPath = entity.markdown_path?.replace(/^content\//, "");
     const displayTitle = relPath
       ? relPath.replace(/\.md$/, "").split("/").pop()!
       : entity.title;
@@ -251,7 +251,7 @@ api.get("/api/collections/:name/outgoing-links/:externalId", async (c) => {
     .filter(({ entity }) => entity !== null)
     .map(({ entity }) => {
       const relPath = entity!.markdown_path
-        ? entity!.markdown_path.replace(/^markdown\//, "")
+        ? entity!.markdown_path.replace(/^content\//, "")
         : null;
       const displayTitle = relPath
         ? relPath.replace(/\.md$/, "").split("/").pop()!


### PR DESCRIPTION
## Summary

- **Collection content not showing**: `serve`, `generate`, `index`, `worker`, and `mcp` were reading from `markdown/` (legacy path); all now use `content/` (canonical)
- **Slugs in FileTree/Cmd+P**: UI bundle was stale (pre-dating the title display commit); rebuilt. `SearchBar` now uses entity titles from tree nodes instead of deriving from filenames. Search endpoints read `title` from `entities` table rather than the FTS index copy
- **Large attachment download attempts**: Added `AssetFilter` interface and `setAssetFilter()` on the `Crawler` interface; MantisBT crawler pre-checks file size and extension before any network request
- **MantisHub signed URLs**: Fetch all signed URLs upfront once per issue and use as primary download method, falling back to REST API only if needed
- **Issue title format**: MantisBT issue titles now formatted as `"00044: Update MantisTouch screenshots in docs"` — consistently in the FileTree, Cmd+P, and FTS search results
- **Re-generation without re-sync**: Added `Theme.getTitle()` so `fink generate` re-derives titles from stored JSON data; minor version bump (3.1 → 3.2) triggers `reRenderAllEntities` which also updates DB titles

## Test plan

- [ ] `fink serve` — collection tree shows human-readable titles (not slugs)
- [ ] `fink generate <collection>` — updates issue titles to `<padded-id>: <summary>` format without re-syncing from API
- [ ] `fink sync <collection>` — attachments larger than 10 MB or with disallowed extensions are skipped before download
- [ ] On MantisHub collections, attachments use signed URLs (faster, no 500 errors on cloud-stored files)
- [ ] Cmd+P shows `"00044: Update MantisTouch screenshots in docs"` format after generate
- [ ] Shift+Cmd+F full-text search results use same title format

🤖 Generated with [Claude Code](https://claude.com/claude-code)