### PR TITLE
Auto-regenerate stale collections on serve and handle port conflicts

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -16,9 +16,196 @@ import {
   LocalStorageBackend,
   SearchIndexer,
   extractWikilinks,
+  CollectionEntry,
 } from "@frozenink/core";
 import { eq } from "drizzle-orm";
-import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme, mantisBTTheme } from "@frozenink/crawlers";
+import { gitHubTheme, obsidianTheme, gitTheme, mantisBTTheme } from "@frozenink/crawlers";
+
+export function createGenerateThemeEngine(): ThemeEngine {
+  const themeEngine = new ThemeEngine();
+  themeEngine.register(gitHubTheme);
+  themeEngine.register(obsidianTheme);
+  themeEngine.register(gitTheme);
+  themeEngine.register(mantisBTTheme);
+  return themeEngine;
+}
+
+/**
+ * Re-generate markdown files for a single collection from its stored entity data.
+ * Returns a summary string (e.g. "Generated 42 files from 42 entities").
+ */
+export async function generateCollection(
+  col: CollectionEntry & { name: string },
+  home: string,
+  themeEngine: ThemeEngine,
+): Promise<string | null> {
+  const dbPath = getCollectionDbPath(col.name);
+  if (!existsSync(dbPath)) {
+    return null;
+  }
+
+  if (!themeEngine.has(col.crawler)) {
+    return null;
+  }
+
+  const colDb = getCollectionDb(dbPath);
+  const collectionDir = join(home, "collections", col.name);
+  const storage = new LocalStorageBackend(collectionDir);
+  const markdownBasePath = "content";
+
+  // Build a lookup function for cross-entity wikilinks (used by some themes)
+  const entityPathLookup = (externalId: string): string | undefined => {
+    const rows = colDb
+      .select({ markdownPath: entities.markdownPath })
+      .from(entities)
+      .where(eq(entities.externalId, externalId))
+      .all();
+    const markdownPath = rows[0]?.markdownPath;
+    if (!markdownPath) return undefined;
+    const base = `${markdownBasePath}/`;
+    const relative = markdownPath.startsWith(base)
+      ? markdownPath.slice(base.length)
+      : markdownPath;
+    return relative.endsWith(".md") ? relative.slice(0, -3) : relative;
+  };
+
+  // Build stem-matching wikilink resolver (for Obsidian [[bare name]] links)
+  const allEntityRows = colDb
+    .select({ externalId: entities.externalId, markdownPath: entities.markdownPath })
+    .from(entities)
+    .all();
+  const byExtId = new Map<string, string>();
+  const byStem = new Map<string, string>();
+  const base = `${markdownBasePath}/`;
+  for (const r of allEntityRows) {
+    if (!r.markdownPath) continue;
+    const rel = r.markdownPath.startsWith(base) ? r.markdownPath.slice(base.length) : r.markdownPath;
+    const noExt = rel.endsWith(".md") ? rel.slice(0, -3) : rel;
+    byExtId.set(r.externalId, noExt);
+    const stem = r.externalId.replace(/\.md$/, "");
+    const stemName = stem.includes("/") ? stem.split("/").pop()! : stem;
+    if (!byStem.has(stemName)) byStem.set(stemName, noExt);
+  }
+  const resolveWikilink = (target: string): string | undefined => {
+    const clean = target.replace(/[#^].*$/, "").trim();
+    if (!clean) return undefined;
+    const withMd = clean.endsWith(".md") ? clean : `${clean}.md`;
+    if (byExtId.has(withMd)) return byExtId.get(withMd);
+    if (byExtId.has(clean)) return byExtId.get(clean);
+    const stemName = clean.includes("/") ? clean.split("/").pop()! : clean;
+    return byStem.get(stemName);
+  };
+
+  const indexer = new SearchIndexer(dbPath);
+  indexer.clearIndex();
+  colDb.delete(links).run();
+
+  const allEntities = colDb.select().from(entities).all();
+  let generated = 0;
+  let renamed = 0;
+
+  for (const entity of allEntities) {
+    const entityTagNames = colDb
+      .select()
+      .from(entityTags)
+      .where(eq(entityTags.entityId, entity.id))
+      .all()
+      .map((t: any) => {
+        const [tagRow] = colDb.select().from(tags).where(eq(tags.id, t.tagId)).all();
+        return tagRow?.name ?? "";
+      })
+      .filter(Boolean);
+
+    // Re-derive title from stored data (no API call needed).
+    const baseCtx = {
+      entity: {
+        externalId: entity.externalId,
+        entityType: entity.entityType,
+        title: entity.title,
+        data: entity.data as Record<string, unknown>,
+        url: entity.url ?? undefined,
+        tags: entityTagNames,
+      },
+      collectionName: col.name,
+      crawlerType: col.crawler,
+      lookupEntityPath: entityPathLookup,
+      resolveWikilink,
+    };
+    const derivedTitle = themeEngine.getTitle(baseCtx);
+    const title = derivedTitle ?? entity.title;
+
+    const renderCtx = derivedTitle ? { ...baseCtx, entity: { ...baseCtx.entity, title } } : baseCtx;
+
+    const newPath = `${markdownBasePath}/${themeEngine.getFilePath(renderCtx)}`;
+    const markdown = themeEngine.render(renderCtx);
+
+    // Handle rename: delete old file if path changed
+    if (entity.markdownPath && entity.markdownPath !== newPath) {
+      try {
+        await storage.delete(entity.markdownPath);
+      } catch {
+        // File may already be gone
+      }
+      renamed++;
+    }
+
+    // Write new markdown file
+    await storage.write(newPath, markdown);
+    const fileStat = await storage.stat(newPath);
+
+    // Update entity record with new path, mtime, and re-derived title
+    colDb
+      .update(entities)
+      .set({
+        title,
+        markdownPath: newPath,
+        markdownMtime: fileStat?.mtimeMs ?? null,
+        markdownSize: fileStat?.size ?? null,
+      })
+      .where(eq(entities.id, entity.id))
+      .run();
+
+    // Rebuild FTS index
+    indexer.updateIndex({
+      id: entity.id,
+      externalId: entity.externalId,
+      entityType: entity.entityType,
+      title,
+      content: markdown,
+      tags: entityTagNames,
+    });
+
+    // Rebuild entity links
+    const sourceFile = newPath.startsWith(markdownBasePath + "/")
+      ? newPath.slice(markdownBasePath.length + 1)
+      : undefined;
+    const targets = extractWikilinks(markdown, sourceFile);
+    for (const target of targets) {
+      const targetPath = `${markdownBasePath}/${target}.md`;
+      const [targetEntity] = colDb
+        .select({ id: entities.id })
+        .from(entities)
+        .where(eq(entities.markdownPath, targetPath))
+        .all();
+      if (targetEntity) {
+        colDb
+          .insert(links)
+          .values({
+            sourceEntityId: entity.id,
+            targetEntityId: targetEntity.id,
+          })
+          .run();
+      }
+    }
+
+    generated++;
+  }
+
+  indexer.close();
+
+  const renameNote = renamed > 0 ? `, ${renamed} renamed` : "";
+  return `Generated ${generated} files from ${allEntities.length} entities${renameNote}`;
+}
 
 export const generateCommand = new Command("generate")
   .description(
@@ -47,11 +234,7 @@ export const generateCommand = new Command("generate")
       return;
     }
 
-    const themeEngine = new ThemeEngine();
-    themeEngine.register(gitHubTheme);
-    themeEngine.register(obsidianTheme);
-    themeEngine.register(gitTheme);
-    themeEngine.register(mantisBTTheme);
+    const themeEngine = createGenerateThemeEngine();
 
     for (const col of collectionRows) {
       console.log(`Generating "${col.name}" (${col.crawler})...`);
@@ -67,164 +250,9 @@ export const generateCommand = new Command("generate")
         continue;
       }
 
-      const colDb = getCollectionDb(dbPath);
-      const collectionDir = join(home, "collections", col.name);
-      const storage = new LocalStorageBackend(collectionDir);
-      const markdownBasePath = "content";
-
-      // Build a lookup function for cross-entity wikilinks (used by some themes)
-      const entityPathLookup = (externalId: string): string | undefined => {
-        const rows = colDb
-          .select({ markdownPath: entities.markdownPath })
-          .from(entities)
-          .where(eq(entities.externalId, externalId))
-          .all();
-        const markdownPath = rows[0]?.markdownPath;
-        if (!markdownPath) return undefined;
-        const base = `${markdownBasePath}/`;
-        const relative = markdownPath.startsWith(base)
-          ? markdownPath.slice(base.length)
-          : markdownPath;
-        return relative.endsWith(".md") ? relative.slice(0, -3) : relative;
-      };
-
-      // Build stem-matching wikilink resolver (for Obsidian [[bare name]] links)
-      const allEntityRows = colDb
-        .select({ externalId: entities.externalId, markdownPath: entities.markdownPath })
-        .from(entities)
-        .all();
-      const byExtId = new Map<string, string>();
-      const byStem = new Map<string, string>();
-      const base = `${markdownBasePath}/`;
-      for (const r of allEntityRows) {
-        if (!r.markdownPath) continue;
-        const rel = r.markdownPath.startsWith(base) ? r.markdownPath.slice(base.length) : r.markdownPath;
-        const noExt = rel.endsWith(".md") ? rel.slice(0, -3) : rel;
-        byExtId.set(r.externalId, noExt);
-        const stem = r.externalId.replace(/\.md$/, "");
-        const stemName = stem.includes("/") ? stem.split("/").pop()! : stem;
-        if (!byStem.has(stemName)) byStem.set(stemName, noExt);
+      const summary = await generateCollection(col, home, themeEngine);
+      if (summary) {
+        console.log(`  ${summary}`);
       }
-      const resolveWikilink = (target: string): string | undefined => {
-        const clean = target.replace(/[#^].*$/, "").trim();
-        if (!clean) return undefined;
-        const withMd = clean.endsWith(".md") ? clean : `${clean}.md`;
-        if (byExtId.has(withMd)) return byExtId.get(withMd);
-        if (byExtId.has(clean)) return byExtId.get(clean);
-        const stemName = clean.includes("/") ? clean.split("/").pop()! : clean;
-        return byStem.get(stemName);
-      };
-
-      const indexer = new SearchIndexer(dbPath);
-      indexer.clearIndex();
-      colDb.delete(links).run();
-
-      const allEntities = colDb.select().from(entities).all();
-      let generated = 0;
-      let renamed = 0;
-
-      for (const entity of allEntities) {
-        const entityTagNames = colDb
-          .select()
-          .from(entityTags)
-          .where(eq(entityTags.entityId, entity.id))
-          .all()
-          .map((t: any) => {
-            const [tagRow] = colDb.select().from(tags).where(eq(tags.id, t.tagId)).all();
-            return tagRow?.name ?? "";
-          })
-          .filter(Boolean);
-
-        // Re-derive title from stored data (no API call needed).
-        const baseCtx = {
-          entity: {
-            externalId: entity.externalId,
-            entityType: entity.entityType,
-            title: entity.title,
-            data: entity.data as Record<string, unknown>,
-            url: entity.url ?? undefined,
-            tags: entityTagNames,
-          },
-          collectionName: col.name,
-          crawlerType: col.crawler,
-          lookupEntityPath: entityPathLookup,
-          resolveWikilink,
-        };
-        const derivedTitle = themeEngine.getTitle(baseCtx);
-        const title = derivedTitle ?? entity.title;
-
-        const renderCtx = derivedTitle ? { ...baseCtx, entity: { ...baseCtx.entity, title } } : baseCtx;
-
-        const newPath = `${markdownBasePath}/${themeEngine.getFilePath(renderCtx)}`;
-        const markdown = themeEngine.render(renderCtx);
-
-        // Handle rename: delete old file if path changed
-        if (entity.markdownPath && entity.markdownPath !== newPath) {
-          try {
-            await storage.delete(entity.markdownPath);
-          } catch {
-            // File may already be gone
-          }
-          renamed++;
-        }
-
-        // Write new markdown file
-        await storage.write(newPath, markdown);
-        const fileStat = await storage.stat(newPath);
-
-        // Update entity record with new path, mtime, and re-derived title
-        colDb
-          .update(entities)
-          .set({
-            title,
-            markdownPath: newPath,
-            markdownMtime: fileStat?.mtimeMs ?? null,
-            markdownSize: fileStat?.size ?? null,
-          })
-          .where(eq(entities.id, entity.id))
-          .run();
-
-        // Rebuild FTS index
-        indexer.updateIndex({
-          id: entity.id,
-          externalId: entity.externalId,
-          entityType: entity.entityType,
-          title,
-          content: markdown,
-          tags: entityTagNames,
-        });
-
-        // Rebuild entity links
-        const sourceFile = newPath.startsWith(markdownBasePath + "/")
-          ? newPath.slice(markdownBasePath.length + 1)
-          : undefined;
-        const targets = extractWikilinks(markdown, sourceFile);
-        for (const target of targets) {
-          const targetPath = `${markdownBasePath}/${target}.md`;
-          const [targetEntity] = colDb
-            .select({ id: entities.id })
-            .from(entities)
-            .where(eq(entities.markdownPath, targetPath))
-            .all();
-          if (targetEntity) {
-            colDb
-              .insert(links)
-              .values({
-                sourceEntityId: entity.id,
-                targetEntityId: targetEntity.id,
-              })
-              .run();
-          }
-        }
-
-        generated++;
-      }
-
-      indexer.close();
-
-      const renameNote = renamed > 0 ? `, ${renamed} renamed` : "";
-      console.log(
-        `  Generated ${generated} files from ${allEntities.length} entities${renameNote}`,
-      );
     }
   });

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -8,6 +8,7 @@ import {
   listCollections,
   getCollection,
   getCollectionDbPath,
+  updateCollection,
   entities,
   entityTags,
   tags,
@@ -21,6 +22,7 @@ import {
   resolveUiDist,
 } from "@frozenink/core";
 import {
+  createDefaultRegistry,
   gitHubTheme,
   obsidianTheme,
   gitTheme,
@@ -29,6 +31,7 @@ import {
 import { startStdioServer } from "@frozenink/mcp";
 import { eq, desc } from "drizzle-orm";
 import { handleManagementRequest, setAppMode } from "./management-api";
+import { generateCollection, createGenerateThemeEngine } from "./generate";
 
 const __moduleDir = getModuleDir(import.meta.url);
 
@@ -148,6 +151,41 @@ function tryServeStatic(
   }
 
   return null;
+}
+
+/**
+ * Check all enabled collections for minor-version upgrades and re-generate
+ * markdown for any that are behind. Logs progress for each collection regenerated.
+ */
+async function checkAndRegenerateCollections(home: string): Promise<void> {
+  const registry = createDefaultRegistry();
+  const themeEngine = createGenerateThemeEngine();
+  const collections = listCollections().filter((c) => c.enabled);
+
+  for (const col of collections) {
+    const factory = registry.get(col.crawler);
+    if (!factory) continue;
+
+    const crawlerVersion = factory().metadata.version ?? "1.0";
+    const collectionVersion = col.version ?? "1.0";
+
+    const [colMajor, colMinor] = collectionVersion.split(".").map(Number);
+    const [crwMajor, crwMinor] = crawlerVersion.split(".").map(Number);
+
+    // Only re-generate when same major but collection minor is older
+    if (colMajor !== crwMajor) continue;
+    if (colMinor >= crwMinor) continue;
+
+    console.log(
+      `Re-generating collection "${col.name}" (${col.crawler} schema ${collectionVersion} → ${crawlerVersion})...`,
+    );
+
+    const summary = await generateCollection(col, home, themeEngine);
+    if (summary) {
+      console.log(`  ${summary}`);
+      updateCollection(col.name, { version: crawlerVersion });
+    }
+  }
 }
 
 export function createApiServer(
@@ -707,8 +745,17 @@ export function createApiServer(
   }
 
   if (isBun) {
-    const server = Bun.serve({ port, fetch: handleRequest });
-    return { port: server.port as number, stop: () => server.stop() };
+    try {
+      const server = Bun.serve({ port, fetch: handleRequest });
+      return { port: server.port as number, stop: () => server.stop() };
+    } catch (err: any) {
+      if (err?.code === "EADDRINUSE") {
+        console.error(`Error: Port ${port} is already in use.`);
+        console.error(`Use --port <number> to choose a different port, or stop the process using port ${port}.`);
+        process.exit(1);
+      }
+      throw err;
+    }
   }
 
   // Node.js / Electron: plain http server
@@ -750,7 +797,15 @@ export function createApiServer(
 
   // Return a promise that resolves once the server is listening,
   // with the actual assigned port (important when port=0).
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    nodeServer.on("error", (err: any) => {
+      if (err?.code === "EADDRINUSE") {
+        console.error(`Error: Port ${port} is already in use.`);
+        console.error(`Use --port <number> to choose a different port, or stop the process using port ${port}.`);
+        process.exit(1);
+      }
+      reject(err);
+    });
     nodeServer.listen(port, () => {
       const addr = nodeServer.address() as any;
       const actualPort = typeof addr === "object" ? addr.port : port;
@@ -771,6 +826,8 @@ export const serveCommand = new Command("serve")
 
     const config = loadConfig();
     const port = opts.port ? parseInt(opts.port, 10) : config.ui.port;
+
+    await checkAndRegenerateCollections(home);
 
     if (opts.mcpOnly) {
       console.error("Starting Frozen Ink MCP server (STDIO)...");


### PR DESCRIPTION
## Summary

- On `fink serve`, checks each enabled collection's schema version against its crawler's current version. If the major version matches but the collection's minor version is older, re-generates markdown files and updates the stored version (so it only runs once per upgrade, not on every start).
- Extracted `generateCollection()` and `createGenerateThemeEngine()` from `generate.ts` as shared exports so the serve command can reuse the same logic without duplication.
- Catches `EADDRINUSE` on startup and prints a clear, actionable error message instead of a raw Bun/Node stack trace.

## Test plan

- [ ] Run `fink serve` with port already in use — should print friendly error with `--port` hint
- [ ] Bump a crawler's minor version, run `fink serve` — should log re-generation message and update stored version
- [ ] Run `fink serve` again after re-generation — should not re-generate (version now matches)
- [ ] Major version mismatch — should be skipped (no auto-regeneration)
- [ ] `fink generate <collection>` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)