### PR TITLE
Add folder-level yml settings, prepare step, and entity counts in file tree

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -21,6 +21,30 @@ import {
 import { eq } from "drizzle-orm";
 import { gitHubTheme, obsidianTheme, gitTheme, mantisHubTheme } from "@frozenink/crawlers";
 
+/** Write <folder-name>.yml config files for folders matching the theme's folderConfigs(). */
+async function writeFolderConfigFiles(
+  themeEngine: ThemeEngine,
+  crawlerType: string,
+  storage: LocalStorageBackend,
+  basePath: string,
+): Promise<void> {
+  const configs = themeEngine.getFolderConfigs(crawlerType);
+  if (Object.keys(configs).length === 0) return;
+
+  // Use listDirs so empty directories (e.g. assets/ with no files yet) are also covered
+  const allDirs = await storage.listDirs!(basePath);
+
+  for (const dirPath of allDirs) {
+    const folderName = dirPath.split("/").pop()!;
+    if (!(folderName in configs)) continue;
+    const config = configs[folderName];
+    const lines: string[] = [];
+    if (config.visible === false) lines.push("visible: false");
+    if (config.sort === "DESC") lines.push("sort: DESC");
+    await storage.write(`${dirPath}/${folderName}.yml`, lines.join("\n") + "\n");
+  }
+}
+
 export function createGenerateThemeEngine(): ThemeEngine {
   const themeEngine = new ThemeEngine();
   themeEngine.register(gitHubTheme);
@@ -202,6 +226,9 @@ export async function generateCollection(
   }
 
   indexer.close();
+
+  // Write folder config yml files (visible/sort settings)
+  await writeFolderConfigFiles(themeEngine, col.crawler, storage, markdownBasePath);
 
   const renameNote = renamed > 0 ? `, ${renamed} renamed` : "";
   return `Generated ${generated} files from ${allEntities.length} entities${renameNote}`;

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -34,6 +34,8 @@ import {
   mantisHubTheme,
 } from "@frozenink/crawlers";
 import { desc, eq } from "drizzle-orm";
+import { prepareCollection } from "./prepare";
+import { createGenerateThemeEngine } from "./generate";
 
 // --- In-memory sync/publish/export progress tracking ---
 
@@ -517,6 +519,7 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
   const home = getFrozenInkHome();
   const registry = createDefaultRegistry();
   const themeEngine = createThemeEngine();
+  const prepareThemeEngine = createGenerateThemeEngine();
 
   syncProgress = {
     active: true,
@@ -536,6 +539,12 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
     for (const name of collectionNames) {
       const col = getCollection(name);
       if (!col) continue;
+
+      // Run prepare before incremental sync: schema migrations, folder ymls, stale markdown check
+      if (!full) {
+        syncProgress = { ...syncProgress, collectionName: name, status: `preparing ${name}` };
+        await prepareCollection(col, home, prepareThemeEngine, (msg) => console.log(`[prepare:${name}]`, msg));
+      }
 
       syncProgress = {
         ...syncProgress,

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -1,0 +1,281 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  getFrozenInkHome,
+  getCollectionDb,
+  getCollectionDbPath,
+  listCollections,
+  updateCollection,
+  ThemeEngine,
+  LocalStorageBackend,
+  CollectionEntry,
+  entities,
+  entityTags,
+  tags,
+} from "@frozenink/core";
+import { eq, sql } from "drizzle-orm";
+import { createDefaultRegistry } from "@frozenink/crawlers";
+import { generateCollection, createGenerateThemeEngine } from "./generate";
+
+type Log = (msg: string) => void;
+
+type ColDb = ReturnType<typeof getCollectionDb>;
+
+/** Build entity path lookup for theme cross-reference resolution. */
+function makeEntityPathLookup(colDb: ColDb, basePath: string): (id: string) => string | undefined {
+  return (externalId: string) => {
+    const rows = colDb
+      .select({ markdownPath: entities.markdownPath })
+      .from(entities)
+      .where(eq(entities.externalId, externalId))
+      .all();
+    const mdPath = rows[0]?.markdownPath;
+    if (!mdPath) return undefined;
+    const rel = mdPath.startsWith(`${basePath}/`) ? mdPath.slice(basePath.length + 1) : mdPath;
+    return rel.endsWith(".md") ? rel.slice(0, -3) : rel;
+  };
+}
+
+/** Build stem-matching wikilink resolver (for Obsidian-style [[bare name]] links). */
+function makeResolveWikilink(colDb: ColDb, basePath: string): (target: string) => string | undefined {
+  const allRows = colDb
+    .select({ externalId: entities.externalId, markdownPath: entities.markdownPath })
+    .from(entities)
+    .all();
+
+  const byExtId = new Map<string, string>();
+  const byStem = new Map<string, string>();
+
+  for (const row of allRows) {
+    if (!row.markdownPath) continue;
+    const rel = row.markdownPath.startsWith(`${basePath}/`)
+      ? row.markdownPath.slice(basePath.length + 1)
+      : row.markdownPath;
+    const noExt = rel.endsWith(".md") ? rel.slice(0, -3) : rel;
+    byExtId.set(row.externalId, noExt);
+    const stem = row.externalId.replace(/\.md$/, "");
+    const stemName = stem.includes("/") ? stem.split("/").pop()! : stem;
+    if (!byStem.has(stemName)) byStem.set(stemName, noExt);
+  }
+
+  return (target: string) => {
+    const clean = target.replace(/[#^].*$/, "").trim();
+    if (!clean) return undefined;
+    const withMd = clean.endsWith(".md") ? clean : `${clean}.md`;
+    if (byExtId.has(withMd)) return byExtId.get(withMd);
+    if (byExtId.has(clean)) return byExtId.get(clean);
+    const stemName = clean.includes("/") ? clean.split("/").pop()! : clean;
+    return byStem.get(stemName);
+  };
+}
+
+/**
+ * Write <folder-name>.yml config files for folders matching the theme's folderConfigs().
+ * Only writes when the file is missing or its content has changed.
+ * Returns true if any file was written.
+ */
+async function writeFolderConfigFiles(
+  themeEngine: ThemeEngine,
+  crawlerType: string,
+  storage: LocalStorageBackend,
+  basePath: string,
+): Promise<boolean> {
+  const configs = themeEngine.getFolderConfigs(crawlerType);
+  if (Object.keys(configs).length === 0) return false;
+
+  // Use listDirs so empty directories (e.g. assets/ with no files yet) are also covered
+  const allDirs = await storage.listDirs!(basePath);
+  let wrote = false;
+
+  for (const dirPath of allDirs) {
+    const folderName = dirPath.split("/").pop()!;
+    if (!(folderName in configs)) continue;
+
+    const config = configs[folderName];
+    const lines: string[] = [];
+    if (config.visible === false) lines.push("visible: false");
+    if (config.sort === "DESC") lines.push("sort: DESC");
+    const ymlContent = lines.join("\n") + "\n";
+    const ymlPath = `${dirPath}/${folderName}.yml`;
+
+    // Skip if already up to date
+    try {
+      const existing = await storage.read(ymlPath);
+      if (existing === ymlContent) continue;
+    } catch { /* file doesn't exist yet */ }
+
+    await storage.write(ymlPath, ymlContent);
+    wrote = true;
+  }
+  return wrote;
+}
+
+/**
+ * Sample up to `sampleSize` entities per entity type and check two things:
+ *   - Title freshness: does getTitle() match the stored DB title?
+ *   - Markdown freshness: does render() match what's on disk?
+ *
+ * Returns counts of sampled entities and how many had title or markdown mismatches.
+ */
+async function checkSamples(
+  colDb: ColDb,
+  storage: LocalStorageBackend,
+  themeEngine: ThemeEngine,
+  crawlerType: string,
+  collectionName: string,
+  basePath: string,
+  sampleSize: number,
+): Promise<{ sampled: number; titleMismatches: number; markdownMismatches: number }> {
+  // Get distinct entity types via GROUP BY
+  const typeRows = colDb
+    .select({ entityType: entities.entityType, count: sql<number>`count(*)` })
+    .from(entities)
+    .groupBy(entities.entityType)
+    .all();
+
+  const lookupEntityPath = makeEntityPathLookup(colDb, basePath);
+  const resolveWikilink = makeResolveWikilink(colDb, basePath);
+
+  let sampled = 0;
+  let titleMismatches = 0;
+  let markdownMismatches = 0;
+
+  for (const { entityType } of typeRows) {
+    const sample = colDb
+      .select()
+      .from(entities)
+      .where(eq(entities.entityType, entityType))
+      .limit(sampleSize)
+      .all();
+
+    for (const entity of sample) {
+      if (!entity.markdownPath) continue;
+      sampled++;
+
+      // Load tags for accurate rendering
+      const entityTagNames = colDb
+        .select()
+        .from(entityTags)
+        .where(eq(entityTags.entityId, entity.id))
+        .all()
+        .map((t: any) => {
+          const [tagRow] = colDb.select().from(tags).where(eq(tags.id, t.tagId)).all();
+          return tagRow?.name ?? "";
+        })
+        .filter(Boolean);
+
+      const ctx = {
+        entity: {
+          externalId: entity.externalId,
+          entityType: entity.entityType,
+          title: entity.title,
+          data: entity.data as Record<string, unknown>,
+          url: entity.url ?? undefined,
+          tags: entityTagNames,
+        },
+        collectionName,
+        crawlerType,
+        lookupEntityPath,
+        resolveWikilink,
+      };
+
+      // Check title: compare DB title against what the theme derives from stored data
+      const derivedTitle = themeEngine.getTitle(ctx);
+      if (derivedTitle !== undefined && derivedTitle !== entity.title) {
+        titleMismatches++;
+      }
+
+      // Check markdown: compare on-disk file against fresh render
+      let onDisk: string | null = null;
+      try {
+        onDisk = await storage.read(entity.markdownPath);
+      } catch { /* file missing */ }
+
+      // Re-render with the derived title (same logic as generateCollection)
+      const renderCtx = derivedTitle ? { ...ctx, entity: { ...ctx.entity, title: derivedTitle } } : ctx;
+      const rendered = themeEngine.render(renderCtx);
+      if (onDisk !== rendered) markdownMismatches++;
+    }
+  }
+
+  return { sampled, titleMismatches, markdownMismatches };
+}
+
+/**
+ * Prepare a single collection before serve or sync:
+ *   1. Apply DB schema migrations (automatic via getCollectionDb).
+ *   2. Write missing/outdated folder yml config files.
+ *   3. Sample up to 10 entities per type; if any mismatch → regenerate all.
+ *
+ * Skips silently if the collection has never been synced (no DB yet).
+ */
+export async function prepareCollection(
+  col: CollectionEntry & { name: string },
+  home: string,
+  themeEngine: ThemeEngine,
+  log: Log,
+): Promise<void> {
+  const dbPath = getCollectionDbPath(col.name);
+  if (!existsSync(dbPath)) return; // Never synced — nothing to prepare
+
+  // Opening the DB applies schema migrations automatically (ALTER TABLE IF NOT EXISTS)
+  const colDb = getCollectionDb(dbPath);
+  const collectionDir = join(home, "collections", col.name);
+  const storage = new LocalStorageBackend(collectionDir);
+  const basePath = "content";
+
+  // Step 1: Write folder yml files
+  const ymlUpdated = await writeFolderConfigFiles(themeEngine, col.crawler, storage, basePath);
+  if (ymlUpdated) log(`  Folder config files updated`);
+
+  // Step 2: Sample check — skip if theme is not registered
+  if (!themeEngine.has(col.crawler)) return;
+
+  const { sampled, titleMismatches, markdownMismatches } = await checkSamples(
+    colDb, storage, themeEngine, col.crawler, col.name, basePath, 10,
+  );
+
+  if (sampled === 0) return;
+
+  const totalMismatches = titleMismatches + markdownMismatches;
+  if (totalMismatches === 0) {
+    log(`  Up to date (${sampled} sample${sampled === 1 ? "" : "s"} checked)`);
+    return;
+  }
+
+  // Step 3: Mismatch — regenerate all entities
+  const reasons = [
+    titleMismatches > 0 ? `${titleMismatches} title${titleMismatches === 1 ? "" : "s"}` : "",
+    markdownMismatches > 0 ? `${markdownMismatches} markdown` : "",
+  ].filter(Boolean).join(", ");
+  log(`  ${reasons} outdated (${totalMismatches}/${sampled} samples) — regenerating all...`);
+  const summary = await generateCollection(col, home, themeEngine);
+  if (summary) {
+    log(`  ${summary}`);
+    // Stamp the current crawler version so subsequent prepare runs skip the check
+    const registry = createDefaultRegistry();
+    const factory = registry.get(col.crawler);
+    if (factory) {
+      updateCollection(col.name, { version: factory().metadata.version ?? "1.0" });
+    }
+  }
+}
+
+/**
+ * Run prepare for all enabled local collections.
+ * Called before `serve` starts and before each `sync` run.
+ * Safe to call multiple times — all steps are idempotent.
+ */
+export async function prepareCollections(
+  home: string = getFrozenInkHome(),
+  log: Log = console.log,
+): Promise<void> {
+  const themeEngine = createGenerateThemeEngine();
+  const collections = listCollections().filter((c) => c.enabled);
+
+  for (const col of collections) {
+    if (!existsSync(getCollectionDbPath(col.name))) continue;
+    log(`Preparing "${col.name}" (${col.crawler})...`);
+    await prepareCollection(col, home, themeEngine, log);
+  }
+}

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -53,6 +53,7 @@ const MIME_TYPES: Record<string, string> = {
   ".pdf": "application/pdf", ".json": "application/json",
   ".md": "text/markdown", ".txt": "text/plain", ".html": "text/html",
   ".css": "text/css", ".js": "application/javascript", ".ico": "image/x-icon",
+  ".yml": "text/yaml",
 };
 
 function getMimeType(filePath: string): string {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { existsSync, readdirSync, statSync, readFileSync } from "fs";
-import { join, extname } from "path";
+import { join, extname, basename } from "path";
 import {
   getFrozenInkHome,
   getCollectionDb,
@@ -8,7 +8,6 @@ import {
   listCollections,
   getCollection,
   getCollectionDbPath,
-  updateCollection,
   entities,
   entityTags,
   tags,
@@ -22,7 +21,6 @@ import {
   resolveUiDist,
 } from "@frozenink/core";
 import {
-  createDefaultRegistry,
   gitHubTheme,
   obsidianTheme,
   gitTheme,
@@ -31,7 +29,7 @@ import {
 import { startStdioServer } from "@frozenink/mcp";
 import { eq, desc } from "drizzle-orm";
 import { handleManagementRequest, setAppMode } from "./management-api";
-import { generateCollection, createGenerateThemeEngine } from "./generate";
+import { prepareCollections } from "./prepare";
 
 const __moduleDir = getModuleDir(import.meta.url);
 
@@ -68,12 +66,48 @@ function getMimeType(filePath: string): string {
   return MIME_TYPES[ext] || "application/octet-stream";
 }
 
+/** Parse a folder yml file (visible/sort fields only). */
+function readFolderConfig(dirPath: string): { visible?: boolean; sort?: "ASC" | "DESC" } {
+  const folderName = basename(dirPath);
+  const ymlPath = join(dirPath, `${folderName}.yml`);
+  if (!existsSync(ymlPath)) return {};
+  try {
+    const content = readFileSync(ymlPath, "utf-8");
+    const config: { visible?: boolean; sort?: "ASC" | "DESC" } = {};
+    for (const line of content.split("\n")) {
+      const m = line.match(/^(\w+):\s*(.+)$/);
+      if (!m) continue;
+      const [, key, val] = m;
+      if (key === "visible") config.visible = val.trim() !== "false";
+      if (key === "sort") config.sort = val.trim() === "DESC" ? "DESC" : "ASC";
+    }
+    return config;
+  } catch {
+    return {};
+  }
+}
+
+/** Recursively count all file nodes in a built subtree. */
+function countFiles(nodes: object[]): number {
+  let n = 0;
+  for (const node of nodes) {
+    const typed = node as { type: string; children?: object[] };
+    if (typed.type === "file") n++;
+    else if (typed.children) n += countFiles(typed.children);
+  }
+  return n;
+}
+
 function buildFileTree(
   dirPath: string,
   titleByPath: Map<string, string>,
   basePath: string = "",
 ): object[] {
   if (!existsSync(dirPath)) return [];
+
+  // Read this directory's own config to determine sort order for its files
+  const ownConfig = basePath ? readFolderConfig(dirPath) : {};
+  const sortOrder = ownConfig.sort ?? "ASC";
 
   const entries = readdirSync(dirPath, { withFileTypes: true });
   const dirs: object[] = [];
@@ -82,11 +116,17 @@ function buildFileTree(
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     const relativePath = basePath ? `${basePath}/${entry.name}` : entry.name;
     if (entry.isDirectory()) {
+      const childDirPath = join(dirPath, entry.name);
+      // Check child dir's visibility before including it
+      const childConfig = readFolderConfig(childDirPath);
+      if (childConfig.visible === false) continue;
+      const children = buildFileTree(childDirPath, titleByPath, relativePath);
       dirs.push({
         name: entry.name,
         path: relativePath,
         type: "directory",
-        children: buildFileTree(join(dirPath, entry.name), titleByPath, relativePath),
+        count: countFiles(children),
+        children,
       });
     } else if (entry.name.endsWith(".md")) {
       const node: Record<string, unknown> = {
@@ -100,7 +140,9 @@ function buildFileTree(
     }
   }
 
-  return [...dirs, ...files];
+  // Apply sort order to files (dirs always sort ASC alphabetically)
+  const sortedFiles = sortOrder === "DESC" ? files.slice().reverse() : files;
+  return [...dirs, ...sortedFiles];
 }
 
 function jsonResponse(data: unknown, status: number = 200): Response {
@@ -153,40 +195,6 @@ function tryServeStatic(
   return null;
 }
 
-/**
- * Check all enabled collections for minor-version upgrades and re-generate
- * markdown for any that are behind. Logs progress for each collection regenerated.
- */
-async function checkAndRegenerateCollections(home: string): Promise<void> {
-  const registry = createDefaultRegistry();
-  const themeEngine = createGenerateThemeEngine();
-  const collections = listCollections().filter((c) => c.enabled);
-
-  for (const col of collections) {
-    const factory = registry.get(col.crawler);
-    if (!factory) continue;
-
-    const crawlerVersion = factory().metadata.version ?? "1.0";
-    const collectionVersion = col.version ?? "1.0";
-
-    const [colMajor, colMinor] = collectionVersion.split(".").map(Number);
-    const [crwMajor, crwMinor] = crawlerVersion.split(".").map(Number);
-
-    // Only re-generate when same major but collection minor is older
-    if (colMajor !== crwMajor) continue;
-    if (colMinor >= crwMinor) continue;
-
-    console.log(
-      `Re-generating collection "${col.name}" (${col.crawler} schema ${collectionVersion} → ${crawlerVersion})...`,
-    );
-
-    const summary = await generateCollection(col, home, themeEngine);
-    if (summary) {
-      console.log(`  ${summary}`);
-      updateCollection(col.name, { version: crawlerVersion });
-    }
-  }
-}
 
 export function createApiServer(
   home: string,
@@ -827,7 +835,7 @@ export const serveCommand = new Command("serve")
     const config = loadConfig();
     const port = opts.port ? parseInt(opts.port, 10) : config.ui.port;
 
-    await checkAndRegenerateCollections(home);
+    await prepareCollections(home);
 
     if (opts.mcpOnly) {
       console.error("Starting Frozen Ink MCP server (STDIO)...");

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -15,6 +15,8 @@ import {
 } from "@frozenink/core";
 import { sql } from "drizzle-orm";
 import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme, mantisHubTheme } from "@frozenink/crawlers";
+import { prepareCollection } from "./prepare";
+import { createGenerateThemeEngine } from "./generate";
 
 export const syncCommand = new Command("sync")
   .description("Sync collections")
@@ -53,7 +55,13 @@ export const syncCommand = new Command("sync")
     themeEngine.register(gitTheme);
     themeEngine.register(mantisHubTheme);
 
+    const prepareThemeEngine = createGenerateThemeEngine();
+
     for (const col of collectionRows) {
+      if (!opts.full) {
+        console.log(`Preparing "${col.name}" (${col.crawler})...`);
+        await prepareCollection(col, home, prepareThemeEngine, (msg) => console.log(msg));
+      }
       console.log(`Syncing "${col.name}" (${col.crawler})...`);
 
       const factory = registry.get(col.crawler);

--- a/packages/core/src/crawler/sync-engine.ts
+++ b/packages/core/src/crawler/sync-engine.ts
@@ -12,8 +12,17 @@ import {
 } from "../db/collection-schema";
 import { SearchIndexer } from "../search/indexer";
 import type { Crawler, CrawlerEntityData, SyncCursor } from "./interface";
+import type { FolderConfig } from "../theme/interface";
 import type { ThemeEngine } from "../theme/engine";
 import type { StorageBackend } from "../storage/interface";
+
+/** Serialize a FolderConfig to yml content (only non-default fields). */
+function serializeFolderConfig(config: FolderConfig): string {
+  const lines: string[] = [];
+  if (config.visible === false) lines.push("visible: false");
+  if (config.sort === "DESC") lines.push("sort: DESC");
+  return lines.join("\n") + "\n";
+}
 
 /** Returns true if any path segment starts with "." (hidden dirs like .git, .obsidian). */
 function isToolPath(filePath: string): boolean {
@@ -280,6 +289,9 @@ export class SyncEngine {
 
       // Reconcile filesystem with DB
       await this.reconcile(crawlerType);
+
+      // Write folder config yml files (visible/sort settings)
+      await this.writeFolderConfigFiles(crawlerType);
 
       // Notify caller to update collection version in .config
       this.onVersionUpdate?.(currentVersion);
@@ -869,6 +881,27 @@ export class SyncEngine {
       if (!exists) {
         this.db.delete(assets).where(eq(assets.id, att.id)).run();
       }
+    }
+  }
+
+  /**
+   * Write <folder-name>.yml config files for all folders whose leaf name matches
+   * a key in the theme's folderConfigs(). Covers any depth (e.g. project/issues/).
+   */
+  private async writeFolderConfigFiles(crawlerType: string): Promise<void> {
+    const configs = this.themeEngine.getFolderConfigs(crawlerType);
+    if (Object.keys(configs).length === 0) return;
+
+    // Use listDirs to cover empty directories too (file-based listing misses them)
+    const allDirs = this.storage.listDirs
+      ? await this.storage.listDirs(this.markdownBasePath)
+      : [];
+
+    for (const dirPath of allDirs) {
+      const folderName = dirPath.split("/").pop()!;
+      if (!(folderName in configs)) continue;
+      const ymlPath = `${dirPath}/${folderName}.yml`;
+      await this.storage.write(ymlPath, serializeFolderConfig(configs[folderName]));
     }
   }
 

--- a/packages/core/src/storage/interface.ts
+++ b/packages/core/src/storage/interface.ts
@@ -11,6 +11,8 @@ export interface StorageBackend {
   delete(path: string): Promise<void>;
   exists(path: string): Promise<boolean>;
   list(prefix: string): Promise<string[]>;
+  /** List all subdirectories (recursively) under the given prefix. Paths are relative to the storage root. */
+  listDirs?(prefix: string): Promise<string[]>;
   /** Returns file metadata, or null if the file does not exist. */
   stat(path: string): Promise<FileStat | null>;
 }

--- a/packages/core/src/storage/local.ts
+++ b/packages/core/src/storage/local.ts
@@ -57,6 +57,30 @@ export class LocalStorageBackend implements StorageBackend {
     return result;
   }
 
+  async listDirs(prefix: string): Promise<string[]> {
+    const dir = join(this.basePath, prefix);
+    const base = this.basePath;
+    const result: string[] = [];
+
+    async function walk(dirPath: string): Promise<void> {
+      let entries;
+      try {
+        entries = await readdir(dirPath, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const entryPath = join(dirPath, entry.name);
+        result.push(relative(base, entryPath));
+        await walk(entryPath);
+      }
+    }
+
+    await walk(dir);
+    return result;
+  }
+
   async stat(path: string): Promise<FileStat | null> {
     const fullPath = join(this.basePath, path);
     try {

--- a/packages/core/src/theme/engine.ts
+++ b/packages/core/src/theme/engine.ts
@@ -1,4 +1,4 @@
-import type { Theme, ThemeRenderContext } from "./interface";
+import type { Theme, ThemeRenderContext, FolderConfig } from "./interface";
 
 export class ThemeEngine {
   private themes = new Map<string, Theme>();
@@ -41,5 +41,11 @@ export class ThemeEngine {
     const theme = this.themes.get(context.crawlerType);
     if (!theme?.renderHtml) return null;
     return theme.renderHtml(context);
+  }
+
+  /** Return folder configs for the given crawler type, or empty object if none defined. */
+  getFolderConfigs(crawlerType: string): Record<string, FolderConfig> {
+    const theme = this.themes.get(crawlerType);
+    return theme?.folderConfigs?.() ?? {};
   }
 }

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -1,3 +1,3 @@
-export type { Theme, ThemeRenderContext } from "./interface";
+export type { Theme, ThemeRenderContext, FolderConfig } from "./interface";
 export { frontmatter, wikilink, callout, embed, basename, dirname, relativePath } from "./obsidian";
 export { ThemeEngine } from "./engine";

--- a/packages/core/src/theme/interface.ts
+++ b/packages/core/src/theme/interface.ts
@@ -1,3 +1,10 @@
+export interface FolderConfig {
+  /** Whether this folder is visible in the file tree (default: true). */
+  visible?: boolean;
+  /** Sort order for files in this folder (default: ASC). */
+  sort?: "ASC" | "DESC";
+}
+
 export interface ThemeRenderContext {
   entity: {
     externalId: string;
@@ -40,4 +47,11 @@ export interface Theme {
    * from the source API. Returns undefined if the theme cannot derive a title.
    */
   getTitle?(context: ThemeRenderContext): string | undefined;
+  /**
+   * Optional: return folder-level display configs keyed by folder name.
+   * Any folder whose leaf name matches a key inherits the associated config,
+   * regardless of depth (e.g. "issues" matches both "issues/" and "project/issues/").
+   * The sync engine writes these as <folder-name>.yml inside each matching folder.
+   */
+  folderConfigs?(): Record<string, FolderConfig>;
 }

--- a/packages/crawlers/src/git/theme.ts
+++ b/packages/crawlers/src/git/theme.ts
@@ -43,6 +43,12 @@ export class GitTheme implements Theme {
     }
   }
 
+  folderConfigs() {
+    return {
+      assets: { visible: false },
+    };
+  }
+
   getFilePath(context: ThemeRenderContext): string {
     const { entity } = context;
     switch (entity.entityType) {

--- a/packages/crawlers/src/github/theme.ts
+++ b/packages/crawlers/src/github/theme.ts
@@ -411,6 +411,14 @@ export class GitHubTheme implements Theme {
     return `issues/${number}-${slug}.md`;
   }
 
+  folderConfigs() {
+    return {
+      issues: { sort: "DESC" as const },
+      "pull-requests": { sort: "DESC" as const },
+      assets: { visible: false },
+    };
+  }
+
   private renderIssue(context: ThemeRenderContext): string {
     const { entity } = context;
     const d = entity.data;

--- a/packages/crawlers/src/mantishub/theme.ts
+++ b/packages/crawlers/src/mantishub/theme.ts
@@ -347,6 +347,13 @@ export class MantisHubTheme implements Theme {
     return this.renderIssue(context);
   }
 
+  folderConfigs() {
+    return {
+      issues: { sort: "DESC" as const },
+      assets: { visible: false },
+    };
+  }
+
   getFilePath(context: ThemeRenderContext): string {
     const d = context.entity.data;
 

--- a/packages/crawlers/src/obsidian/theme.ts
+++ b/packages/crawlers/src/obsidian/theme.ts
@@ -48,6 +48,12 @@ export class ObsidianTheme implements Theme {
     return result;
   }
 
+  folderConfigs() {
+    return {
+      assets: { visible: false },
+    };
+  }
+
   getFilePath(context: ThemeRenderContext): string {
     // Preserve the original vault-relative path
     return context.entity.data.relativePath as string;

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -693,6 +693,14 @@ body {
   white-space: nowrap;
 }
 
+.tree-count {
+  margin-left: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 /* ===== Markdown View ===== */
 .markdown-view {
   max-width: 800px;

--- a/packages/ui/src/components/FileTree.tsx
+++ b/packages/ui/src/components/FileTree.tsx
@@ -27,6 +27,9 @@ function TreeItem({ node, selectedFile, onSelect, depth }: TreeItemProps) {
         >
           <span className="tree-icon">{expanded ? "▼" : "▶"}</span>
           <span className="tree-name">{node.name}</span>
+          {node.count !== undefined && node.count > 0 && (
+            <span className="tree-count">({node.count.toLocaleString()})</span>
+          )}
         </button>
         {expanded && node.children && (
           <ul className="tree-children" role="group">

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -15,6 +15,8 @@ export interface TreeNode {
   type: "file" | "directory";
   /** Human-readable entity title; falls back to name (without .md) if absent */
   title?: string;
+  /** Total number of entity files (recursive) in this directory; only present on directory nodes. */
+  count?: number;
   children?: TreeNode[];
 }
 

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -103,7 +103,9 @@ api.get("/api/collections/:name/tree", async (c) => {
   const prefix = `${name}/content/`;
 
   const listed = await c.env.BUCKET.list({ prefix });
-  const paths = listed.objects.map((o) => o.key.slice(prefix.length)).filter((p) => p.endsWith(".md"));
+  const mdPaths = listed.objects
+    .map((o) => o.key.slice(prefix.length))
+    .filter((p) => p.endsWith(".md"));
 
   // Fetch entity titles from D1 to display instead of raw filenames
   const titleByPath = new Map<string, string>();
@@ -122,8 +124,29 @@ api.get("/api/collections/:name/tree", async (c) => {
     // If title lookup fails, fall back to filenames
   }
 
-  // Build tree from paths
-  const tree = buildTreeFromPaths(paths, titleByPath);
+  // Derive unique folder paths from md paths and fetch each folder's yml config
+  // directly by key — avoids relying on R2 list pagination (yml files sort
+  // alphabetically after digit-prefixed md files and can fall beyond 1000-object limit).
+  const folderPaths = new Set<string>();
+  for (const mdPath of mdPaths) {
+    const parts = mdPath.split("/");
+    for (let i = 1; i < parts.length; i++) {
+      folderPaths.add(parts.slice(0, i).join("/"));
+    }
+  }
+
+  const folderConfigs = new Map<string, { visible?: boolean; sort?: "ASC" | "DESC" }>();
+  await Promise.all(
+    [...folderPaths].map(async (folderPath) => {
+      const folderName = folderPath.split("/").pop()!;
+      const obj = await c.env.BUCKET.get(`${prefix}${folderPath}/${folderName}.yml`);
+      if (!obj) return;
+      folderConfigs.set(folderPath, parseFolderConfig(await obj.text()));
+    }),
+  );
+
+  // Build tree from paths with folder configs applied
+  const tree = buildTreeFromPaths(mdPaths, titleByPath, folderConfigs);
   return c.json(tree);
 });
 
@@ -278,14 +301,41 @@ api.get("/api/attachments/:collection/*", async (c) => {
   });
 });
 
-// Helper to build tree from flat file paths
-function buildTreeFromPaths(paths: string[], titleByPath: Map<string, string> = new Map()): object[] {
+/** Parse a minimal folder yml (visible/sort only). Works without js-yaml in the Worker runtime. */
+function parseFolderConfig(content: string): { visible?: boolean; sort?: "ASC" | "DESC" } {
+  const config: { visible?: boolean; sort?: "ASC" | "DESC" } = {};
+  for (const line of content.split("\n")) {
+    const m = line.match(/^(\w+):\s*(.+)$/);
+    if (!m) continue;
+    const [, key, val] = m;
+    if (key === "visible") config.visible = val.trim() !== "false";
+    if (key === "sort") config.sort = val.trim() === "DESC" ? "DESC" : "ASC";
+  }
+  return config;
+}
+
+// Helper to build tree from flat file paths, honoring folder yml configs
+function buildTreeFromPaths(
+  paths: string[],
+  titleByPath: Map<string, string> = new Map(),
+  folderConfigs: Map<string, { visible?: boolean; sort?: "ASC" | "DESC" }> = new Map(),
+): object[] {
   interface TreeNode {
     name: string;
     path: string;
     type: "directory" | "file";
     title?: string;
+    count?: number;
     children?: TreeNode[];
+  }
+
+  function countFilesInTree(nodes: TreeNode[]): number {
+    let n = 0;
+    for (const node of nodes) {
+      if (node.type === "file") n++;
+      else if (node.children) n += countFilesInTree(node.children);
+    }
+    return n;
   }
 
   const root: TreeNode[] = [];
@@ -316,12 +366,32 @@ function buildTreeFromPaths(paths: string[], titleByPath: Map<string, string> = 
     }
   }
 
-  // Sort: directories first, then files, alphabetical within each
-  function sortTree(nodes: TreeNode[]): TreeNode[] {
-    const dirs = nodes.filter((n) => n.type === "directory").sort((a, b) => a.name.localeCompare(b.name));
-    const files = nodes.filter((n) => n.type === "file").sort((a, b) => a.name.localeCompare(b.name));
+  // Sort: directories first (ASC), files per-folder config (ASC or DESC); prune hidden dirs
+  function sortTree(nodes: TreeNode[], parentPath: string = ""): TreeNode[] {
+    const config = parentPath ? folderConfigs.get(parentPath) : undefined;
+    const sortOrder = config?.sort ?? "ASC";
+
+    const dirs = nodes
+      .filter((n) => n.type === "directory")
+      .filter((n) => {
+        const childPath = parentPath ? `${parentPath}/${n.name}` : n.name;
+        return folderConfigs.get(childPath)?.visible !== false;
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    const files = nodes.filter((n) => n.type === "file");
+    if (sortOrder === "DESC") {
+      files.sort((a, b) => b.name.localeCompare(a.name));
+    } else {
+      files.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
     for (const dir of dirs) {
-      if (dir.children) dir.children = sortTree(dir.children);
+      if (dir.children) {
+        const childPath = parentPath ? `${parentPath}/${dir.name}` : dir.name;
+        dir.children = sortTree(dir.children, childPath);
+      }
+      dir.count = countFilesInTree(dir.children ?? []);
     }
     return [...dirs, ...files];
   }


### PR DESCRIPTION
## Summary

- **Folder yml settings**: Each crawler now writes `<folder-name>.yml` files (e.g. `issues/issues.yml`) specifying `visible: false` or `sort: DESC`. These are honored by both the local serve and the Cloudflare worker. GitHub hides assets and sorts issues/PRs newest-first; MantisHub hides assets and sorts issues newest-first; Git and Obsidian hide assets.
- **Prepare step**: A new `prepare` command runs automatically before every incremental `serve` and `sync`. It (1) writes any missing/outdated folder ymls, (2) applies DB schema migrations, and (3) samples 10 entities per type — if titles or markdown are stale it regenerates everything. Full syncs skip prepare. Users see clear log output distinguishing title vs markdown mismatches.
- **Empty-folder fix**: Switched from file-based folder discovery to `listDirs()` so empty directories (e.g. a fresh `assets/` folder with no files yet) also get their yml written. Added `listDirs?` to `StorageBackend` interface and implemented it in `LocalStorageBackend`.
- **Entity counts in file tree**: Each folder in the sidebar now shows the recursive count of entities it contains, e.g. `issues (10,240)`. Works for both local and Cloudflare worker.

## Test plan

- [ ] Run `bun run ci` — all linting, typechecking, tests, UI build, and worker build pass
- [ ] Start `serve` and confirm the assets folder is hidden for MantisHub/GitHub/Git/Obsidian collections
- [ ] Confirm issues folder sorts newest-first for MantisHub and GitHub collections
- [ ] Verify entity counts appear next to folder names in the sidebar
- [ ] Run an incremental sync and confirm the prepare step logs appear
- [ ] Run a full sync (`--full`) and confirm prepare is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)