### PR TITLE
Add hide files support, AGENTS.md generation, and lifecycle fixes

### DIFF
--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -223,6 +223,27 @@ export function handleManagementRequest(req: Request): Response | null {
       if (!col) return errorResponse("Collection not found", 404);
       const body = await readBody(req);
       updateCollection(name, body as any);
+      // Re-run prepare so AGENTS.md/CLAUDE.md and folder configs stay up to date
+      const updatedCol = getCollection(name);
+      if (updatedCol) {
+        const home = getFrozenInkHome();
+        const themeEngine = createGenerateThemeEngine();
+        await prepareCollection(updatedCol, home, themeEngine, (msg) => console.log(`[prepare:${name}]`, msg));
+      }
+      return jsonResponse({ ok: true });
+    });
+  }
+
+  // POST /api/collections/:name/prepare
+  const prepareColMatch = path.match(/^\/api\/collections\/([^/]+)\/prepare$/);
+  if (prepareColMatch && method === "POST") {
+    return handleAsync(async () => {
+      const name = decodeURIComponent(prepareColMatch[1]);
+      const col = getCollection(name);
+      if (!col) return errorResponse("Collection not found", 404);
+      const home = getFrozenInkHome();
+      const themeEngine = createGenerateThemeEngine();
+      await prepareCollection(col, home, themeEngine, (msg) => console.log(`[prepare:${name}]`, msg));
       return jsonResponse({ ok: true });
     });
   }

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -9,6 +9,7 @@ import {
   ThemeEngine,
   LocalStorageBackend,
   CollectionEntry,
+  type FolderConfig,
   entities,
   entityTags,
   tags,
@@ -69,8 +70,20 @@ function makeResolveWikilink(colDb: ColDb, basePath: string): (target: string) =
   };
 }
 
+/** Serialize a FolderConfig to yml content (only non-default fields). */
+function serializeFolderConfig(config: FolderConfig): string {
+  const lines: string[] = [];
+  if (config.visible === false) lines.push("visible: false");
+  if (config.sort === "DESC") lines.push("sort: DESC");
+  if (config.hide && config.hide.length > 0) {
+    lines.push(`hide: [${config.hide.join(", ")}]`);
+  }
+  return lines.join("\n") + "\n";
+}
+
 /**
  * Write <folder-name>.yml config files for folders matching the theme's folderConfigs().
+ * Also writes root content.yml merging theme rootConfig with collection-level hide list.
  * Only writes when the file is missing or its content has changed.
  * Returns true if any file was written.
  */
@@ -79,35 +92,104 @@ async function writeFolderConfigFiles(
   crawlerType: string,
   storage: LocalStorageBackend,
   basePath: string,
+  collectionHide: string[] = [],
 ): Promise<boolean> {
   const configs = themeEngine.getFolderConfigs(crawlerType);
-  if (Object.keys(configs).length === 0) return false;
-
-  // Use listDirs so empty directories (e.g. assets/ with no files yet) are also covered
-  const allDirs = await storage.listDirs!(basePath);
   let wrote = false;
 
-  for (const dirPath of allDirs) {
-    const folderName = dirPath.split("/").pop()!;
-    if (!(folderName in configs)) continue;
+  if (Object.keys(configs).length > 0) {
+    // Use listDirs so empty directories (e.g. assets/ with no files yet) are also covered
+    const allDirs = await storage.listDirs!(basePath);
 
-    const config = configs[folderName];
-    const lines: string[] = [];
-    if (config.visible === false) lines.push("visible: false");
-    if (config.sort === "DESC") lines.push("sort: DESC");
-    const ymlContent = lines.join("\n") + "\n";
-    const ymlPath = `${dirPath}/${folderName}.yml`;
+    for (const dirPath of allDirs) {
+      const folderName = dirPath.split("/").pop()!;
+      if (!(folderName in configs)) continue;
 
-    // Skip if already up to date
-    try {
-      const existing = await storage.read(ymlPath);
-      if (existing === ymlContent) continue;
-    } catch { /* file doesn't exist yet */ }
+      const ymlContent = serializeFolderConfig(configs[folderName]);
+      const ymlPath = `${dirPath}/${folderName}.yml`;
 
-    await storage.write(ymlPath, ymlContent);
-    wrote = true;
+      // Skip if already up to date
+      try {
+        const existing = await storage.read(ymlPath);
+        if (existing === ymlContent) continue;
+      } catch { /* file doesn't exist yet */ }
+
+      await storage.write(ymlPath, ymlContent);
+      wrote = true;
+    }
   }
+
+  // Write root content.yml merging theme rootConfig with collection-level hide patterns
+  const themeRootConfig = themeEngine.getRootConfig(crawlerType);
+  const mergedHide = [
+    ...(themeRootConfig.hide ?? []),
+    ...collectionHide.filter((p) => !(themeRootConfig.hide ?? []).includes(p)),
+  ];
+  const rootConfig = { ...themeRootConfig, ...(mergedHide.length > 0 ? { hide: mergedHide } : {}) };
+  const hasRootConfig = Object.keys(rootConfig).length > 0;
+  if (hasRootConfig) {
+    const rootYmlContent = serializeFolderConfig(rootConfig);
+    const rootYmlPath = `${basePath}/content.yml`;
+    try {
+      const existing = await storage.read(rootYmlPath);
+      if (existing !== rootYmlContent) {
+        await storage.write(rootYmlPath, rootYmlContent);
+        wrote = true;
+      }
+    } catch {
+      await storage.write(rootYmlPath, rootYmlContent);
+      wrote = true;
+    }
+  }
+
   return wrote;
+}
+
+/** Write AGENTS.md and CLAUDE.md to the collection root (outside content/). Only writes when content has changed. */
+async function writeAgentFiles(
+  themeEngine: ThemeEngine,
+  col: CollectionEntry & { name: string },
+  storage: LocalStorageBackend,
+  log: Log,
+): Promise<void> {
+  const agentsContent = themeEngine.agentsMarkdown(col.crawler, {
+    title: col.title ?? col.name,
+    description: col.description,
+    config: col.config as Record<string, unknown>,
+  });
+
+  if (agentsContent === null) return;
+
+  const claudeContent =
+    "See [AGENTS.md](AGENTS.md) for full project context, architecture, schemas, conventions, and navigation guide.\n";
+
+  let changed = false;
+
+  const agentsPath = "AGENTS.md";
+  try {
+    const existing = await storage.read(agentsPath);
+    if (existing !== agentsContent) {
+      await storage.write(agentsPath, agentsContent);
+      changed = true;
+    }
+  } catch {
+    await storage.write(agentsPath, agentsContent);
+    changed = true;
+  }
+
+  const claudePath = "CLAUDE.md";
+  try {
+    const existing = await storage.read(claudePath);
+    if (existing !== claudeContent) {
+      await storage.write(claudePath, claudeContent);
+      changed = true;
+    }
+  } catch {
+    await storage.write(claudePath, claudeContent);
+    changed = true;
+  }
+
+  if (changed) log(`  AGENTS.md and CLAUDE.md updated`);
 }
 
 /**
@@ -224,9 +306,13 @@ export async function prepareCollection(
   const storage = new LocalStorageBackend(collectionDir);
   const basePath = "content";
 
-  // Step 1: Write folder yml files
-  const ymlUpdated = await writeFolderConfigFiles(themeEngine, col.crawler, storage, basePath);
+  // Step 1: Write folder yml files and root content.yml (incorporating collection-level hide)
+  const collectionHide = col.hide ?? [];
+  const ymlUpdated = await writeFolderConfigFiles(themeEngine, col.crawler, storage, basePath, collectionHide);
   if (ymlUpdated) log(`  Folder config files updated`);
+
+  // Step 1b: Always write AGENTS.md and CLAUDE.md (at collection root, outside content/)
+  await writeAgentFiles(themeEngine, col, storage, log);
 
   // Step 2: Sample check — skip if theme is not registered
   if (!themeEngine.has(col.crawler)) return;
@@ -239,7 +325,6 @@ export async function prepareCollection(
 
   const totalMismatches = titleMismatches + markdownMismatches;
   if (totalMismatches === 0) {
-    log(`  Up to date (${sampled} sample${sampled === 1 ? "" : "s"} checked)`);
     return;
   }
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -66,20 +66,46 @@ function getMimeType(filePath: string): string {
   return MIME_TYPES[ext] || "application/octet-stream";
 }
 
-/** Parse a folder yml file (visible/sort fields only). */
-function readFolderConfig(dirPath: string): { visible?: boolean; sort?: "ASC" | "DESC" } {
+/** Returns true if `filename` matches any of the glob patterns. */
+function matchesHidePattern(patterns: string[], filename: string): boolean {
+  return patterns.some((pattern) => {
+    // Escape regex special chars except * and ?, then convert glob wildcards
+    const re = new RegExp(
+      "^" +
+        pattern
+          .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+          .replace(/\*/g, ".*")
+          .replace(/\?/g, ".") +
+        "$",
+    );
+    return re.test(filename);
+  });
+}
+
+/** Parse a folder yml file (visible/sort/hide fields). */
+function readFolderConfig(dirPath: string): { visible?: boolean; sort?: "ASC" | "DESC"; hide?: string[] } {
   const folderName = basename(dirPath);
   const ymlPath = join(dirPath, `${folderName}.yml`);
   if (!existsSync(ymlPath)) return {};
   try {
     const content = readFileSync(ymlPath, "utf-8");
-    const config: { visible?: boolean; sort?: "ASC" | "DESC" } = {};
+    const config: { visible?: boolean; sort?: "ASC" | "DESC"; hide?: string[] } = {};
     for (const line of content.split("\n")) {
       const m = line.match(/^(\w+):\s*(.+)$/);
       if (!m) continue;
       const [, key, val] = m;
       if (key === "visible") config.visible = val.trim() !== "false";
       if (key === "sort") config.sort = val.trim() === "DESC" ? "DESC" : "ASC";
+      if (key === "hide") {
+        // Parse inline YAML array: [item1, item2] or ["item1", "item2"]
+        const arrayMatch = val.trim().match(/^\[(.+)\]$/);
+        if (arrayMatch) {
+          config.hide = arrayMatch[1]
+            .split(",")
+            .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+            .filter(Boolean);
+        }
+      }
     }
     return config;
   } catch {
@@ -105,9 +131,10 @@ function buildFileTree(
 ): object[] {
   if (!existsSync(dirPath)) return [];
 
-  // Read this directory's own config to determine sort order for its files
-  const ownConfig = basePath ? readFolderConfig(dirPath) : {};
+  // Read this directory's own config (including root: content/content.yml)
+  const ownConfig = readFolderConfig(dirPath);
   const sortOrder = ownConfig.sort ?? "ASC";
+  const folderHide = ownConfig.hide ?? [];
 
   const entries = readdirSync(dirPath, { withFileTypes: true });
   const dirs: object[] = [];
@@ -129,6 +156,8 @@ function buildFileTree(
         children,
       });
     } else if (entry.name.endsWith(".md")) {
+      // Apply folder-level hide patterns
+      if (folderHide.length > 0 && matchesHidePattern(folderHide, entry.name)) continue;
       const node: Record<string, unknown> = {
         name: entry.name,
         path: relativePath,

--- a/packages/core/src/config/context.ts
+++ b/packages/core/src/config/context.ts
@@ -26,6 +26,12 @@ const collectionEntrySchema = z.object({
   config: z.record(z.unknown()).default({}),
   credentials: z.record(z.unknown()).default({}),
   assets: assetsConfigSchema,
+  /**
+   * Glob patterns matching filenames to hide from the collection root.
+   * These are merged with the theme's rootConfig() defaults during prepare.
+   * Example: ["draft.md", "*.wip"]
+   */
+  hide: z.array(z.string()).optional(),
 });
 
 /** Site config schema — immutable settings stored in <name>.yml */

--- a/packages/core/src/crawler/sync-engine.ts
+++ b/packages/core/src/crawler/sync-engine.ts
@@ -21,6 +21,9 @@ function serializeFolderConfig(config: FolderConfig): string {
   const lines: string[] = [];
   if (config.visible === false) lines.push("visible: false");
   if (config.sort === "DESC") lines.push("sort: DESC");
+  if (config.hide && config.hide.length > 0) {
+    lines.push(`hide: [${config.hide.join(", ")}]`);
+  }
   return lines.join("\n") + "\n";
 }
 
@@ -828,6 +831,7 @@ export class SyncEngine {
       const diskMarkdownFiles = await this.storage.list(this.markdownBasePath);
       for (const diskPath of diskMarkdownFiles) {
         if (isToolPath(diskPath)) continue;
+        if (diskPath.endsWith(".yml")) continue;
         if (!dbMarkdownPaths.has(diskPath)) {
           try {
             await this.storage.delete(diskPath);
@@ -886,11 +890,11 @@ export class SyncEngine {
 
   /**
    * Write <folder-name>.yml config files for all folders whose leaf name matches
-   * a key in the theme's folderConfigs(). Covers any depth (e.g. project/issues/).
+   * a key in the theme's folderConfigs(). Also writes content.yml for the root config.
+   * Covers any depth (e.g. project/issues/).
    */
   private async writeFolderConfigFiles(crawlerType: string): Promise<void> {
     const configs = this.themeEngine.getFolderConfigs(crawlerType);
-    if (Object.keys(configs).length === 0) return;
 
     // Use listDirs to cover empty directories too (file-based listing misses them)
     const allDirs = this.storage.listDirs
@@ -903,6 +907,9 @@ export class SyncEngine {
       const ymlPath = `${dirPath}/${folderName}.yml`;
       await this.storage.write(ymlPath, serializeFolderConfig(configs[folderName]));
     }
+
+    // Root content.yml is written only by prepare (which merges theme rootConfig
+    // with collection-level hide patterns). The yml survives reconcile (skipped above).
   }
 
   private async deleteEntity(externalId: string): Promise<boolean> {

--- a/packages/core/src/theme/engine.ts
+++ b/packages/core/src/theme/engine.ts
@@ -48,4 +48,20 @@ export class ThemeEngine {
     const theme = this.themes.get(crawlerType);
     return theme?.folderConfigs?.() ?? {};
   }
+
+  /** Return the root config for the given crawler type, or empty object if none defined. */
+  getRootConfig(crawlerType: string): FolderConfig {
+    const theme = this.themes.get(crawlerType);
+    return theme?.rootConfig?.() ?? {};
+  }
+
+  /** Generate AGENTS.md content for the given crawler type. Returns null if not supported. */
+  agentsMarkdown(
+    crawlerType: string,
+    options: { title: string; description?: string; config?: Record<string, unknown> },
+  ): string | null {
+    const theme = this.themes.get(crawlerType);
+    if (!theme?.agentsMarkdown) return null;
+    return theme.agentsMarkdown(options);
+  }
 }

--- a/packages/core/src/theme/interface.ts
+++ b/packages/core/src/theme/interface.ts
@@ -3,6 +3,12 @@ export interface FolderConfig {
   visible?: boolean;
   /** Sort order for files in this folder (default: ASC). */
   sort?: "ASC" | "DESC";
+  /**
+   * Glob patterns matching filenames to hide within this folder.
+   * Wildcards: * matches any sequence of characters, ? matches one character.
+   * Example: ["AGENTS.md", "CLAUDE.md", "*.draft"]
+   */
+  hide?: string[];
 }
 
 export interface ThemeRenderContext {
@@ -54,4 +60,19 @@ export interface Theme {
    * The sync engine writes these as <folder-name>.yml inside each matching folder.
    */
   folderConfigs?(): Record<string, FolderConfig>;
+  /**
+   * Optional: return the config for the content root directory.
+   * Merged with collection-level hide patterns and written as content/content.yml
+   * during prepare. Use this to specify default visibility or sort settings.
+   */
+  rootConfig?(): FolderConfig;
+  /**
+   * Optional: generate the body of AGENTS.md for this collection.
+   * Called during prepare to create/update the AI guidance file.
+   */
+  agentsMarkdown?(options: {
+    title: string;
+    description?: string;
+    config?: Record<string, unknown>;
+  }): string;
 }

--- a/packages/crawlers/src/git/theme.ts
+++ b/packages/crawlers/src/git/theme.ts
@@ -49,6 +49,30 @@ export class GitTheme implements Theme {
     };
   }
 
+  agentsMarkdown(options: { title: string; description?: string; config?: Record<string, unknown> }): string {
+    const { title, description } = options;
+    const lines: string[] = [];
+    lines.push(`# ${title}`);
+    lines.push("");
+    if (description) {
+      lines.push(description);
+    } else {
+      lines.push("This collection is synced from a Git repository.");
+    }
+    lines.push("");
+    lines.push("## Entity Types");
+    lines.push("");
+    lines.push("### Commits (`commits/`)");
+    lines.push("Git commits with full metadata including author, date, changed files, and diffs. Each commit is stored as `commits/{hash}-{subject}.md`.");
+    lines.push("");
+    lines.push("### Branches (`branches/`)");
+    lines.push("Git branches with their latest commit reference. Each branch is stored as `branches/{name}.md`.");
+    lines.push("");
+    lines.push("### Tags (`tags/`)");
+    lines.push("Git tags marking specific releases or points in history. Each tag is stored as `tags/{name}.md`.");
+    return lines.join("\n") + "\n";
+  }
+
   getFilePath(context: ThemeRenderContext): string {
     const { entity } = context;
     switch (entity.entityType) {

--- a/packages/crawlers/src/github/theme.ts
+++ b/packages/crawlers/src/github/theme.ts
@@ -419,6 +419,36 @@ export class GitHubTheme implements Theme {
     };
   }
 
+  agentsMarkdown(options: { title: string; description?: string; config?: Record<string, unknown> }): string {
+    const { title, description, config } = options;
+    const owner = config?.owner as string | undefined;
+    const repo = config?.repo as string | undefined;
+    const repoRef = owner && repo ? ` **${owner}/${repo}**` : "";
+
+    const lines: string[] = [];
+    lines.push(`# ${title}`);
+    lines.push("");
+    if (description) {
+      // Use the user-provided description as-is
+      lines.push(description);
+    } else {
+      // Fall back to a generic description when none is set
+      lines.push(`This collection is synced from the GitHub repository${repoRef}.`);
+    }
+    lines.push("");
+    lines.push("## Entity Types");
+    lines.push("");
+    lines.push("### Issues (`issues/`)");
+    lines.push("GitHub Issues representing bugs, feature requests, and tasks. Each issue is stored as a Markdown file named `{number}-{slug}.md`. Files include frontmatter with state, labels, and assignees, the original description, and all comments.");
+    lines.push("");
+    lines.push("### Pull Requests (`pull-requests/`)");
+    lines.push("GitHub Pull Requests representing proposed code changes. Each PR is stored as a Markdown file named `{number}-{slug}.md`. Files include frontmatter with state, base/head branches, and reviewers, the description, review comments, and check run results.");
+    lines.push("");
+    lines.push("### Users (`users/`)");
+    lines.push("GitHub user profiles referenced by issues and pull requests. Each user is stored as `users/{username}.md`.");
+    return lines.join("\n") + "\n";
+  }
+
   private renderIssue(context: ThemeRenderContext): string {
     const { entity } = context;
     const d = entity.data;

--- a/packages/crawlers/src/mantishub/theme.ts
+++ b/packages/crawlers/src/mantishub/theme.ts
@@ -354,6 +354,36 @@ export class MantisHubTheme implements Theme {
     };
   }
 
+  agentsMarkdown(options: { title: string; description?: string; config?: Record<string, unknown> }): string {
+    const { title, description, config } = options;
+    const baseUrl = config?.baseUrl as string | undefined;
+    const hostRef = baseUrl ? ` at **${baseUrl}**` : "";
+
+    const lines: string[] = [];
+    lines.push(`# ${title}`);
+    lines.push("");
+    if (description) {
+      lines.push(description);
+    } else {
+      lines.push(`This collection is synced from a MantisHub instance${hostRef}.`);
+    }
+    lines.push("");
+    lines.push("## Entity Types");
+    lines.push("");
+    lines.push("### Issues (`issues/`)");
+    lines.push("Issues represent a feature request, a task, or a bug report. Each issue is stored as a Markdown file with frontmatter containing status, priority, severity, category, and reporter. Files include the full description, notes, and references to attachments.");
+    lines.push("");
+    lines.push("### Projects (`projects/`)");
+    lines.push("Projects are containers for issues and wiki pages. A set of users generally have visibility and contribute to a project. Each project is stored as `projects/{name}.md`.");
+    lines.push("");
+    lines.push("### Users (`users/`)");
+    lines.push("These are user profile pages and are references from issues and wiki pages where such users are referenced. Each user is stored as `users/{name}.md`.");
+    lines.push("");
+    lines.push("### Pages (`pages/`)");
+    lines.push("Pages are wiki pages associated with projects. Each page is stored as `pages/{name}.md`.");
+    return lines.join("\n") + "\n";
+  }
+
   getFilePath(context: ThemeRenderContext): string {
     const d = context.entity.data;
 

--- a/packages/crawlers/src/obsidian/theme.ts
+++ b/packages/crawlers/src/obsidian/theme.ts
@@ -54,6 +54,24 @@ export class ObsidianTheme implements Theme {
     };
   }
 
+  agentsMarkdown(options: { title: string; description?: string }): string {
+    const { title, description } = options;
+    const lines: string[] = [];
+    lines.push(`# ${title}`);
+    lines.push("");
+    if (description) {
+      lines.push(description);
+    } else {
+      lines.push("This collection is synced from an Obsidian vault. Notes preserve their original vault folder structure.");
+    }
+    lines.push("");
+    lines.push("## Content");
+    lines.push("");
+    lines.push("### Notes");
+    lines.push("Markdown notes from the vault, with Obsidian-style wikilinks converted to standard Markdown links. The folder hierarchy matches the original vault layout.");
+    return lines.join("\n") + "\n";
+  }
+
   getFilePath(context: ThemeRenderContext): string {
     // Preserve the original vault-relative path
     return context.entity.data.relativePath as string;

--- a/packages/ui/src/components/manage/CollectionForm.tsx
+++ b/packages/ui/src/components/manage/CollectionForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 interface CollectionFormProps {
   /** If provided, editing existing collection; else creating new */
@@ -35,15 +35,38 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
   );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [discardPrompt, setDiscardPrompt] = useState(false);
 
-  // ESC dismisses the form
+  function hasUnsavedChanges(): boolean {
+    if (!editName) return false; // creating new — no prior state to compare
+    return (
+      title !== (editConfig?.title ?? "") ||
+      description !== (editConfig?.description ?? "") ||
+      JSON.stringify(config) !== JSON.stringify(configToStrings(editConfig?.config ?? {})) ||
+      JSON.stringify(credentials) !== JSON.stringify(configToStrings(editConfig?.credentials ?? {}))
+    );
+  }
+
+  function handleCancel() {
+    if (hasUnsavedChanges()) {
+      setDiscardPrompt(true);
+    } else {
+      onCancel();
+    }
+  }
+
+  // Keep a ref to always call the latest handleCancel without re-registering the listener
+  const handleCancelRef = useRef(handleCancel);
+  handleCancelRef.current = handleCancel;
+
+  // ESC dismisses the form (with confirmation if there are unsaved changes)
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCancel();
+      if (e.key === "Escape") handleCancelRef.current();
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [onCancel]);
+  }, []); // register once on mount
 
   function configToStrings(obj: Record<string, unknown>): Record<string, string> {
     const result: Record<string, string> = {};
@@ -99,6 +122,25 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
     }
   };
 
+  if (discardPrompt) {
+    return (
+      <div className="manage-panel">
+        <div className="manage-panel-header">
+          <h2>Discard changes?</h2>
+        </div>
+        <p className="manage-panel-subtitle">You have unsaved changes. Do you want to save or discard them?</p>
+        <div className="form-actions">
+          <button className="btn btn-secondary" onClick={() => setDiscardPrompt(false)}>Keep editing</button>
+          <button className="btn btn-secondary" onClick={onCancel}>Discard</button>
+          <button className="btn btn-primary" onClick={handleSubmit} disabled={saving}>
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+        {error && <div className="form-error">{error}</div>}
+      </div>
+    );
+  }
+
   if (step === 1) {
     return (
       <div className="manage-panel">
@@ -127,7 +169,7 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
     <div className="manage-panel">
       <div className="manage-panel-header">
         <h2>{editName ? `Edit: ${editName}` : `New ${CRAWLER_TYPES.find((c) => c.id === crawler)?.label} Collection`}</h2>
-        <button className="btn btn-sm" onClick={onCancel}>Cancel</button>
+        <button className="btn btn-sm" onClick={handleCancel}>Cancel</button>
       </div>
 
       <div className="form-group">
@@ -177,7 +219,7 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
       {error && <div className="form-error">{error}</div>}
 
       <div className="form-actions">
-        <button className="btn btn-secondary" onClick={onCancel}>Cancel</button>
+        <button className="btn btn-secondary" onClick={handleCancel}>Cancel</button>
         <button
           className="btn btn-primary"
           onClick={handleSubmit}

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -102,10 +102,23 @@ api.get("/api/collections/:name/tree", async (c) => {
   const name = c.req.param("name");
   const prefix = `${name}/content/`;
 
+  // Fetch root config (content/content.yml) for collection-root-level settings (e.g. hide list)
+  const rootConfigObj = await c.env.BUCKET.get(`${prefix}content.yml`);
+  const rootConfig = rootConfigObj ? parseFolderConfig(await rootConfigObj.text()) : {};
+  const rootHide = rootConfig.hide ?? [];
+
   const listed = await c.env.BUCKET.list({ prefix });
   const mdPaths = listed.objects
     .map((o) => o.key.slice(prefix.length))
-    .filter((p) => p.endsWith(".md"));
+    .filter((p) => p.endsWith(".md"))
+    // Apply root-level hide patterns to files at the root (no subdirectory)
+    .filter((p) => {
+      const parts = p.split("/");
+      if (parts.length === 1 && rootHide.length > 0) {
+        return !matchesHidePattern(rootHide, parts[0]);
+      }
+      return true;
+    });
 
   // Fetch entity titles from D1 to display instead of raw filenames
   const titleByPath = new Map<string, string>();
@@ -135,7 +148,7 @@ api.get("/api/collections/:name/tree", async (c) => {
     }
   }
 
-  const folderConfigs = new Map<string, { visible?: boolean; sort?: "ASC" | "DESC" }>();
+  const folderConfigs = new Map<string, { visible?: boolean; sort?: "ASC" | "DESC"; hide?: string[] }>();
   await Promise.all(
     [...folderPaths].map(async (folderPath) => {
       const folderName = folderPath.split("/").pop()!;
@@ -301,15 +314,40 @@ api.get("/api/attachments/:collection/*", async (c) => {
   });
 });
 
-/** Parse a minimal folder yml (visible/sort only). Works without js-yaml in the Worker runtime. */
-function parseFolderConfig(content: string): { visible?: boolean; sort?: "ASC" | "DESC" } {
-  const config: { visible?: boolean; sort?: "ASC" | "DESC" } = {};
+/** Returns true if `filename` matches any of the glob patterns. */
+function matchesHidePattern(patterns: string[], filename: string): boolean {
+  return patterns.some((pattern) => {
+    const re = new RegExp(
+      "^" +
+        pattern
+          .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+          .replace(/\*/g, ".*")
+          .replace(/\?/g, ".") +
+        "$",
+    );
+    return re.test(filename);
+  });
+}
+
+/** Parse a minimal folder yml (visible/sort/hide). Works without js-yaml in the Worker runtime. */
+function parseFolderConfig(content: string): { visible?: boolean; sort?: "ASC" | "DESC"; hide?: string[] } {
+  const config: { visible?: boolean; sort?: "ASC" | "DESC"; hide?: string[] } = {};
   for (const line of content.split("\n")) {
     const m = line.match(/^(\w+):\s*(.+)$/);
     if (!m) continue;
     const [, key, val] = m;
     if (key === "visible") config.visible = val.trim() !== "false";
     if (key === "sort") config.sort = val.trim() === "DESC" ? "DESC" : "ASC";
+    if (key === "hide") {
+      // Parse inline YAML array: [item1, item2] or ["item1", "item2"]
+      const arrayMatch = val.trim().match(/^\[(.+)\]$/);
+      if (arrayMatch) {
+        config.hide = arrayMatch[1]
+          .split(",")
+          .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+          .filter(Boolean);
+      }
+    }
   }
   return config;
 }
@@ -318,7 +356,7 @@ function parseFolderConfig(content: string): { visible?: boolean; sort?: "ASC" |
 function buildTreeFromPaths(
   paths: string[],
   titleByPath: Map<string, string> = new Map(),
-  folderConfigs: Map<string, { visible?: boolean; sort?: "ASC" | "DESC" }> = new Map(),
+  folderConfigs: Map<string, { visible?: boolean; sort?: "ASC" | "DESC"; hide?: string[] }> = new Map(),
 ): object[] {
   interface TreeNode {
     name: string;
@@ -366,10 +404,11 @@ function buildTreeFromPaths(
     }
   }
 
-  // Sort: directories first (ASC), files per-folder config (ASC or DESC); prune hidden dirs
+  // Sort: directories first (ASC), files per-folder config (ASC or DESC); prune hidden dirs/files
   function sortTree(nodes: TreeNode[], parentPath: string = ""): TreeNode[] {
     const config = parentPath ? folderConfigs.get(parentPath) : undefined;
     const sortOrder = config?.sort ?? "ASC";
+    const folderHide = config?.hide ?? [];
 
     const dirs = nodes
       .filter((n) => n.type === "directory")
@@ -379,7 +418,9 @@ function buildTreeFromPaths(
       })
       .sort((a, b) => a.name.localeCompare(b.name));
 
-    const files = nodes.filter((n) => n.type === "file");
+    const files = nodes
+      .filter((n) => n.type === "file")
+      .filter((n) => folderHide.length === 0 || !matchesHidePattern(folderHide, n.name));
     if (sortOrder === "DESC") {
       files.sort((a, b) => b.name.localeCompare(a.name));
     } else {


### PR DESCRIPTION
## Summary

- **AGENTS.md/CLAUDE.md generation**: Themes produce AI-guidance files during prepare, placed at collection root (outside `content/`) so they survive sync reconcile and don't collide with Obsidian vault notes
- **Hide file patterns**: Collection-level and folder-level `hide` config support in content.yml, merged from theme defaults and user settings
- **Folder config files**: Theme-driven `<folder>.yml` settings (visible, sort, hide) written during prepare and sync
- **Prepare step**: New `prepare` command runs schema migrations, writes folder/root configs, samples entities for staleness, and regenerates if needed
- **Bug fixes**: Missing `getFrozenInkHome()` in API handlers, `.yml` files protected from reconcile orphan cleanup, root `content.yml` only written by prepare (not overwritten by sync)

## Test plan

- [x] `bun test packages/core/src/ packages/crawlers/src/ packages/mcp/src/` — 322 tests pass
- [x] `cd packages/ui && bun x vitest run` — 27 tests pass
- [x] `cd packages/ui && bun run build` — UI build succeeds
- [ ] Manual: sync a collection, verify AGENTS.md at collection root (not content/), verify content.yml with collection-level hide survives sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)