### PR TITLE
Add tableplus and vscode CLI commands

### DIFF
--- a/packages/cli/src/commands/tableplus.ts
+++ b/packages/cli/src/commands/tableplus.ts
@@ -1,0 +1,25 @@
+import { Command } from "commander";
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import { ensureInitialized, getCollection, getCollectionDbPath } from "@frozenink/core";
+
+export const tableplusCommand = new Command("tableplus")
+  .description("Open a collection's SQLite database in TablePlus")
+  .argument("<collection>", "Collection name")
+  .action((collection: string) => {
+    ensureInitialized();
+
+    const col = getCollection(collection);
+    if (!col) {
+      console.error(`Collection "${collection}" not found`);
+      process.exit(1);
+    }
+
+    const dbPath = getCollectionDbPath(collection);
+    if (!existsSync(dbPath)) {
+      console.error(`Database not found at ${dbPath}`);
+      process.exit(1);
+    }
+
+    execSync(`open -a TablePlus "${dbPath}"`);
+  });

--- a/packages/cli/src/commands/vscode.ts
+++ b/packages/cli/src/commands/vscode.ts
@@ -1,0 +1,34 @@
+import { Command } from "commander";
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+import { getFrozenInkHome, ensureInitialized, getCollection } from "@frozenink/core";
+
+export const vscodeCommand = new Command("vscode")
+  .description("Open a collection folder in VS Code (defaults to ~/.frozenink)")
+  .argument("[collection]", "Collection name (optional)")
+  .action((collection?: string) => {
+    const home = getFrozenInkHome();
+
+    let folderPath: string;
+
+    if (collection) {
+      ensureInitialized();
+
+      const col = getCollection(collection);
+      if (!col) {
+        console.error(`Collection "${collection}" not found`);
+        process.exit(1);
+      }
+
+      folderPath = join(home, "collections", collection);
+      if (!existsSync(folderPath)) {
+        console.error(`Collection folder not found at ${folderPath}`);
+        process.exit(1);
+      }
+    } else {
+      folderPath = home;
+    }
+
+    execSync(`code "${folderPath}"`);
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,8 @@ import { updateCommand } from "./commands/update";
 import { unpublishCommand } from "./commands/unpublish";
 import { tuiCommand } from "./commands/tui";
 import { mcpCommand } from "./commands/mcp";
+import { tableplusCommand } from "./commands/tableplus";
+import { vscodeCommand } from "./commands/vscode";
 import { startTui } from "./tui/index";
 
 const program = new Command();
@@ -41,6 +43,8 @@ program.addCommand(publishCommand);
 program.addCommand(unpublishCommand);
 program.addCommand(tuiCommand);
 program.addCommand(mcpCommand);
+program.addCommand(tableplusCommand);
+program.addCommand(vscodeCommand);
 
 // If no arguments passed (just "fink"), launch TUI by default
 const args = process.argv.slice(2);


### PR DESCRIPTION
## Summary
- `fink tableplus <collection>` — opens the collection's SQLite db directly in TablePlus
- `fink vscode [collection]` — opens the collection folder in VS Code, or `~/.frozenink` if no collection specified
- CLI-only commands, not reflected in docs, TUI, or desktop app

## Test plan
- [ ] Run `fink tableplus <collection>` and verify TablePlus opens with the correct database
- [ ] Run `fink vscode <collection>` and verify VS Code opens the collection folder
- [ ] Run `fink vscode` with no args and verify VS Code opens `~/.frozenink`
- [ ] Test error cases: nonexistent collection name

🤖 Generated with [Claude Code](https://claude.com/claude-code)