### PR TITLE
Linkify issue refs in all MantisHub text fields and add custom field support

### DIFF
--- a/packages/crawlers/src/mantishub/__tests__/theme.test.ts
+++ b/packages/crawlers/src/mantishub/__tests__/theme.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "bun:test";
+import { MantisHubTheme } from "../theme";
+import type { ThemeRenderContext } from "@frozenink/core/theme";
+
+const theme = new MantisHubTheme();
+
+/** Minimal lookup covering issues 100 and 200. */
+const lookup = (externalId: string): string | undefined => {
+  const map: Record<string, string> = {
+    "issue:100": "issues/00100-linked-issue",
+    "issue:200": "issues/00200-another-issue",
+    "user:alice": "users/alice",
+  };
+  return map[externalId];
+};
+
+function makeIssueContext(overrides: Partial<ThemeRenderContext["entity"]["data"]> = {}): ThemeRenderContext {
+  return {
+    entity: {
+      externalId: "issue:42",
+      entityType: "issue",
+      title: "00042: Sample Issue",
+      data: {
+        id: 42,
+        summary: "Sample issue summary",
+        description: "Issue description",
+        stepsToReproduce: "",
+        additionalInformation: "",
+        project: { id: 1, name: "TestProject" },
+        category: { id: 1, name: "general" },
+        reporter: { id: 1, name: "alice" },
+        handler: null,
+        status: { id: 10, name: "new", label: "New", color: "#aaa" },
+        resolution: { id: 10, name: "open", label: "Open" },
+        priority: { id: 30, name: "normal", label: "Normal" },
+        severity: { id: 50, name: "minor", label: "Minor" },
+        reproducibility: null,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-02T00:00:00Z",
+        sticky: false,
+        attachments: [],
+        notes: [],
+        relationships: [],
+        customFields: [],
+        _projectNameToId: {},
+        _singleProject: false,
+        ...overrides,
+      },
+      tags: [],
+    },
+    collectionName: "test",
+    crawlerType: "mantishub",
+    lookupEntityPath: lookup,
+  };
+}
+
+describe("MantisHubTheme HTML issue-ref linkification", () => {
+  it("linkifies #N in additional information", () => {
+    const ctx = makeIssueContext({ additionalInformation: "Regression introduced by #100" });
+    const html = theme.renderHtml!(ctx);
+    expect(html).toContain('class="mt-issue-ref"');
+    expect(html).toContain("#wikilink/issues%2F00100-linked-issue");
+    expect(html).toContain("#00100");
+  });
+
+  it("does not linkify #N without a matching issue in lookup", () => {
+    const ctx = makeIssueContext({ additionalInformation: "See #9999 for context" });
+    const html = theme.renderHtml!(ctx);
+    // #9999 has no entry in lookup → plain text
+    expect(html).toContain("#9999");
+    expect(html).not.toContain("#wikilink/issues%2F09999");
+  });
+
+  it("linkifies #N in description", () => {
+    const ctx = makeIssueContext({ description: "Relates to #100 and #200" });
+    const html = theme.renderHtml!(ctx);
+    expect(html).toContain("#wikilink/issues%2F00100-linked-issue");
+    expect(html).toContain("#wikilink/issues%2F00200-another-issue");
+  });
+
+  it("linkifies #N in steps to reproduce", () => {
+    const ctx = makeIssueContext({ stepsToReproduce: "As described in #100, follow these steps." });
+    const html = theme.renderHtml!(ctx);
+    expect(html).toContain("#wikilink/issues%2F00100-linked-issue");
+  });
+
+  it("linkifies #N in summary title", () => {
+    const ctx = makeIssueContext({ summary: "Regression from #100 fix" });
+    const html = theme.renderHtml!(ctx);
+    expect(html).toContain("mt-title");
+    expect(html).toContain("#wikilink/issues%2F00100-linked-issue");
+  });
+
+  it("linkifies #N in text custom fields", () => {
+    const ctx = makeIssueContext({
+      customFields: [
+        { id: 1, name: "Root Cause", value: "Introduced by #100 refactor" },
+        { id: 2, name: "Fix Version", value: "2.5.0" },
+      ],
+    });
+    const html = theme.renderHtml!(ctx);
+    expect(html).toContain("Root Cause");
+    expect(html).toContain("#wikilink/issues%2F00100-linked-issue");
+    // Plain value with no issue ref renders as-is
+    expect(html).toContain("2.5.0");
+  });
+
+  it("skips empty custom field values", () => {
+    const ctx = makeIssueContext({
+      customFields: [{ id: 1, name: "Empty Field", value: "" }],
+    });
+    const html = theme.renderHtml!(ctx);
+    expect(html).not.toContain("Empty Field");
+  });
+});
+
+describe("MantisHubTheme markdown issue-ref linkification", () => {
+  it("linkifies #N in additional information (markdown)", () => {
+    const ctx = makeIssueContext({ additionalInformation: "Regression from #100" });
+    const md = theme.render(ctx);
+    expect(md).toContain("[[issues/00100-linked-issue|#00100]]");
+  });
+
+  it("linkifies #N in text custom fields (markdown)", () => {
+    const ctx = makeIssueContext({
+      customFields: [{ id: 1, name: "Root Cause", value: "See #100 for details" }],
+    });
+    const md = theme.render(ctx);
+    expect(md).toContain("### Root Cause");
+    expect(md).toContain("[[issues/00100-linked-issue|#00100]]");
+  });
+
+  it("skips empty custom field values (markdown)", () => {
+    const ctx = makeIssueContext({
+      customFields: [{ id: 1, name: "Empty", value: "" }],
+    });
+    const md = theme.render(ctx);
+    expect(md).not.toContain("### Empty");
+  });
+});

--- a/packages/crawlers/src/mantishub/crawler.ts
+++ b/packages/crawlers/src/mantishub/crawler.ts
@@ -1076,6 +1076,11 @@ export class MantisHubCrawler implements Crawler {
           }),
         })),
         relationships: issue.relationships ?? [],
+        customFields: (issue.custom_fields ?? []).map((cf) => ({
+          id: cf.field.id,
+          name: cf.field.name,
+          value: cf.value,
+        })),
         _projectNameToId: this.getProjectNameToId(),
         _singleProject: !!this.projectId,
       },

--- a/packages/crawlers/src/mantishub/theme.ts
+++ b/packages/crawlers/src/mantishub/theme.ts
@@ -468,7 +468,7 @@ export class MantisHubTheme implements Theme {
       const crumbs = [projectHtml, category ? esc(category.name) : null, esc(padId(d.id as number))].filter(Boolean);
       parts.push(`<div class="mt-breadcrumb">${crumbs.join(" &rsaquo; ")}</div>`);
     }
-    parts.push(`<h1 class="mt-title">${esc(d.summary as string)}</h1>`);
+    parts.push(`<h1 class="mt-title">${textToHtml(d.summary as string, lookup, projectId, projectNameToId)}</h1>`);
 
     // Tags as badges
     const tags = context.entity.tags ?? [];
@@ -498,6 +498,14 @@ export class MantisHubTheme implements Theme {
     if (d.additionalInformation) {
       parts.push(`<h3 class="mt-subsection-title">Additional Information</h3>`);
       parts.push(`<div class="mt-description">${textToHtml(d.additionalInformation as string, lookup, projectId, projectNameToId)}</div>`);
+    }
+
+    // Text custom fields
+    const customFields = d.customFields as Array<{ id: number; name: string; value: string }> | undefined;
+    for (const cf of customFields ?? []) {
+      if (!cf.value) continue;
+      parts.push(`<h3 class="mt-subsection-title">${esc(cf.name)}</h3>`);
+      parts.push(`<div class="mt-description">${textToHtml(cf.value, lookup, projectId, projectNameToId)}</div>`);
     }
 
     // Issue-level attachments
@@ -994,6 +1002,13 @@ export class MantisHubTheme implements Theme {
         "### Additional Information\n\n" +
           linkifyContent(d.additionalInformation as string, lookup, projectId, projectNameToId),
       );
+    }
+
+    // Text custom fields
+    const customFields = d.customFields as Array<{ id: number; name: string; value: string }> | undefined;
+    for (const cf of customFields ?? []) {
+      if (!cf.value) continue;
+      sections.push(`### ${cf.name}\n\n${linkifyContent(cf.value, lookup, projectId, projectNameToId)}`);
     }
 
     // Relationships — label: "00042 Title" (no # prefix)

--- a/packages/crawlers/src/mantishub/types.ts
+++ b/packages/crawlers/src/mantishub/types.ts
@@ -118,4 +118,8 @@ export interface MantisHubIssue {
     message: string;
     field?: { name: string; old_value: string; new_value: string };
   }>;
+  custom_fields?: Array<{
+    field: { id: number; name: string };
+    value: string;
+  }>;
 }


### PR DESCRIPTION
## Summary

- Issue refs (`#N`) in **summary, description, steps to reproduce, additional information, and text custom fields** are now hyperlinked in both HTML and markdown rendering
- Added `custom_fields` support: the MantisHub REST API response's `custom_fields` array is now stored in entity data and rendered as named subsections with full issue-ref linkification
- Added `theme.test.ts` with 10 tests covering all text fields in HTML and markdown output

## Details

**`types.ts`** — Added `custom_fields?: Array<{ field: { id, name }; value: string }>` to `MantisHubIssue`

**`crawler.ts`** — Maps API `custom_fields` → `customFields: [{ id, name, value }]` in stored entity data

**`theme.ts`**:
- Summary HTML `<h1>`: `esc()` → `textToHtml()` so `#N` refs in titles get hyperlinked
- Custom fields HTML: each non-empty field rendered as `<h3>` + `textToHtml()` body
- Custom fields markdown: each non-empty field rendered as `### Name` + `linkifyContent()` body

## Test plan

- [x] `bun test packages/crawlers/src/mantishub/` — 15 tests pass (5 existing + 10 new)
- [x] `bun test packages/crawlers/src/` and `bun test packages/core/src/` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)