### PR TITLE
Add SQLite metadata key-value store

### DIFF
--- a/packages/core/src/db/__tests__/metadata.test.ts
+++ b/packages/core/src/db/__tests__/metadata.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { MetadataStore } from "../metadata";
+
+const TEST_DIR = join(import.meta.dir, ".test-dbs-metadata");
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("MetadataStore", () => {
+  it("set then get returns the stored value", () => {
+    const store = new MetadataStore(join(TEST_DIR, "meta.db"));
+    store.set("cursor", "abc123");
+    expect(store.get("cursor")).toBe("abc123");
+    store.close();
+  });
+
+  it("get on missing key without default throws", () => {
+    const store = new MetadataStore(join(TEST_DIR, "meta.db"));
+    expect(() => store.get("missing")).toThrow('Metadata key not found: "missing"');
+    store.close();
+  });
+
+  it("get on missing key with default returns the default", () => {
+    const store = new MetadataStore(join(TEST_DIR, "meta.db"));
+    expect(store.get("missing", "fallback")).toBe("fallback");
+    store.close();
+  });
+
+  it("get on present key ignores the default", () => {
+    const store = new MetadataStore(join(TEST_DIR, "meta.db"));
+    store.set("key", "real-value");
+    expect(store.get("key", "fallback")).toBe("real-value");
+    store.close();
+  });
+
+  it("set overwrites an existing key", () => {
+    const store = new MetadataStore(join(TEST_DIR, "meta.db"));
+    store.set("version", "1");
+    store.set("version", "2");
+    expect(store.get("version")).toBe("2");
+    store.close();
+  });
+
+  it("multiple distinct keys are independent", () => {
+    const store = new MetadataStore(join(TEST_DIR, "meta.db"));
+    store.set("a", "alpha");
+    store.set("b", "beta");
+    expect(store.get("a")).toBe("alpha");
+    expect(store.get("b")).toBe("beta");
+    store.close();
+  });
+
+  it("persists across instances with the same dbPath", () => {
+    const dbPath = join(TEST_DIR, "meta.db");
+    const store1 = new MetadataStore(dbPath);
+    store1.set("sync_cursor", "xyz789");
+    store1.close();
+
+    const store2 = new MetadataStore(dbPath);
+    expect(store2.get("sync_cursor")).toBe("xyz789");
+    store2.close();
+  });
+});

--- a/packages/core/src/db/metadata.ts
+++ b/packages/core/src/db/metadata.ts
@@ -1,0 +1,41 @@
+import { openDatabase } from "../compat/sqlite";
+
+export class MetadataStore {
+  private sqlite: any;
+
+  constructor(dbPath: string) {
+    this.sqlite = openDatabase(dbPath);
+    this.sqlite.exec("PRAGMA journal_mode = WAL;");
+    this.sqlite.exec(`
+      CREATE TABLE IF NOT EXISTS metadata (
+        key   TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `);
+  }
+
+  get(key: string): string;
+  get(key: string, defaultValue: string): string;
+  get(key: string, defaultValue?: string): string {
+    const row = this.sqlite
+      .prepare("SELECT value FROM metadata WHERE key = ?")
+      .get(key) as { value: string } | undefined;
+    if (row != null) {
+      return row.value;
+    }
+    if (defaultValue !== undefined) {
+      return defaultValue;
+    }
+    throw new Error(`Metadata key not found: "${key}"`);
+  }
+
+  set(key: string, value: string): void {
+    this.sqlite
+      .prepare("INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)")
+      .run(key, value);
+  }
+
+  close(): void {
+    this.sqlite.close();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `MetadataStore` class (`packages/core/src/db/metadata.ts`) backed by a `metadata (key TEXT, value TEXT)` SQLite table for persisting string key-value pairs (sync cursors, config snapshots, version markers)
- Follows the `SearchIndexer` pattern: own raw SQLite connection, `CREATE TABLE IF NOT EXISTS` in constructor, WAL mode
- Overloaded `get(key)` throws on missing keys; `get(key, default)` returns the fallback; `set(key, value)` upserts via `INSERT OR REPLACE`

## Test plan

- [x] 7 bun:test cases covering: set/get roundtrip, missing key throws, default value, present key ignores default, upsert overwrite, key independence, cross-instance persistence
- [x] All existing test suites pass (334 tests across core/crawlers/mcp/ui)
- [x] Markdown lint passes
- [x] UI build passes
- [x] Note: typecheck and worker build have pre-existing failures on `main` (unresolved `@frozenink/core/theme` imports), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)