### PR TITLE
Move credentials to separate credentials.yml file

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -9,6 +9,8 @@ import {
   getCollection,
   addCollection,
   getCollectionDbPath,
+  getNamedCredentials,
+  resolveCredentials,
 } from "@frozenink/core";
 import { createDefaultRegistry, MantisHubCrawler } from "@frozenink/crawlers";
 
@@ -29,6 +31,7 @@ export const addCommand = new Command("add")
   .option("--max-prs <count>", "Maximum pull requests to sync (for github)", parseInt)
   .option("--open-only", "Only sync open issues/PRs, delete closed ones (for github)")
   .option("--sync-entities <types>", "Comma-separated entity types to sync: issues,pages,users (for mantishub)")
+  .option("--credentials <name>", "Use a named credential set from ~/.frozenink/credentials.yml")
   .action(async (crawlerType: string, opts: Record<string, string>) => {
     ensureInitialized();
 
@@ -53,14 +56,36 @@ export const addCommand = new Command("add")
     }
 
     // Build credentials and config based on crawler type
-    const credentials: Record<string, unknown> = {};
+    let credentials: string | Record<string, unknown> = {};
     const config: Record<string, unknown> = {};
 
-    if (crawlerType === "github") {
-      if (!opts.token || !opts.repo) {
+    // If --credentials is specified, use a named credential set from credentials.yml
+    if (opts.credentials) {
+      const credentialsPath = join(getFrozenInkHome(), "credentials.yml");
+      const named = getNamedCredentials(opts.credentials);
+      if (!named) {
         console.error(
-          "GitHub crawler requires --token and --repo (in owner/repo format)",
+          `Credential set "${opts.credentials}" not found.\nDefine it in ${credentialsPath} — see the file for format and examples.`,
         );
+        process.exit(1);
+      }
+      credentials = opts.credentials; // store the reference name
+    }
+
+    // Build inline credentials only when not using a named reference
+    const useNamedCreds = typeof credentials === "string";
+
+    if (crawlerType === "github") {
+      if (!useNamedCreds) {
+        if (!opts.token || !opts.repo) {
+          console.error(
+            "GitHub crawler requires --token and --repo (in owner/repo format), or --credentials <name>",
+          );
+          process.exit(1);
+        }
+        (credentials as Record<string, unknown>).token = opts.token;
+      } else if (!opts.repo) {
+        console.error("GitHub crawler requires --repo (in owner/repo format)");
         process.exit(1);
       }
       const repoParts = (opts.repo as string).split("/");
@@ -71,14 +96,12 @@ export const addCommand = new Command("add")
         process.exit(1);
       }
       const [ghOwner, ghRepo] = repoParts;
-      credentials.token = opts.token;
       config.owner = ghOwner;
       config.repo = ghRepo;
       if (opts.openOnly) {
         config.openOnly = true;
       }
       if (opts.max) {
-        // --max sets both per-type limits (e.g. --max 20 = at most 20 issues + 20 PRs)
         config.maxIssues = opts.max;
         config.maxPullRequests = opts.max;
       }
@@ -95,7 +118,9 @@ export const addCommand = new Command("add")
       }
       const { resolve } = await import("path");
       const vaultPath = resolve(opts.path);
-      credentials.vaultPath = vaultPath;
+      if (!useNamedCreds) {
+        (credentials as Record<string, unknown>).vaultPath = vaultPath;
+      }
       config.vaultPath = vaultPath;
     } else if (crawlerType === "mantishub") {
       if (!opts.url) {
@@ -103,8 +128,10 @@ export const addCommand = new Command("add")
         process.exit(1);
       }
       config.url = opts.url;
-      credentials.token = opts.token ?? "";
-      credentials.url = opts.url;
+      if (!useNamedCreds) {
+        (credentials as Record<string, unknown>).token = opts.token ?? "";
+        (credentials as Record<string, unknown>).url = opts.url;
+      }
       if (opts.projectName) {
         config.project = { name: opts.projectName };
       }
@@ -129,18 +156,23 @@ export const addCommand = new Command("add")
       }
       const { resolve } = await import("path");
       const repoPath = resolve(opts.path);
-      credentials.repoPath = repoPath;
+      if (!useNamedCreds) {
+        (credentials as Record<string, unknown>).repoPath = repoPath;
+      }
       config.repoPath = repoPath;
       if (opts.includeDiffs) {
         config.includeDiffs = true;
       }
     }
 
+    // Resolve credentials for validation (named ref → concrete object)
+    const resolvedCreds = resolveCredentials(credentials);
+
     // Validate credentials
     const factory = registry.get(crawlerType)!;
     const crawler = factory();
     console.log("Validating credentials...");
-    const valid = await crawler.validateCredentials(credentials);
+    const valid = await crawler.validateCredentials(resolvedCreds);
 
     if (!valid) {
       console.error("Credential validation failed. Check your token and access.");
@@ -151,7 +183,7 @@ export const addCommand = new Command("add")
     const project = config.project as { id?: number; name?: string } | undefined;
     if (crawlerType === "mantishub" && project?.name) {
       try {
-        await crawler.initialize(config, credentials);
+        await crawler.initialize(config, resolvedCreds);
         const resolved = await (crawler as MantisHubCrawler).resolveProjectName(project.name);
         config.project = { id: resolved.id, name: resolved.name };
         console.log(`  Resolved project "${resolved.name}" → ID ${resolved.id}`);
@@ -171,10 +203,10 @@ export const addCommand = new Command("add")
     // Create markdown output directory
     mkdirSync(join(collectionDir, "content"), { recursive: true });
 
-    // For MantisHub, don't store url in credentials (it's already in config)
-    if (crawlerType === "mantishub") {
-      delete credentials.url;
-      delete credentials.baseUrl;
+    // For MantisHub with inline credentials, don't store url (it's already in config)
+    if (crawlerType === "mantishub" && !useNamedCreds) {
+      delete (credentials as Record<string, unknown>).url;
+      delete (credentials as Record<string, unknown>).baseUrl;
     }
 
     // Save collection config

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -12,6 +12,7 @@ import {
   ThemeEngine,
   LocalStorageBackend,
   spawnDetached,
+  resolveCredentials,
 } from "@frozenink/core";
 import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme } from "@frozenink/crawlers";
 
@@ -52,7 +53,7 @@ async function runSyncLoop(intervalMs: number): Promise<void> {
       try {
         await crawler.initialize(
           col.config as Record<string, unknown>,
-          col.credentials as Record<string, unknown>,
+          resolveCredentials(col.credentials),
         );
 
         const collectionDir = join(home, "collections", col.name);

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -22,6 +22,9 @@ import {
   ThemeEngine,
   LocalStorageBackend,
   entities,
+  resolveCredentials,
+  listNamedCredentials,
+  getNamedCredentials,
 } from "@frozenink/core";
 import {
   createDefaultRegistry,
@@ -160,6 +163,18 @@ export function handleManagementRequest(req: Request): Response | null {
     });
   }
 
+  // --- Credentials CRUD ---
+
+  // GET /api/credentials — list named credential sets (names + keys only)
+  if (path === "/api/credentials" && method === "GET") {
+    const names = listNamedCredentials();
+    const items = names.map((name) => {
+      const creds = getNamedCredentials(name)!;
+      return { name, keys: Object.keys(creds) };
+    });
+    return jsonResponse(items);
+  }
+
   // --- Collection CRUD ---
 
   // POST /api/collections (add collection)
@@ -170,7 +185,7 @@ export function handleManagementRequest(req: Request): Response | null {
       const crawler = body.crawler as string;
       if (!name || !crawler) return errorResponse("Missing name or crawler", 400);
       const config = (body.config ?? {}) as Record<string, unknown>;
-      const credentials = (body.credentials ?? {}) as Record<string, unknown>;
+      const credentials = (body.credentials ?? {}) as string | Record<string, unknown>;
       const title = (body.title as string) ?? name;
       const description = (body.description as string) || undefined;
       const enabled = body.enabled !== false;
@@ -180,7 +195,7 @@ export function handleManagementRequest(req: Request): Response | null {
         try {
           const registry = createDefaultRegistry();
           const crawlerInstance = registry.get("mantishub")!() as MantisHubCrawler;
-          await crawlerInstance.initialize(config, credentials);
+          await crawlerInstance.initialize(config, resolveCredentials(credentials));
           const resolved = await crawlerInstance.resolveProjectName(config.projectName as string);
           config.projectId = resolved.id;
           config.projectName = resolved.name;
@@ -535,7 +550,7 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
       try {
         await crawler.initialize(
           col.config as Record<string, unknown>,
-          col.credentials as Record<string, unknown>,
+          resolveCredentials(col.credentials),
         );
 
         const collectionDir = join(home, "collections", name);

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -12,6 +12,7 @@ import {
   SearchIndexer,
   entityMarkdownPath,
   splitMarkdownPath,
+  resolveCredentials,
 } from "@frozenink/core";
 import type { EntityData } from "@frozenink/core";
 import { eq } from "drizzle-orm";
@@ -65,7 +66,8 @@ export const pullCommand = new Command("pull")
       process.exit(1);
     }
 
-    const password = (col.credentials as any)?.password;
+    const resolved = resolveCredentials(col.credentials);
+    const password = (resolved as any)?.password;
     const client = new RemoteClient(sourceUrl, password);
 
     const dbPath = getCollectionDbPath(collection);

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -12,6 +12,7 @@ import {
   ThemeEngine,
   LocalStorageBackend,
   entities,
+  resolveCredentials,
 } from "@frozenink/core";
 import { sql } from "drizzle-orm";
 import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme, mantisHubTheme } from "@frozenink/crawlers";
@@ -92,7 +93,7 @@ export const syncCommand = new Command("sync")
       }
       await crawler.initialize(
         config,
-        col.credentials as Record<string, unknown>,
+        resolveCredentials(col.credentials),
       );
 
       const dbPath = getCollectionDbPath(col.name);

--- a/packages/cli/src/tui/components/AddCollection.tsx
+++ b/packages/cli/src/tui/components/AddCollection.tsx
@@ -10,6 +10,7 @@ import {
   getCollection,
   addCollection,
   isValidCollectionKey,
+  resolveCredentials,
 } from "@frozenink/core";
 import { createDefaultRegistry, MantisHubCrawler } from "@frozenink/crawlers";
 import { SelectInput, type SelectItem } from "./SelectInput.js";

--- a/packages/core/src/config/__tests__/credentials.test.ts
+++ b/packages/core/src/config/__tests__/credentials.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import {
+  loadCredentials,
+  getNamedCredentials,
+  saveNamedCredentials,
+  removeNamedCredentials,
+  listNamedCredentials,
+  resolveCredentials,
+} from "../credentials";
+import {
+  addCollection,
+  getCollection,
+  ensureInitialized,
+} from "../context";
+
+const TEST_DIR = join(import.meta.dir, ".test-credentials");
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  process.env.FROZENINK_HOME = TEST_DIR;
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  delete process.env.FROZENINK_HOME;
+});
+
+describe("loadCredentials", () => {
+  it("returns empty object when file does not exist", () => {
+    expect(loadCredentials()).toEqual({});
+  });
+});
+
+describe("saveNamedCredentials / getNamedCredentials", () => {
+  it("saves and retrieves a credential set", () => {
+    saveNamedCredentials("my-github", { token: "ghp_abc123" });
+    const creds = getNamedCredentials("my-github");
+    expect(creds).toEqual({ token: "ghp_abc123" });
+  });
+
+  it("returns null for missing name", () => {
+    expect(getNamedCredentials("nonexistent")).toBeNull();
+  });
+
+  it("updates an existing credential set", () => {
+    saveNamedCredentials("my-github", { token: "old" });
+    saveNamedCredentials("my-github", { token: "new" });
+    expect(getNamedCredentials("my-github")).toEqual({ token: "new" });
+  });
+
+  it("preserves other entries when saving", () => {
+    saveNamedCredentials("a", { token: "aaa" });
+    saveNamedCredentials("b", { token: "bbb" });
+    expect(getNamedCredentials("a")).toEqual({ token: "aaa" });
+    expect(getNamedCredentials("b")).toEqual({ token: "bbb" });
+  });
+});
+
+describe("removeNamedCredentials", () => {
+  it("removes an entry", () => {
+    saveNamedCredentials("my-github", { token: "ghp_abc123" });
+    removeNamedCredentials("my-github");
+    expect(getNamedCredentials("my-github")).toBeNull();
+  });
+
+  it("removes file when last entry is deleted", () => {
+    saveNamedCredentials("only", { token: "x" });
+    removeNamedCredentials("only");
+    expect(existsSync(join(TEST_DIR, "credentials.yml"))).toBe(false);
+  });
+
+  it("preserves other entries", () => {
+    saveNamedCredentials("a", { token: "aaa" });
+    saveNamedCredentials("b", { token: "bbb" });
+    removeNamedCredentials("a");
+    expect(getNamedCredentials("a")).toBeNull();
+    expect(getNamedCredentials("b")).toEqual({ token: "bbb" });
+  });
+
+  it("is a no-op for missing names", () => {
+    saveNamedCredentials("a", { token: "aaa" });
+    removeNamedCredentials("nonexistent");
+    expect(getNamedCredentials("a")).toEqual({ token: "aaa" });
+  });
+});
+
+describe("listNamedCredentials", () => {
+  it("returns empty array when no credentials exist", () => {
+    expect(listNamedCredentials()).toEqual([]);
+  });
+
+  it("returns all credential set names", () => {
+    saveNamedCredentials("a", { token: "aaa" });
+    saveNamedCredentials("b", { token: "bbb" });
+    expect(listNamedCredentials().sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("ensureInitialized creates sample credentials.yml", () => {
+  it("creates a credentials.yml with documentation header", () => {
+    ensureInitialized();
+    const credPath = join(TEST_DIR, "credentials.yml");
+    expect(existsSync(credPath)).toBe(true);
+    const { readFileSync } = require("fs");
+    const content = readFileSync(credPath, "utf-8");
+    expect(content).toContain("# Frozen Ink");
+    expect(content).toContain("my-github");
+    // Should parse as empty (all entries are commented out)
+    expect(loadCredentials()).toEqual({});
+  });
+
+  it("does not overwrite existing credentials.yml", () => {
+    saveNamedCredentials("existing", { token: "keep-me" });
+    ensureInitialized();
+    expect(getNamedCredentials("existing")).toEqual({ token: "keep-me" });
+  });
+});
+
+describe("collection schema with credential references", () => {
+  it("accepts inline credentials object", () => {
+    ensureInitialized();
+    addCollection("test-inline", {
+      crawler: "github",
+      config: {},
+      credentials: { token: "ghp_abc" },
+    });
+    const col = getCollection("test-inline");
+    expect(col).not.toBeNull();
+    expect(col!.credentials).toEqual({ token: "ghp_abc" });
+  });
+
+  it("accepts string credential reference", () => {
+    ensureInitialized();
+    addCollection("test-ref", {
+      crawler: "github",
+      config: {},
+      credentials: "my-github",
+    });
+    const col = getCollection("test-ref");
+    expect(col).not.toBeNull();
+    expect(col!.credentials).toBe("my-github");
+  });
+
+  it("defaults credentials to empty object", () => {
+    ensureInitialized();
+    addCollection("test-default", {
+      crawler: "github",
+      config: {},
+    });
+    const col = getCollection("test-default");
+    expect(col).not.toBeNull();
+    expect(col!.credentials).toEqual({});
+  });
+});
+
+describe("resolveCredentials", () => {
+  it("passes through object credentials", () => {
+    const creds = { token: "ghp_abc123" };
+    expect(resolveCredentials(creds)).toBe(creds);
+  });
+
+  it("resolves a string reference to the named credential set", () => {
+    saveNamedCredentials("my-github", { token: "ghp_abc123" });
+    expect(resolveCredentials("my-github")).toEqual({ token: "ghp_abc123" });
+  });
+
+  it("throws for unknown string reference", () => {
+    expect(() => resolveCredentials("nonexistent")).toThrow(
+      /Unknown credential set: "nonexistent"/,
+    );
+  });
+});

--- a/packages/core/src/config/context.ts
+++ b/packages/core/src/config/context.ts
@@ -1,9 +1,9 @@
-import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, readdirSync, statSync, unlinkSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, statSync, unlinkSync, renameSync } from "fs";
 import { join, dirname } from "path";
-import { randomBytes } from "crypto";
 import { z } from "zod";
 import yaml from "js-yaml";
 import { getFrozenInkHome } from "./loader";
+import { atomicWriteYaml, readYaml } from "./yaml-utils";
 
 // --- Zod Schemas ---
 
@@ -33,7 +33,7 @@ const collectionEntrySchema = z.object({
   version: z.string().optional().default("1.0"),
   syncInterval: z.number().optional(),
   config: z.record(z.unknown()).default({}),
-  credentials: z.record(z.unknown()).default({}),
+  credentials: z.union([z.string(), z.record(z.unknown())]).default({}),
   assets: assetsConfigSchema,
   /**
    * Glob patterns matching filenames to hide from the collection root.
@@ -157,23 +157,6 @@ function getLegacyPublishPath(): string {
 
 function getLegacyContextPath(): string {
   return join(getFrozenInkHome(), "context.yml");
-}
-
-// --- Atomic YAML write ---
-
-function atomicWriteYaml(filePath: string, data: unknown): void {
-  const dir = dirname(filePath);
-  mkdirSync(dir, { recursive: true });
-  const content = yaml.dump(data, { lineWidth: -1, noRefs: true, sortKeys: false });
-  const tmpPath = `${filePath}.${randomBytes(4).toString("hex")}.tmp`;
-  writeFileSync(tmpPath, content, "utf-8");
-  renameSync(tmpPath, filePath);
-}
-
-function readYaml<T>(filePath: string): T | null {
-  if (!existsSync(filePath)) return null;
-  const raw = readFileSync(filePath, "utf-8");
-  return (yaml.load(raw) as T) ?? null;
 }
 
 // --- Migration ---
@@ -319,7 +302,36 @@ export function ensureInitialized(): void {
   if (!existsSync(configPath) && !existsSync(legacyConfigPath)) {
     atomicWriteYaml(configPath, { sync: { interval: 900 }, ui: { port: 3000 } });
   }
+
+  // Create sample credentials.yml if it doesn't exist
+  const credentialsPath = join(home, "credentials.yml");
+  if (!existsSync(credentialsPath)) {
+    writeFileSync(credentialsPath, SAMPLE_CREDENTIALS_YML, "utf-8");
+  }
 }
+
+const SAMPLE_CREDENTIALS_YML = `\
+# Frozen Ink — Named Credentials
+#
+# Define reusable credential sets here. Collections can reference them by name
+# instead of storing secrets inline, keeping your collection folders safe to
+# share with AI tools.
+#
+# Usage in a collection YAML:
+#   credentials: my-github        # references the "my-github" entry below
+#
+# Format:
+#   <name>:
+#     <key>: <value>
+#
+# Examples (uncomment and fill in your values):
+#
+# my-github:
+#   token: ghp_your_token_here
+#
+# work-mantishub:
+#   token: your_api_token_here
+`;
 
 export function contextExists(): boolean {
   const home = getFrozenInkHome();

--- a/packages/core/src/config/credentials.ts
+++ b/packages/core/src/config/credentials.ts
@@ -1,0 +1,62 @@
+import { join } from "path";
+import { unlinkSync } from "fs";
+import { getFrozenInkHome } from "./loader";
+import { atomicWriteYaml, readYaml } from "./yaml-utils";
+
+type CredentialSet = Record<string, unknown>;
+type CredentialsStore = Record<string, CredentialSet>;
+
+function getCredentialsPath(): string {
+  return join(getFrozenInkHome(), "credentials.yml");
+}
+
+export function loadCredentials(): CredentialsStore {
+  return readYaml<CredentialsStore>(getCredentialsPath()) ?? {};
+}
+
+export function getNamedCredentials(name: string): CredentialSet | null {
+  const store = loadCredentials();
+  return store[name] ?? null;
+}
+
+export function saveNamedCredentials(name: string, creds: CredentialSet): void {
+  const store = loadCredentials();
+  store[name] = creds;
+  atomicWriteYaml(getCredentialsPath(), store);
+}
+
+export function removeNamedCredentials(name: string): void {
+  const store = loadCredentials();
+  if (!(name in store)) return;
+  delete store[name];
+  if (Object.keys(store).length === 0) {
+    try { unlinkSync(getCredentialsPath()); } catch { /* ignore */ }
+  } else {
+    atomicWriteYaml(getCredentialsPath(), store);
+  }
+}
+
+export function listNamedCredentials(): string[] {
+  return Object.keys(loadCredentials());
+}
+
+/**
+ * Resolve the `credentials` field from a collection entry.
+ * - If it's a string, look it up in credentials.yml by name.
+ * - If it's an object, return it as-is (backward compat).
+ */
+export function resolveCredentials(
+  credentialsField: string | CredentialSet,
+): CredentialSet {
+  if (typeof credentialsField === "string") {
+    const creds = getNamedCredentials(credentialsField);
+    if (!creds) {
+      const credPath = join(getFrozenInkHome(), "credentials.yml");
+      throw new Error(
+        `Unknown credential set: "${credentialsField}". Define it in ${credPath}`,
+      );
+    }
+    return creds;
+  }
+  return credentialsField;
+}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -2,6 +2,11 @@ export { configSchema, type FrozenInkConfig, type SyncConfig, type UiConfig } fr
 export { defaultConfig } from "./defaults";
 export { loadConfig, getFrozenInkHome } from "./loader";
 export {
+  listNamedCredentials,
+  getNamedCredentials,
+  resolveCredentials,
+} from "./credentials";
+export {
   contextExists,
   ensureInitialized,
   getCollection,

--- a/packages/core/src/config/yaml-utils.ts
+++ b/packages/core/src/config/yaml-utils.ts
@@ -1,0 +1,19 @@
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import { randomBytes } from "crypto";
+import yaml from "js-yaml";
+
+export function atomicWriteYaml(filePath: string, data: unknown): void {
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true });
+  const content = yaml.dump(data, { lineWidth: -1, noRefs: true, sortKeys: false });
+  const tmpPath = `${filePath}.${randomBytes(4).toString("hex")}.tmp`;
+  writeFileSync(tmpPath, content, "utf-8");
+  renameSync(tmpPath, filePath);
+}
+
+export function readYaml<T>(filePath: string): T | null {
+  if (!existsSync(filePath)) return null;
+  const raw = readFileSync(filePath, "utf-8");
+  return (yaml.load(raw) as T) ?? null;
+}

--- a/packages/ui/src/components/manage/CollectionForm.tsx
+++ b/packages/ui/src/components/manage/CollectionForm.tsx
@@ -1,5 +1,10 @@
 import { useState, useEffect, useRef } from "react";
 
+interface NamedCredential {
+  name: string;
+  keys: string[];
+}
+
 interface CollectionFormProps {
   /** If provided, editing existing collection; else creating new */
   editName?: string;
@@ -8,7 +13,7 @@ interface CollectionFormProps {
     description?: string;
     crawler: string;
     config: Record<string, unknown>;
-    credentials: Record<string, unknown>;
+    credentials: string | Record<string, unknown>;
   };
   onSave: () => void;
   onCancel: () => void;
@@ -30,20 +35,37 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
   const [config, setConfig] = useState<Record<string, string>>(
     configToStrings(editConfig?.config ?? {}),
   );
-  const [credentials, setCredentials] = useState<Record<string, string>>(
-    configToStrings(editConfig?.credentials ?? {}),
+  const editCredsIsNamed = typeof editConfig?.credentials === "string";
+  const [credMode, setCredMode] = useState<"inline" | "named">(editCredsIsNamed ? "named" : "inline");
+  const [selectedCredName, setSelectedCredName] = useState<string>(
+    editCredsIsNamed ? (editConfig?.credentials as string) : "",
   );
+  const [credentials, setCredentials] = useState<Record<string, string>>(
+    editCredsIsNamed ? {} : configToStrings((editConfig?.credentials as Record<string, unknown>) ?? {}),
+  );
+  const [namedCredentials, setNamedCredentials] = useState<NamedCredential[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [discardPrompt, setDiscardPrompt] = useState(false);
 
+  // Fetch available named credentials
+  useEffect(() => {
+    fetch("/api/credentials")
+      .then((res) => res.json())
+      .then((data: NamedCredential[]) => setNamedCredentials(data))
+      .catch(() => {});
+  }, []);
+
   function hasUnsavedChanges(): boolean {
     if (!editName) return false; // creating new — no prior state to compare
+    const credsChanged = editCredsIsNamed
+      ? (credMode !== "named" || selectedCredName !== (editConfig?.credentials as string))
+      : (credMode !== "inline" || JSON.stringify(credentials) !== JSON.stringify(configToStrings((editConfig?.credentials as Record<string, unknown>) ?? {})));
     return (
       title !== (editConfig?.title ?? "") ||
       description !== (editConfig?.description ?? "") ||
       JSON.stringify(config) !== JSON.stringify(configToStrings(editConfig?.config ?? {})) ||
-      JSON.stringify(credentials) !== JSON.stringify(configToStrings(editConfig?.credentials ?? {}))
+      credsChanged
     );
   }
 
@@ -84,9 +106,15 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
     for (const [k, v] of Object.entries(config)) {
       try { parsedConfig[k] = JSON.parse(v); } catch { parsedConfig[k] = v; }
     }
-    const parsedCreds: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(credentials)) {
-      try { parsedCreds[k] = JSON.parse(v); } catch { parsedCreds[k] = v; }
+    let credsPayload: string | Record<string, unknown>;
+    if (credMode === "named" && selectedCredName) {
+      credsPayload = selectedCredName;
+    } else {
+      const parsedCreds: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(credentials)) {
+        try { parsedCreds[k] = JSON.parse(v); } catch { parsedCreds[k] = v; }
+      }
+      credsPayload = parsedCreds;
     }
 
     try {
@@ -94,7 +122,7 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
         await fetch(`/api/collections/${encodeURIComponent(editName)}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ title, description: description || undefined, config: parsedConfig, credentials: parsedCreds }),
+          body: JSON.stringify({ title, description: description || undefined, config: parsedConfig, credentials: credsPayload }),
         });
       } else {
         const res = await fetch("/api/collections", {
@@ -106,7 +134,7 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
             description: description || undefined,
             crawler,
             config: parsedConfig,
-            credentials: parsedCreds,
+            credentials: credsPayload,
           }),
         });
         if (!res.ok) {
@@ -213,7 +241,49 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
 
       <div className="form-group">
         <h3>Credentials</h3>
-        {renderCredentialFields(crawler, credentials, setCredentials)}
+        {namedCredentials.length > 0 && (
+          <div className="cred-mode-toggle">
+            <label>
+              <input
+                type="radio"
+                name="credMode"
+                value="inline"
+                checked={credMode === "inline"}
+                onChange={() => setCredMode("inline")}
+              />
+              {" "}Enter directly
+            </label>
+            <label style={{ marginLeft: "1rem" }}>
+              <input
+                type="radio"
+                name="credMode"
+                value="named"
+                checked={credMode === "named"}
+                onChange={() => setCredMode("named")}
+              />
+              {" "}Use saved credentials
+            </label>
+          </div>
+        )}
+        {credMode === "named" ? (
+          <div>
+            <label>Credential Set</label>
+            <select
+              className="form-input"
+              value={selectedCredName}
+              onChange={(e) => setSelectedCredName(e.target.value)}
+            >
+              <option value="">Select...</option>
+              {namedCredentials.map((nc) => (
+                <option key={nc.name} value={nc.name}>
+                  {nc.name} ({nc.keys.join(", ")})
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          renderCredentialFields(crawler, credentials, setCredentials)
+        )}
       </div>
 
       {error && <div className="form-error">{error}</div>}
@@ -223,7 +293,7 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
         <button
           className="btn btn-primary"
           onClick={handleSubmit}
-          disabled={saving || (!editName && !name)}
+          disabled={saving || (!editName && !name) || (credMode === "named" && !selectedCredName)}
         >
           {saving ? "Saving..." : editName ? "Update" : "Create"}
         </button>


### PR DESCRIPTION
## Summary

- Secrets were stored inline in collection YAML files (`~/.frozenink/collections/<name>/<name>.yml`), which is problematic when collection folders are shared with AI tools as context
- Introduces `~/.frozenink/credentials.yml` as a separate, centralized store for named credential sets
- Collections reference credentials by name (e.g. `credentials: my-github`) instead of embedding secrets inline
- Fully backward compatible — inline credential objects still work

## Changes

- **`packages/core/src/config/credentials.ts`** — New credential store: load, get, list, resolve
- **`packages/core/src/config/yaml-utils.ts`** — Extracted shared YAML read/write utilities
- **`packages/core/src/config/context.ts`** — Schema change (`credentials` accepts string or object), sample `credentials.yml` created on init
- **`packages/cli/src/commands/{sync,daemon,pull}.ts`** — Resolve credential references before passing to crawlers
- **`packages/cli/src/commands/management-api.ts`** — Read-only `GET /api/credentials` endpoint (names + keys only), resolve references in sync path
- **`packages/cli/src/commands/add.ts`** — New `--credentials <name>` flag to reference existing credential sets
- **`packages/ui/src/components/manage/CollectionForm.tsx`** — Toggle between inline credentials and saved credential dropdown
- **16 new tests** covering credential store, schema changes, and sample file creation

## Test plan

- [x] `bun run ci` passes (lint, typecheck, 380 tests, UI build, worker build)
- [x] Migrated existing local collections to use named credentials
- [ ] Verify `fink sync *` works with credential references
- [ ] Verify desktop UI shows credential dropdown when credentials.yml has entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)