### PR TITLE
Fix publish/unpublish reliability, worker render, and search/links correctness

### DIFF
--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -36,6 +36,7 @@ function collectFiles(dir: string, base: string = ""): Array<{ relativePath: str
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const relPath = base ? `${base}/${entry.name}` : entry.name;
     const fullPath = join(dir, entry.name);
+    if (entry.name.startsWith(".")) continue;
     if (entry.isDirectory()) {
       files.push(...collectFiles(fullPath, relPath));
     } else {
@@ -161,7 +162,7 @@ export async function publishCollections(
     checkWranglerAuth,
     createD1,
     executeD1File,
-    executeD1Command,
+
     createR2Bucket,
     putR2Object,
     putR2String,
@@ -241,6 +242,12 @@ export async function publishCollections(
 
   assertInitialPublishConfirmation({ isUpdate, workerOnly, passwordHash, forcePublic });
 
+  // Check worker bundle exists before touching any infrastructure
+  const workerBundlePath = resolveWorkerBundle(__moduleDir);
+  if (!workerBundlePath || !existsSync(workerBundlePath)) {
+    throw new Error("Worker bundle not found. If developing locally, run 'cd packages/worker && bun run build'.");
+  }
+
   // --- Phase 1: Create infrastructure + deploy worker ---
 
   if (!workerOnly) {
@@ -254,10 +261,6 @@ export async function publishCollections(
   await createR2Bucket(r2BucketName);
 
   onProgress("deploy", "Deploying worker...");
-  const workerBundlePath = resolveWorkerBundle(__moduleDir);
-  if (!workerBundlePath || !existsSync(workerBundlePath)) {
-    throw new Error("Worker bundle not found. If developing locally, run 'cd packages/worker && bun run build'.");
-  }
 
   const tomlContent = generateWranglerToml({
     workerName,
@@ -295,22 +298,15 @@ export async function publishCollections(
       });
     }
   } else {
-    // Read R2 manifest from D1 (still intact — D1 hasn't been rebuilt yet)
-    const existingR2Manifest = new Map<string, number>();
+    // Fetch existing R2 objects once — used for both upload skipping and stale cleanup
+    const existingR2Objects = new Map<string, number>();
     if (isUpdate) {
       try {
-        onProgress("r2-manifest", "Reading existing R2 manifest...");
-        const manifestJson = await executeD1Command(
-          d1DatabaseName,
-          "SELECT key, size FROM r2_manifest",
-        );
-        const parsed = JSON.parse(manifestJson);
-        const results = Array.isArray(parsed) ? parsed[0]?.results : parsed?.results;
-        if (Array.isArray(results)) {
-          for (const row of results) existingR2Manifest.set(row.key, row.size ?? -1);
-        }
+        onProgress("r2-list", "Listing existing R2 objects...");
+        const remoteObjects = await listR2Objects(r2BucketName);
+        for (const obj of remoteObjects) existingR2Objects.set(obj.key, obj.size);
       } catch {
-        // Manifest table may not exist or lack size column on old deployments
+        // Treat as empty on error; all files will be uploaded
       }
     }
 
@@ -333,7 +329,7 @@ export async function publishCollections(
     for (const { r2Key, fullPath } of uploads) {
       const localSize = statSync(fullPath).size;
       fileSizes.set(r2Key, localSize);
-      if (existingR2Manifest.get(r2Key) === localSize) {
+      if (existingR2Objects.get(r2Key) === localSize) {
         skippedCount++;
       } else {
         toUpload.push({ r2Key, fullPath });
@@ -346,49 +342,24 @@ export async function publishCollections(
     }
 
     let uploadCount = 0;
-    const pendingManifest: Array<{ key: string; size: number }> = [];
-    const CHECKPOINT_INTERVAL = 500;
-
-    const flushManifestCheckpoint = async () => {
-      if (pendingManifest.length === 0) return;
-      const batch = pendingManifest.splice(0);
-      const sql = batch
-        .map((e) => `INSERT OR REPLACE INTO r2_manifest (key, size) VALUES ('${escapeSQL(e.key)}', ${e.size});`)
-        .join("\n");
-      const tmpFile = writeTempFile(sql, ".sql");
-      try {
-        await executeD1File(d1DatabaseName, tmpFile);
-      } finally {
-        cleanupTempFile(tmpFile);
-      }
-    };
-
     await runConcurrent(toUpload, 3, async ({ r2Key, fullPath }) => {
       await putR2Object(r2BucketName, r2Key, fullPath, getMimeType(fullPath));
-      pendingManifest.push({ key: r2Key, size: fileSizes.get(r2Key)! });
       uploadCount++;
-      if (uploadCount % CHECKPOINT_INTERVAL === 0) {
-        onProgress("r2-upload", `${uploadCount}/${toUpload.length} files uploaded`);
-        await flushManifestCheckpoint();
-      }
     });
-    await flushManifestCheckpoint();
 
-    // Stale cleanup via R2 list (source of truth)
+    // Stale cleanup: remove R2 keys no longer in the local set
     let deletedCount = 0;
     if (isUpdate) {
       const allKeys = new Set(fileSizes.keys());
-      onProgress("r2-cleanup", "Checking for stale R2 files...");
       try {
-        const remoteKeys = await listR2Objects(r2BucketName);
-        const staleKeys = remoteKeys.filter((key) => !allKeys.has(key) && !key.endsWith("/db-digest"));
+        const staleKeys = [...existingR2Objects.keys()].filter((key) => !allKeys.has(key) && !key.endsWith("/db-digest"));
         if (staleKeys.length > 0) {
           onProgress("r2-cleanup", `Removing ${staleKeys.length} stale file(s)...`);
           await deleteR2Objects(r2BucketName, staleKeys);
           deletedCount = staleKeys.length;
         }
       } catch {
-        onProgress("r2-cleanup", "Warning: could not list R2 objects for stale cleanup");
+        onProgress("r2-cleanup", "Warning: could not clean up stale R2 files");
       }
     }
 
@@ -427,7 +398,6 @@ export async function publishCollections(
       const schemaSql: string[] = [];
 
       schemaSql.push("DROP TABLE IF EXISTS entities_fts;");
-      schemaSql.push("DROP TABLE IF EXISTS r2_manifest;");
       schemaSql.push("DROP TABLE IF EXISTS entities;");
       schemaSql.push("DROP TABLE IF EXISTS collections_meta;");
       schemaSql.push("");
@@ -496,13 +466,29 @@ export async function publishCollections(
         onProgress("d1-build", `Built "${colName}": ${allEntities.length} entities`);
       }
 
-      // Upload in batches (D1 has execution time limits on large SQL files)
-      const D1_BATCH_SIZE = 500;
-      const totalBatches = Math.ceil(schemaSql.length / D1_BATCH_SIZE);
+      // Upload in batches bounded by both size (large data blobs) and count (execution time).
+      // Use Buffer.byteLength for accurate UTF-8 byte count — stmt.length undercounts Unicode.
+      const MAX_BATCH_BYTES = 100 * 1024; // 100 KB — conservative against D1's SQL length limit
+      const MAX_BATCH_COUNT = 500;
+      const batches: string[][] = [];
+      let current: string[] = [];
+      let currentBytes = 0;
+      for (const stmt of schemaSql) {
+        const stmtBytes = Buffer.byteLength(stmt, "utf8");
+        if (current.length > 0 && (currentBytes + stmtBytes > MAX_BATCH_BYTES || current.length >= MAX_BATCH_COUNT)) {
+          batches.push(current);
+          current = [];
+          currentBytes = 0;
+        }
+        current.push(stmt);
+        currentBytes += stmtBytes;
+      }
+      if (current.length > 0) batches.push(current);
+
+      const totalBatches = batches.length;
       onProgress("d1-upload", `Uploading to D1 (${totalBatches} batches)...`);
       let batchCount = 0;
-      for (let i = 0; i < schemaSql.length; i += D1_BATCH_SIZE) {
-        const batch = schemaSql.slice(i, i + D1_BATCH_SIZE);
+      for (const batch of batches) {
         const batchFile = writeTempFile(batch.join("\n"), ".sql");
         try {
           await executeD1File(d1DatabaseName, batchFile);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,10 +1,11 @@
 import { Command } from "commander";
-import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { existsSync, readFileSync, readdirSync, statSync, unlinkSync } from "fs";
 import { join, extname } from "path";
 import { createInterface } from "readline";
 import {
   getFrozenInkHome,
   getCollectionDb,
+  openDatabase,
   ensureInitialized,
   getCollection,
   updateCollection,
@@ -26,8 +27,12 @@ function randomSuffix(): string {
   return Math.random().toString(36).slice(2, 8);
 }
 
-function escapeSQL(str: string): string {
-  return str.replace(/'/g, "''");
+/** Format a value read from SQLite as a SQL literal for use in a dump. */
+function sqlLiteral(v: unknown): string {
+  if (v === null || v === undefined) return "NULL";
+  if (typeof v === "number" || typeof v === "bigint") return String(v);
+  if (v instanceof Uint8Array) return "X'" + Buffer.from(v).toString("hex").toUpperCase() + "'";
+  return "'" + String(v).replace(/'/g, "''") + "'";
 }
 
 function collectFiles(dir: string, base: string = ""): Array<{ relativePath: string; fullPath: string }> {
@@ -395,75 +400,107 @@ export async function publishCollections(
       onProgress("d1-build", `Database unchanged (digest match) — skipping D1 rebuild`);
     } else {
       onProgress("d1-build", "Building D1 payload...");
-      const schemaSql: string[] = [];
 
-      schemaSql.push("DROP TABLE IF EXISTS entities_fts;");
-      schemaSql.push("DROP TABLE IF EXISTS entities;");
-      schemaSql.push("DROP TABLE IF EXISTS collections_meta;");
-      schemaSql.push("");
-      schemaSql.push(`CREATE TABLE entities (
+      // Build a temp SQLite DB with the target schema using prepared statements
+      // (no manual string escaping), then dump it to SQL for D1 upload.
+      const tmpDbPath = join(process.env.TMPDIR || "/tmp", `fink-d1-${randomSuffix()}.db`);
+      let tmpDb: any = null;
+      const schemaSql: string[] = [];
+      try {
+        tmpDb = openDatabase(tmpDbPath);
+
+        const D1_DDL = [
+          "DROP TABLE IF EXISTS entities_fts;",
+          "DROP TABLE IF EXISTS entities;",
+          "DROP TABLE IF EXISTS collections_meta;",
+          `CREATE TABLE entities (
   id INTEGER PRIMARY KEY,
   external_id TEXT NOT NULL, entity_type TEXT NOT NULL,
   title TEXT NOT NULL, data TEXT NOT NULL DEFAULT '{}',
-  content_hash TEXT,
-  folder TEXT,
-  slug TEXT,
+  content_hash TEXT, folder TEXT, slug TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);`);
-      schemaSql.push("CREATE INDEX idx_entities_external ON entities(external_id);");
-      schemaSql.push("CREATE INDEX idx_entities_folder   ON entities(folder, slug);");
-      schemaSql.push("CREATE INDEX idx_entities_type     ON entities(entity_type);");
-      schemaSql.push("CREATE INDEX idx_entities_updated  ON entities(updated_at);");
-      schemaSql.push("CREATE VIRTUAL TABLE entities_fts USING fts5(entity_id UNINDEXED, external_id UNINDEXED, entity_type UNINDEXED, title, content, tags);");
-      schemaSql.push("");
-
-      const themeEngine = createGenerateThemeEngine();
-      const MAX_FTS_CONTENT = 8000;
-
-      let entityIdOffset = 0;
-
-      for (const colName of collectionNames) {
-        const col = getCollection(colName)!;
-        const colDb = colName === collectionName ? colDbForDigest : getCollectionDb(getCollectionDbPath(colName));
-
-        const allEntities = colDb.select().from(entities).all();
-
-        for (const entity of allEntities) {
-          entityIdOffset++;
-          const data = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
-          const folderVal = entity.folder != null ? `'${escapeSQL(entity.folder)}'` : "NULL";
-          const slugVal = entity.slug != null ? `'${escapeSQL(entity.slug)}'` : "NULL";
-
-          schemaSql.push(`INSERT INTO entities (id, external_id, entity_type, title, data, content_hash, folder, slug, created_at, updated_at) VALUES (${entityIdOffset}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(data)}', ${entity.contentHash ? `'${escapeSQL(entity.contentHash)}'` : "NULL"}, ${folderVal}, ${slugVal}, ${entity.createdAt ? `'${escapeSQL(entity.createdAt)}'` : "datetime('now')"}, ${entity.updatedAt ? `'${escapeSQL(entity.updatedAt)}'` : "datetime('now')"});`);
-
-          // FTS inline via theme engine
-          const entityDataParsed: EntityData = typeof entity.data === "object" ? entity.data as EntityData : JSON.parse(entity.data as string);
-          const entityTagNames = (entityDataParsed.tags ?? []).join(" ");
-          let ftsContent = "";
-          const hasMarkdown = entity.folder != null && entity.slug != null;
-          if (hasMarkdown && themeEngine.has(col.crawler)) {
-            try {
-              ftsContent = themeEngine.render({
-                entity: {
-                  externalId: entity.externalId,
-                  entityType: entity.entityType,
-                  title: entity.title,
-                  data: (entityDataParsed.source ?? {}) as Record<string, unknown>,
-                  url: entityDataParsed.url ?? undefined,
-                  tags: entityDataParsed.tags ?? [],
-                },
-                collectionName: colName,
-                crawlerType: col.crawler,
-              });
-            } catch { /* fall back to empty content */ }
-          }
-          if (ftsContent.length > MAX_FTS_CONTENT) ftsContent = ftsContent.slice(0, MAX_FTS_CONTENT);
-
-          schemaSql.push(`INSERT INTO entities_fts (entity_id, external_id, entity_type, title, content, tags) VALUES (${entityIdOffset}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(ftsContent)}', '${escapeSQL(entityTagNames)}');`);
+);`,
+          "CREATE INDEX idx_entities_external ON entities(external_id);",
+          "CREATE INDEX idx_entities_folder   ON entities(folder, slug);",
+          "CREATE INDEX idx_entities_type     ON entities(entity_type);",
+          "CREATE INDEX idx_entities_updated  ON entities(updated_at);",
+          "CREATE VIRTUAL TABLE entities_fts USING fts5(entity_id UNINDEXED, external_id UNINDEXED, entity_type UNINDEXED, title, content, tags);",
+        ];
+        for (const stmt of D1_DDL) {
+          // Apply schema to temp DB and include in upload SQL
+          if (!stmt.startsWith("DROP")) tmpDb.exec(stmt);
+          schemaSql.push(stmt);
         }
 
-        onProgress("d1-build", `Built "${colName}": ${allEntities.length} entities`);
+        const insertEntity = tmpDb.prepare(
+          "INSERT INTO entities (id, external_id, entity_type, title, data, content_hash, folder, slug, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        );
+        const insertFts = tmpDb.prepare(
+          "INSERT INTO entities_fts (entity_id, external_id, entity_type, title, content, tags) VALUES (?, ?, ?, ?, ?, ?)",
+        );
+
+        const themeEngine = createGenerateThemeEngine();
+        const MAX_FTS_CONTENT = 8000;
+        let entityIdOffset = 0;
+
+        for (const colName of collectionNames) {
+          const col = getCollection(colName)!;
+          const colDb = colName === collectionName ? colDbForDigest : getCollectionDb(getCollectionDbPath(colName));
+          const allEntities = colDb.select().from(entities).all();
+
+          for (const entity of allEntities) {
+            entityIdOffset++;
+            const data = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
+
+            insertEntity.run(
+              entityIdOffset, entity.externalId, entity.entityType, entity.title,
+              data, entity.contentHash ?? null, entity.folder ?? null, entity.slug ?? null,
+              entity.createdAt ?? null, entity.updatedAt ?? null,
+            );
+
+            const entityDataParsed: EntityData = typeof entity.data === "object" ? entity.data as EntityData : JSON.parse(entity.data as string);
+            const entityTagNames = (entityDataParsed.tags ?? []).join(" ");
+            let ftsContent = "";
+            const hasMarkdown = entity.folder != null && entity.slug != null;
+            if (hasMarkdown && themeEngine.has(col.crawler)) {
+              try {
+                ftsContent = themeEngine.render({
+                  entity: {
+                    externalId: entity.externalId,
+                    entityType: entity.entityType,
+                    title: entity.title,
+                    data: (entityDataParsed.source ?? {}) as Record<string, unknown>,
+                    url: entityDataParsed.url ?? undefined,
+                    tags: entityDataParsed.tags ?? [],
+                  },
+                  collectionName: colName,
+                  crawlerType: col.crawler,
+                });
+              } catch { /* fall back to empty content */ }
+            }
+            if (ftsContent.length > MAX_FTS_CONTENT) ftsContent = ftsContent.slice(0, MAX_FTS_CONTENT);
+
+            insertFts.run(entityIdOffset, entity.externalId, entity.entityType, entity.title, ftsContent, entityTagNames);
+          }
+
+          onProgress("d1-build", `Built "${colName}": ${allEntities.length} entities`);
+        }
+
+        // Dump temp DB rows to SQL statements
+        const entityRows: Record<string, unknown>[] = tmpDb.prepare("SELECT * FROM entities").all();
+        for (const row of entityRows) {
+          schemaSql.push(`INSERT INTO entities VALUES (${Object.values(row).map(sqlLiteral).join(", ")});`);
+        }
+        const ftsRows: Record<string, unknown>[] = tmpDb.prepare(
+          "SELECT entity_id, external_id, entity_type, title, content, tags FROM entities_fts",
+        ).all();
+        for (const row of ftsRows) {
+          schemaSql.push(`INSERT INTO entities_fts (entity_id, external_id, entity_type, title, content, tags) VALUES (${Object.values(row).map(sqlLiteral).join(", ")});`);
+        }
+      } finally {
+        tmpDb?.close();
+        try { unlinkSync(tmpDbPath); } catch { /* ignore cleanup errors */ }
       }
 
       // Upload in batches bounded by both size (large data blobs) and count (execution time).

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -27,7 +27,11 @@ function randomSuffix(): string {
 }
 
 function escapeSQL(str: string): string {
-  return str.replace(/'/g, "''");
+  // Strip C0 control characters (except \t \n \r). NULL bytes break SQLite's
+  // C-based parser by acting as string terminators; other control chars render
+  // as garbage in the worker UI. Source data sometimes contains them when bug
+  // reports include binary file-upload code or other raw byte sequences.
+  return str.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "").replace(/'/g, "''");
 }
 
 function collectFiles(dir: string, base: string = ""): Array<{ relativePath: string; fullPath: string }> {
@@ -161,7 +165,7 @@ export async function publishCollections(
   const {
     checkWranglerAuth,
     createD1,
-    executeD1File,
+    executeD1Query,
 
     createR2Bucket,
     putR2Object,
@@ -423,6 +427,12 @@ export async function publishCollections(
 
       let entityIdOffset = 0;
 
+      // D1's per-statement SQL length limit appears to be ~100-128 KB. Skip
+      // entities whose serialized data alone exceeds this, since their INSERT
+      // would fail SQLITE_TOOBIG even as a single-statement batch.
+      const MAX_ENTITY_DATA_BYTES = 80 * 1024;
+      let skippedTooLarge = 0;
+
       for (const colName of collectionNames) {
         const col = getCollection(colName)!;
         const colDb = colName === collectionName ? colDbForDigest : getCollectionDb(getCollectionDbPath(colName));
@@ -430,8 +440,12 @@ export async function publishCollections(
         const allEntities = colDb.select().from(entities).all();
 
         for (const entity of allEntities) {
-          entityIdOffset++;
           const data = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
+          if (Buffer.byteLength(data, "utf8") > MAX_ENTITY_DATA_BYTES) {
+            skippedTooLarge++;
+            continue;
+          }
+          entityIdOffset++;
           const folderVal = entity.folder != null ? `'${escapeSQL(entity.folder)}'` : "NULL";
           const slugVal = entity.slug != null ? `'${escapeSQL(entity.slug)}'` : "NULL";
 
@@ -465,6 +479,9 @@ export async function publishCollections(
 
         onProgress("d1-build", `Built "${colName}": ${allEntities.length} entities`);
       }
+      if (skippedTooLarge > 0) {
+        onProgress("d1-build", `Skipped ${skippedTooLarge} oversized entit${skippedTooLarge === 1 ? "y" : "ies"} (data > ${MAX_ENTITY_DATA_BYTES / 1024} KB)`);
+      }
 
       // Upload in batches bounded by both size (large data blobs) and count (execution time).
       // Use Buffer.byteLength for accurate UTF-8 byte count — stmt.length undercounts Unicode.
@@ -489,15 +506,10 @@ export async function publishCollections(
       onProgress("d1-upload", `Uploading to D1 (${totalBatches} batches)...`);
       let batchCount = 0;
       for (const batch of batches) {
-        const batchFile = writeTempFile(batch.join("\n"), ".sql");
-        try {
-          await executeD1File(d1DatabaseName, batchFile);
-          batchCount++;
-          if (batchCount % 5 === 0 || batchCount === totalBatches) {
-            onProgress("d1-upload", `Uploading to D1... ${batchCount}/${totalBatches} batches`);
-          }
-        } finally {
-          cleanupTempFile(batchFile);
+        await executeD1Query(d1DatabaseId, batch.join("\n"));
+        batchCount++;
+        if (batchCount % 5 === 0 || batchCount === totalBatches) {
+          onProgress("d1-upload", `Uploading to D1... ${batchCount}/${totalBatches} batches`);
         }
       }
       await putR2String(r2BucketName, `${collectionName}/db-digest`, dbDigest);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,11 +1,10 @@
 import { Command } from "commander";
-import { existsSync, readFileSync, readdirSync, statSync, unlinkSync } from "fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
 import { join, extname } from "path";
 import { createInterface } from "readline";
 import {
   getFrozenInkHome,
   getCollectionDb,
-  openDatabase,
   ensureInitialized,
   getCollection,
   updateCollection,
@@ -27,12 +26,8 @@ function randomSuffix(): string {
   return Math.random().toString(36).slice(2, 8);
 }
 
-/** Format a value read from SQLite as a SQL literal for use in a dump. */
-function sqlLiteral(v: unknown): string {
-  if (v === null || v === undefined) return "NULL";
-  if (typeof v === "number" || typeof v === "bigint") return String(v);
-  if (v instanceof Uint8Array) return "X'" + Buffer.from(v).toString("hex").toUpperCase() + "'";
-  return "'" + String(v).replace(/'/g, "''") + "'";
+function escapeSQL(str: string): string {
+  return str.replace(/'/g, "''");
 }
 
 function collectFiles(dir: string, base: string = ""): Array<{ relativePath: string; fullPath: string }> {
@@ -400,107 +395,75 @@ export async function publishCollections(
       onProgress("d1-build", `Database unchanged (digest match) — skipping D1 rebuild`);
     } else {
       onProgress("d1-build", "Building D1 payload...");
-
-      // Build a temp SQLite DB with the target schema using prepared statements
-      // (no manual string escaping), then dump it to SQL for D1 upload.
-      const tmpDbPath = join(process.env.TMPDIR || "/tmp", `fink-d1-${randomSuffix()}.db`);
-      let tmpDb: any = null;
       const schemaSql: string[] = [];
-      try {
-        tmpDb = openDatabase(tmpDbPath);
 
-        const D1_DDL = [
-          "DROP TABLE IF EXISTS entities_fts;",
-          "DROP TABLE IF EXISTS entities;",
-          "DROP TABLE IF EXISTS collections_meta;",
-          `CREATE TABLE entities (
+      schemaSql.push("DROP TABLE IF EXISTS entities_fts;");
+      schemaSql.push("DROP TABLE IF EXISTS entities;");
+      schemaSql.push("DROP TABLE IF EXISTS collections_meta;");
+      schemaSql.push("");
+      schemaSql.push(`CREATE TABLE entities (
   id INTEGER PRIMARY KEY,
   external_id TEXT NOT NULL, entity_type TEXT NOT NULL,
   title TEXT NOT NULL, data TEXT NOT NULL DEFAULT '{}',
-  content_hash TEXT, folder TEXT, slug TEXT,
+  content_hash TEXT,
+  folder TEXT,
+  slug TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);`,
-          "CREATE INDEX idx_entities_external ON entities(external_id);",
-          "CREATE INDEX idx_entities_folder   ON entities(folder, slug);",
-          "CREATE INDEX idx_entities_type     ON entities(entity_type);",
-          "CREATE INDEX idx_entities_updated  ON entities(updated_at);",
-          "CREATE VIRTUAL TABLE entities_fts USING fts5(entity_id UNINDEXED, external_id UNINDEXED, entity_type UNINDEXED, title, content, tags);",
-        ];
-        for (const stmt of D1_DDL) {
-          // Apply schema to temp DB and include in upload SQL
-          if (!stmt.startsWith("DROP")) tmpDb.exec(stmt);
-          schemaSql.push(stmt);
-        }
+);`);
+      schemaSql.push("CREATE INDEX idx_entities_external ON entities(external_id);");
+      schemaSql.push("CREATE INDEX idx_entities_folder   ON entities(folder, slug);");
+      schemaSql.push("CREATE INDEX idx_entities_type     ON entities(entity_type);");
+      schemaSql.push("CREATE INDEX idx_entities_updated  ON entities(updated_at);");
+      schemaSql.push("CREATE VIRTUAL TABLE entities_fts USING fts5(entity_id UNINDEXED, external_id UNINDEXED, entity_type UNINDEXED, title, content, tags);");
+      schemaSql.push("");
 
-        const insertEntity = tmpDb.prepare(
-          "INSERT INTO entities (id, external_id, entity_type, title, data, content_hash, folder, slug, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        );
-        const insertFts = tmpDb.prepare(
-          "INSERT INTO entities_fts (entity_id, external_id, entity_type, title, content, tags) VALUES (?, ?, ?, ?, ?, ?)",
-        );
+      const themeEngine = createGenerateThemeEngine();
+      const MAX_FTS_CONTENT = 8000;
 
-        const themeEngine = createGenerateThemeEngine();
-        const MAX_FTS_CONTENT = 8000;
-        let entityIdOffset = 0;
+      let entityIdOffset = 0;
 
-        for (const colName of collectionNames) {
-          const col = getCollection(colName)!;
-          const colDb = colName === collectionName ? colDbForDigest : getCollectionDb(getCollectionDbPath(colName));
-          const allEntities = colDb.select().from(entities).all();
+      for (const colName of collectionNames) {
+        const col = getCollection(colName)!;
+        const colDb = colName === collectionName ? colDbForDigest : getCollectionDb(getCollectionDbPath(colName));
 
-          for (const entity of allEntities) {
-            entityIdOffset++;
-            const data = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
+        const allEntities = colDb.select().from(entities).all();
 
-            insertEntity.run(
-              entityIdOffset, entity.externalId, entity.entityType, entity.title,
-              data, entity.contentHash ?? null, entity.folder ?? null, entity.slug ?? null,
-              entity.createdAt ?? null, entity.updatedAt ?? null,
-            );
+        for (const entity of allEntities) {
+          entityIdOffset++;
+          const data = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
+          const folderVal = entity.folder != null ? `'${escapeSQL(entity.folder)}'` : "NULL";
+          const slugVal = entity.slug != null ? `'${escapeSQL(entity.slug)}'` : "NULL";
 
-            const entityDataParsed: EntityData = typeof entity.data === "object" ? entity.data as EntityData : JSON.parse(entity.data as string);
-            const entityTagNames = (entityDataParsed.tags ?? []).join(" ");
-            let ftsContent = "";
-            const hasMarkdown = entity.folder != null && entity.slug != null;
-            if (hasMarkdown && themeEngine.has(col.crawler)) {
-              try {
-                ftsContent = themeEngine.render({
-                  entity: {
-                    externalId: entity.externalId,
-                    entityType: entity.entityType,
-                    title: entity.title,
-                    data: (entityDataParsed.source ?? {}) as Record<string, unknown>,
-                    url: entityDataParsed.url ?? undefined,
-                    tags: entityDataParsed.tags ?? [],
-                  },
-                  collectionName: colName,
-                  crawlerType: col.crawler,
-                });
-              } catch { /* fall back to empty content */ }
-            }
-            if (ftsContent.length > MAX_FTS_CONTENT) ftsContent = ftsContent.slice(0, MAX_FTS_CONTENT);
+          schemaSql.push(`INSERT INTO entities (id, external_id, entity_type, title, data, content_hash, folder, slug, created_at, updated_at) VALUES (${entityIdOffset}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(data)}', ${entity.contentHash ? `'${escapeSQL(entity.contentHash)}'` : "NULL"}, ${folderVal}, ${slugVal}, ${entity.createdAt ? `'${escapeSQL(entity.createdAt)}'` : "datetime('now')"}, ${entity.updatedAt ? `'${escapeSQL(entity.updatedAt)}'` : "datetime('now')"});`);
 
-            insertFts.run(entityIdOffset, entity.externalId, entity.entityType, entity.title, ftsContent, entityTagNames);
+          // FTS inline via theme engine
+          const entityDataParsed: EntityData = typeof entity.data === "object" ? entity.data as EntityData : JSON.parse(entity.data as string);
+          const entityTagNames = (entityDataParsed.tags ?? []).join(" ");
+          let ftsContent = "";
+          const hasMarkdown = entity.folder != null && entity.slug != null;
+          if (hasMarkdown && themeEngine.has(col.crawler)) {
+            try {
+              ftsContent = themeEngine.render({
+                entity: {
+                  externalId: entity.externalId,
+                  entityType: entity.entityType,
+                  title: entity.title,
+                  data: (entityDataParsed.source ?? {}) as Record<string, unknown>,
+                  url: entityDataParsed.url ?? undefined,
+                  tags: entityDataParsed.tags ?? [],
+                },
+                collectionName: colName,
+                crawlerType: col.crawler,
+              });
+            } catch { /* fall back to empty content */ }
           }
+          if (ftsContent.length > MAX_FTS_CONTENT) ftsContent = ftsContent.slice(0, MAX_FTS_CONTENT);
 
-          onProgress("d1-build", `Built "${colName}": ${allEntities.length} entities`);
+          schemaSql.push(`INSERT INTO entities_fts (entity_id, external_id, entity_type, title, content, tags) VALUES (${entityIdOffset}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(ftsContent)}', '${escapeSQL(entityTagNames)}');`);
         }
 
-        // Dump temp DB rows to SQL statements
-        const entityRows: Record<string, unknown>[] = tmpDb.prepare("SELECT * FROM entities").all();
-        for (const row of entityRows) {
-          schemaSql.push(`INSERT INTO entities VALUES (${Object.values(row).map(sqlLiteral).join(", ")});`);
-        }
-        const ftsRows: Record<string, unknown>[] = tmpDb.prepare(
-          "SELECT entity_id, external_id, entity_type, title, content, tags FROM entities_fts",
-        ).all();
-        for (const row of ftsRows) {
-          schemaSql.push(`INSERT INTO entities_fts (entity_id, external_id, entity_type, title, content, tags) VALUES (${Object.values(row).map(sqlLiteral).join(", ")});`);
-        }
-      } finally {
-        tmpDb?.close();
-        try { unlinkSync(tmpDbPath); } catch { /* ignore cleanup errors */ }
+        onProgress("d1-build", `Built "${colName}": ${allEntities.length} entities`);
       }
 
       // Upload in batches bounded by both size (large data blobs) and count (execution time).

--- a/packages/cli/src/commands/unpublish.ts
+++ b/packages/cli/src/commands/unpublish.ts
@@ -46,10 +46,10 @@ export async function unpublishCollection(
   // 1. Empty and delete R2 bucket
   onProgress("r2", "Listing R2 objects...");
   try {
-    const keys = await listR2Objects(r2BucketName);
-    if (keys.length > 0) {
-      onProgress("r2", `Deleting ${keys.length} objects from R2...`);
-      await deleteR2Objects(r2BucketName, keys);
+    const objects = await listR2Objects(r2BucketName);
+    if (objects.length > 0) {
+      onProgress("r2", `Deleting ${objects.length} objects from R2...`);
+      await deleteR2Objects(r2BucketName, objects.map(o => o.key));
     }
     onProgress("r2", "Deleting R2 bucket...");
     await deleteR2Bucket(r2BucketName);

--- a/packages/cli/src/commands/wrangler-api.ts
+++ b/packages/cli/src/commands/wrangler-api.ts
@@ -186,6 +186,32 @@ export async function executeD1File(dbName: string, sqlFilePath: string): Promis
   );
 }
 
+/**
+ * Execute SQL against D1 via the REST API directly. Much faster than spawning
+ * a wrangler subprocess per batch (saves ~500ms-1s per call).
+ */
+export async function executeD1Query(databaseId: string, sql: string): Promise<void> {
+  const { apiToken, accountId } = await getCredentials();
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/query`;
+  const res = await fetchWithRetry(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ sql }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`D1 query failed: ${res.status} ${text.slice(0, 500)}`);
+  }
+  const data = (await res.json()) as { success: boolean; errors?: Array<{ code?: number; message: string }> };
+  if (!data.success) {
+    const errs = (data.errors ?? []).map((e) => `[${e.code ?? "?"}] ${e.message}`).join("; ");
+    throw new Error(`D1 query failed: ${errs || "unknown error"}`);
+  }
+}
+
 export async function executeD1Command(dbName: string, sql: string): Promise<string> {
   const { stdout } = await runWrangler(["d1", "execute", dbName, "--remote", "--command", sql, "--json", "--yes"]);
   return stdout;

--- a/packages/cli/src/commands/wrangler-api.ts
+++ b/packages/cli/src/commands/wrangler-api.ts
@@ -128,6 +128,37 @@ export async function checkWranglerAuth(): Promise<void> {
   }
 }
 
+// --- Retry helper for transient Cloudflare/network errors ---
+
+function isTransientError(err: unknown): boolean {
+  if (!(err instanceof WranglerError)) return false;
+  const msg = (err.stderr + err.stdout).toLowerCase();
+  return (
+    msg.includes("503") ||
+    msg.includes("502") ||
+    msg.includes("500") ||
+    msg.includes("429") ||
+    msg.includes("service unavailable") ||
+    msg.includes("malformed response") ||
+    msg.includes("timeout") ||
+    msg.includes("econnreset") ||
+    msg.includes("econnrefused")
+  );
+}
+
+async function retryWithBackoff<T>(fn: () => Promise<T>, maxRetries = 5): Promise<T> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt === maxRetries || !isTransientError(err)) throw err;
+      const delay = Math.min(2000 * 2 ** attempt, 30000);
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw new Error("unreachable");
+}
+
 // --- D1 operations (via wrangler CLI) ---
 
 export async function createD1(name: string): Promise<{ uuid: string; name: string }> {
@@ -150,7 +181,9 @@ export async function createD1(name: string): Promise<{ uuid: string; name: stri
 }
 
 export async function executeD1File(dbName: string, sqlFilePath: string): Promise<void> {
-  await runWrangler(["d1", "execute", dbName, "--remote", "--file", sqlFilePath, "--yes"]);
+  await retryWithBackoff(() =>
+    runWrangler(["d1", "execute", dbName, "--remote", "--file", sqlFilePath, "--yes"]),
+  );
 }
 
 export async function executeD1Command(dbName: string, sql: string): Promise<string> {
@@ -271,33 +304,24 @@ export async function deleteR2Object(bucket: string, key: string): Promise<void>
 
 export async function deleteR2Objects(bucket: string, keys: string[]): Promise<void> {
   if (keys.length === 0) return;
-  const { apiToken, accountId } = await getCredentials();
-  const BATCH_SIZE = 1000;
-  for (let i = 0; i < keys.length; i += BATCH_SIZE) {
-    const batch = keys.slice(i, i + BATCH_SIZE);
-    const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects`;
-    const res = await fetchWithRetry(url, {
-      method: "DELETE",
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ keys: batch }),
-    });
-    if (!res.ok) {
-      const text = await res.text();
-      throw new Error(`R2 batch delete failed: ${res.status} ${text.slice(0, 200)}`);
+  const CONCURRENCY = 3;
+  let index = 0;
+  async function worker() {
+    while (index < keys.length) {
+      const key = keys[index++];
+      await deleteR2Object(bucket, key);
     }
   }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, keys.length) }, () => worker()));
 }
 
 export async function deleteR2Bucket(name: string): Promise<void> {
   await runWrangler(["r2", "bucket", "delete", name], { allowFailure: true });
 }
 
-export async function listR2Objects(bucket: string, prefix?: string): Promise<string[]> {
+export async function listR2Objects(bucket: string, prefix?: string): Promise<Array<{ key: string; size: number }>> {
   const { apiToken, accountId } = await getCredentials();
-  const keys: string[] = [];
+  const objects: Array<{ key: string; size: number }> = [];
   let cursor: string | undefined;
   for (;;) {
     const params = new URLSearchParams({ per_page: "1000" });
@@ -309,12 +333,12 @@ export async function listR2Objects(bucket: string, prefix?: string): Promise<st
       headers: { Authorization: `Bearer ${apiToken}` },
     });
     if (!res.ok) break;
-    const data = await res.json() as { result: Array<{ key: string }>; result_info?: { cursor?: string } };
-    for (const obj of data.result ?? []) keys.push(obj.key);
+    const data = await res.json() as { result: Array<{ key: string; size: number }>; result_info?: { cursor?: string } };
+    for (const obj of data.result ?? []) objects.push({ key: obj.key, size: obj.size ?? 0 });
     cursor = data.result_info?.cursor;
     if (!cursor || (data.result ?? []).length === 0) break;
   }
-  return keys;
+  return objects;
 }
 
 export async function putR2ObjectFromString(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./theme": "./src/theme/index.ts",
-    "./export": "./src/export/index.ts"
+    "./export": "./src/export/index.ts",
+    "./search/fts-query": "./src/search/fts-query.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/core/src/search/__tests__/indexer.test.ts
+++ b/packages/core/src/search/__tests__/indexer.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, rmSync } from "fs";
 import { join } from "path";
-import { SearchIndexer, buildFtsQuery } from "../indexer";
+import { SearchIndexer } from "../indexer";
+import { buildFtsQuery } from "../fts-query";
 
 const TEST_DIR = join(import.meta.dir, ".test-search");
 

--- a/packages/core/src/search/fts-query.ts
+++ b/packages/core/src/search/fts-query.ts
@@ -1,0 +1,31 @@
+/**
+ * Build an FTS5 query from raw user input. Whitespace-separated "words" are
+ * independent AND clauses; a word with internal punctuation (e.g. "8.4") is
+ * expanded to an FTS5 phrase of its sub-tokens so they must appear adjacent
+ * in the index — mirroring how FTS5's default unicode61 tokenizer actually
+ * stored them at index time.
+ *
+ * Examples:
+ *   "PHP 8.4"       → PHP* "8 4*"
+ *   "fix lo"        → fix* lo*
+ *   "mantis 1.2.3"  → mantis* "1 2 3*"
+ *
+ * Every final token gets a trailing `*` so partial typing still matches.
+ * The phrase-with-last-prefix form `"a b c*"` is valid FTS5 syntax.
+ */
+export function buildFtsQuery(raw: string): string {
+  const words = raw.trim().split(/\s+/).filter(Boolean);
+  const clauses: string[] = [];
+  for (const word of words) {
+    const sub = word.split(/[^\p{L}\p{N}]+/u).filter(Boolean);
+    if (sub.length === 0) continue;
+    if (sub.length === 1) {
+      clauses.push(`${sub[0]}*`);
+    } else {
+      const head = sub.slice(0, -1).join(" ");
+      const tail = sub[sub.length - 1];
+      clauses.push(`"${head} ${tail}*"`);
+    }
+  }
+  return clauses.join(" ");
+}

--- a/packages/core/src/search/index.ts
+++ b/packages/core/src/search/index.ts
@@ -1,1 +1,2 @@
 export { SearchIndexer, type SearchResult, type SearchFilters } from "./indexer";
+export { buildFtsQuery } from "./fts-query";

--- a/packages/core/src/search/indexer.ts
+++ b/packages/core/src/search/indexer.ts
@@ -1,36 +1,5 @@
 import { openDatabase } from "../compat/sqlite";
-
-/**
- * Build an FTS5 query from raw user input. Whitespace-separated "words" are
- * independent AND clauses; a word with internal punctuation (e.g. "8.4") is
- * expanded to an FTS5 phrase of its sub-tokens so they must appear adjacent
- * in the index — mirroring how FTS5's default unicode61 tokenizer actually
- * stored them at index time.
- *
- * Examples:
- *   "PHP 8.4"       → PHP* "8 4*"
- *   "fix lo"        → fix* lo*
- *   "mantis 1.2.3"  → mantis* "1 2 3*"
- *
- * Every final token gets a trailing `*` so partial typing still matches.
- * The phrase-with-last-prefix form `"a b c*"` is valid FTS5 syntax.
- */
-export function buildFtsQuery(raw: string): string {
-  const words = raw.trim().split(/\s+/).filter(Boolean);
-  const clauses: string[] = [];
-  for (const word of words) {
-    const sub = word.split(/[^\p{L}\p{N}]+/u).filter(Boolean);
-    if (sub.length === 0) continue;
-    if (sub.length === 1) {
-      clauses.push(`${sub[0]}*`);
-    } else {
-      const head = sub.slice(0, -1).join(" ");
-      const tail = sub[sub.length - 1];
-      clauses.push(`"${head} ${tail}*"`);
-    }
-  }
-  return clauses.join(" ");
-}
+import { buildFtsQuery } from "./fts-query";
 
 export interface SearchResult {
   entityId: number;

--- a/packages/worker/build.mjs
+++ b/packages/worker/build.mjs
@@ -1,0 +1,16 @@
+import { build } from "esbuild";
+
+const buildId = String(Date.now());
+
+await build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  outfile: "dist/worker.js",
+  format: "esm",
+  target: "es2022",
+  minify: true,
+  external: ["node:*"],
+  define: {
+    __BUILD_ID__: JSON.stringify(buildId),
+  },
+});

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "wrangler dev",
-    "build": "esbuild src/index.ts --bundle --outfile=dist/worker.js --format=esm --target=es2022 --minify --external:node:*",
+    "build": "node build.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/worker/src/db/search.ts
+++ b/packages/worker/src/db/search.ts
@@ -1,3 +1,5 @@
+import { buildFtsQuery } from "@frozenink/core/search/fts-query";
+
 export interface SearchResult {
   entityId: number;
   externalId: string;
@@ -5,34 +7,6 @@ export interface SearchResult {
   title: string;
   rank: number;
   snippet: string;
-}
-
-/**
- * Build an FTS5 query from raw user input. Whitespace-separated "words" are
- * independent AND clauses; a word with internal punctuation (e.g. "8.4") is
- * expanded to an FTS5 phrase of its sub-tokens so they must appear adjacent
- * in the index — mirroring how FTS5's default unicode61 tokenizer actually
- * stored them at index time.
- *
- *   "PHP 8.4"       → PHP* "8 4*"
- *   "fix lo"        → fix* lo*
- *   "mantis 1.2.3"  → mantis* "1 2 3*"
- */
-function buildFtsQuery(raw: string): string {
-  const words = raw.trim().split(/\s+/).filter(Boolean);
-  const clauses: string[] = [];
-  for (const word of words) {
-    const sub = word.split(/[^\p{L}\p{N}]+/u).filter(Boolean);
-    if (sub.length === 0) continue;
-    if (sub.length === 1) {
-      clauses.push(`${sub[0]}*`);
-    } else {
-      const head = sub.slice(0, -1).join(" ");
-      const tail = sub[sub.length - 1];
-      clauses.push(`"${head} ${tail}*"`);
-    }
-  }
-  return clauses.join(" ");
 }
 
 export async function searchEntities(
@@ -49,12 +23,13 @@ export async function searchEntities(
   // matches rank ahead of body mentions. bm25() weights are positional for
   // every declared column including UNINDEXED ones. Published worker schema:
   //   entity_id, external_id, entity_type, title, content, tags.
-  // Lower bm25 = better match.
+  // Lower bm25 = better match. Snippet uses column 4 (content) so the UI
+  // shows where in the body the query matched, not a re-render of the title.
   let sql = `
     SELECT
       entity_id, external_id, entity_type, title,
       bm25(entities_fts, 1.0, 1.0, 1.0, 10.0, 1.0, 2.0) AS rank,
-      snippet(entities_fts, 3, '<mark>', '</mark>', '…', 48) AS snippet
+      snippet(entities_fts, 4, '<mark>', '</mark>', '…', 48) AS snippet
     FROM entities_fts
     WHERE entities_fts MATCH ?
   `;

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -320,19 +320,33 @@ api.get("/api/search", async (c) => {
   return c.json(enriched);
 });
 
-// GET /api/collections/:name/backlinks/:externalId
-api.get("/api/collections/:name/backlinks/:externalId", async (c) => {
-  const name = c.req.param("name");
-  const externalId = decodeURIComponent(c.req.param("externalId"));
+// Resolve an entity from a markdown path like "mantisbt/issues/36614-foo.md".
+// The UI always has the path, not the external_id, so we derive folder/slug
+// and look up by the indexed (folder, slug) columns.
+async function resolveEntityFromPath(
+  db: D1Database,
+  path: string,
+): Promise<Awaited<ReturnType<typeof getEntityByFolderSlug>>> {
+  const decoded = decodeURIComponent(path).replace(/\.md$/, "");
+  const lastSlash = decoded.lastIndexOf("/");
+  const folder = lastSlash >= 0 ? decoded.slice(0, lastSlash) : "";
+  const slug = lastSlash >= 0 ? decoded.slice(lastSlash + 1) : decoded;
+  return getEntityByFolderSlug(db, folder, slug);
+}
 
-  const targetEntity = await getEntityByExternalId(c.env.DB, externalId);
+// GET /api/collections/:name/backlinks/<markdown path>
+api.get("/api/collections/:name/backlinks/*", async (c) => {
+  const name = c.req.param("name");
+  const targetPath = c.req.path.replace(`/api/collections/${encodeURIComponent(name)}/backlinks/`, "");
+
+  const targetEntity = await resolveEntityFromPath(c.env.DB, targetPath);
   if (!targetEntity) return c.json({ error: "Entity not found" }, 404);
 
   const links = await getBacklinks(c.env.DB, targetEntity);
 
   const results = links.map(({ entity }) => {
     const mdPath = entityMarkdownPath(entity);
-    const displayTitle = entity.slug ?? entity.title;
+    const displayTitle = entity.title ?? entity.slug;
     return {
       entityId: entity.id,
       externalId: entity.external_id,
@@ -345,12 +359,12 @@ api.get("/api/collections/:name/backlinks/:externalId", async (c) => {
   return c.json(results);
 });
 
-// GET /api/collections/:name/outgoing-links/:externalId
-api.get("/api/collections/:name/outgoing-links/:externalId", async (c) => {
+// GET /api/collections/:name/outgoing-links/<markdown path>
+api.get("/api/collections/:name/outgoing-links/*", async (c) => {
   const name = c.req.param("name");
-  const externalId = decodeURIComponent(c.req.param("externalId"));
+  const targetPath = c.req.path.replace(`/api/collections/${encodeURIComponent(name)}/outgoing-links/`, "");
 
-  const sourceEntity = await getEntityByExternalId(c.env.DB, externalId);
+  const sourceEntity = await resolveEntityFromPath(c.env.DB, targetPath);
   if (!sourceEntity) return c.json({ error: "Entity not found" }, 404);
 
   const links = await getOutgoingLinks(c.env.DB, sourceEntity);
@@ -359,7 +373,7 @@ api.get("/api/collections/:name/outgoing-links/:externalId", async (c) => {
     .filter(({ entity }) => entity !== null)
     .map(({ entity }) => {
       const mdPath = entityMarkdownPath(entity!);
-      const displayTitle = entity!.slug ?? entity!.title;
+      const displayTitle = entity!.title ?? entity!.slug;
       return { title: displayTitle, markdownPath: mdPath };
     })
     .sort((a, b) => a.title.localeCompare(b.title));

--- a/packages/worker/src/handlers/ui.ts
+++ b/packages/worker/src/handlers/ui.ts
@@ -27,23 +27,27 @@ ui.get("/*", async (c) => {
   const r2Key = `_ui${pathname}`;
   const obj = await getR2Object(c.env.BUCKET, r2Key);
   if (obj) {
-    return new Response(obj.body, {
-      headers: {
-        "Content-Type": getMimeType(pathname),
-        "Cache-Control": getCacheControl(pathname),
-      },
-    });
+    const headers: Record<string, string> = {
+      "Content-Type": getMimeType(pathname),
+      "Cache-Control": getCacheControl(pathname),
+    };
+    if (obj.httpMetadata?.contentEncoding) {
+      headers["Content-Encoding"] = obj.httpMetadata.contentEncoding;
+    }
+    return new Response(obj.body, { headers });
   }
 
   // SPA fallback — serve index.html (always revalidate)
   const indexObj = await getR2Object(c.env.BUCKET, "_ui/index.html");
   if (indexObj) {
-    return new Response(indexObj.body, {
-      headers: {
-        "Content-Type": "text/html",
-        "Cache-Control": "no-cache",
-      },
-    });
+    const headers: Record<string, string> = {
+      "Content-Type": "text/html",
+      "Cache-Control": "no-cache",
+    };
+    if (indexObj.httpMetadata?.contentEncoding) {
+      headers["Content-Encoding"] = indexObj.httpMetadata.contentEncoding;
+    }
+    return new Response(indexObj.body, { headers });
   }
 
   return c.text("Not found", 404);

--- a/packages/worker/src/router.ts
+++ b/packages/worker/src/router.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import { compress } from "hono/compress";
 import type { Env } from "./types";
 import { authMiddleware, handleLogin, handleLogout } from "./auth";
 import { renderLoginPage } from "./login";
@@ -7,11 +6,10 @@ import { api } from "./handlers/api";
 import { ui } from "./handlers/ui";
 import { handleMcpRequest } from "./handlers/mcp";
 
+declare const __BUILD_ID__: string;
 const CACHE_TTL = 60 * 60 * 24;
 
 const app = new Hono<{ Bindings: Env }>();
-
-app.use("*", compress());
 
 // Public routes (no auth)
 app.get("/login", renderLoginPage);
@@ -28,7 +26,9 @@ app.use("/api/*", authMiddleware);
 app.use("/api/*", async (c, next) => {
   if (c.req.method !== "GET") return next();
   const cache = caches.default;
-  const cacheKey = c.req.raw;
+  const cacheUrl = new URL(c.req.url);
+  cacheUrl.searchParams.set("__v", __BUILD_ID__);
+  const cacheKey = new Request(cacheUrl.toString(), c.req.raw);
   const cached = await cache.match(cacheKey);
   if (cached) return cached;
   await next();


### PR DESCRIPTION
## Summary

Bundle of reliability and correctness fixes for `fink publish`, the deployed Cloudflare Worker, and the search/links UI — uncovered while publishing a large MantisHub collection (~24k entities).

**Publish / unpublish (`packages/cli`):**
- Drop the `r2_manifest` D1 table; use a single `listR2Objects` pass (with sizes) for both upload dedup and stale cleanup
- Replace broken R2 batch-delete REST call with concurrent individual deletes (concurrency 3 to avoid 429)
- Move worker-bundle existence check before any infrastructure is created
- Skip dotfiles (e.g. `.DS_Store`) in `collectFiles`
- Fix D1 batch sizing: measure with `Buffer.byteLength` (UTF-8) and cap at 100 KB per batch
- Add `retryWithBackoff` for transient Cloudflare errors (5xx, 429, network blips)
- Replace per-batch wrangler subprocess with direct D1 REST API (`executeD1Query`)
- Strip C0 control chars (incl. NULL bytes) in `escapeSQL` so binary blobs in source data can't break SQLite's C parser or render as garbage
- Skip entities whose `data` column would exceed 80 KB

**Worker render / cache:**
- Remove Hono `compress()`. Cloudflare's edge compresses on its own; stacking them produced double-gzip → browser decompressed once and rendered raw gzip bytes as garbage
- Forward `Content-Encoding` from R2 `httpMetadata` in the UI handler
- Bake a build-time `__BUILD_ID__` (`Date.now()` at esbuild time) into the edge-cache key so every redeploy invalidates old `caches.default` entries. New `packages/worker/build.mjs` drives esbuild with a dynamic define

**Stale UI dist:**
- The R2-uploaded UI bundle was older than the source. It treated `files` as path strings and derived the display name from the filename (slug form) instead of `node.title`. Rebuilding `packages/ui/dist` fixed Cmd+P search showing slugs

**Search divergence (local vs worker):**
- Extract `buildFtsQuery` into `packages/core/src/search/fts-query.ts`. Worker imports via new `@frozenink/core/search/fts-query` subpath export so Node-only code doesn't leak into the Workers bundle
- Worker `snippet()` now reads column 4 (content) instead of column 3 (title), matching the local dev server

**Backlinks / outgoing-links:**
- Route was `:externalId`, but the UI sends markdown paths like `mantisbt/issues/foo.md`. Single-param route didn't match → SPA fallback returned `index.html` → UI's `.json()` yielded nothing. Restored splat route; resolve via `folder`/`slug` using `getEntityByFolderSlug`
- `displayTitle = entity.slug ?? entity.title` always picked slug (always populated). Flipped to `title ?? slug`

## Test plan

- [ ] `bun run ci` passes locally
- [ ] `fink publish mantisbt` (full) completes without D1 SQLITE_TOOBIG, 401/429 bursts, or parser errors
- [ ] `fink publish mantisbt --worker-only` redeploys worker and busts edge cache (verify via `curl` showing new `?__v=...` key in practice)
- [ ] Worker root URL renders HTML, not gzip garbage, with and without `Accept-Encoding: gzip`
- [ ] Cmd+P search shows proper titles (`24558: php mysql`, not `24558-php-mysql`)
- [ ] Free-text search for "PHP 8.5" shows PHP 8.5 issues first; snippets show body context
- [ ] Opening the Links panel on an issue with known links (e.g. `issue:36614`) shows backlinks and outgoing links with proper titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)