### PR TITLE
Support fink serve <collection-name>

### DIFF
--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -362,9 +362,12 @@ export async function prepareCollection(
 export async function prepareCollections(
   home: string = getFrozenInkHome(),
   log: Log = console.log,
+  collectionName?: string,
 ): Promise<void> {
   const themeEngine = createGenerateThemeEngine();
-  const collections = listCollections().filter((c) => c.enabled);
+  const collections = collectionName
+    ? listCollections().filter((c) => c.name === collectionName)
+    : listCollections().filter((c) => c.enabled);
 
   for (const col of collections) {
     if (!existsSync(getCollectionDbPath(col.name))) continue;

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -321,6 +321,7 @@ function tryServeStatic(
 export function createApiServer(
   home: string,
   port: number,
+  collectionFilter?: string,
 ): { port: number; stop?: () => void } | Promise<{ port: number; stop?: () => void }> {
   const uiDistDir = resolveUiDistDir();
   const themeEngine = createThemeEngine();
@@ -335,7 +336,9 @@ export function createApiServer(
 
       // GET /api/collections
       if (path === "/api/collections" && req.method === "GET") {
-        const rows = listCollections();
+        const rows = collectionFilter
+          ? (() => { const col = getCollection(collectionFilter); return col ? [col] : []; })()
+          : listCollections();
         const result = rows.map((r) => ({
           name: r.name,
           title: r.title ?? r.name,
@@ -890,13 +893,22 @@ export function createApiServer(
 
 export const serveCommand = new Command("serve")
   .description("Start the API and/or MCP server")
+  .argument("[collection-name]", "Serve only this collection")
   .option("--mcp-only", "Start only the MCP server (no REST API)")
   .option("--ui-only", "Start only the REST API server (no MCP)")
   .option("--port <port>", "Port for the REST API server")
-  .action(async (opts: { mcpOnly?: boolean; uiOnly?: boolean; port?: string }) => {
+  .action(async (collectionName: string | undefined, opts: { mcpOnly?: boolean; uiOnly?: boolean; port?: string }) => {
     const home = getFrozenInkHome();
 
     ensureInitialized();
+
+    if (collectionName) {
+      const col = getCollection(collectionName);
+      if (!col) {
+        console.error(`Error: Collection "${collectionName}" not found.`);
+        process.exit(1);
+      }
+    }
 
     const config = loadConfig();
     const port = opts.port ? parseInt(opts.port, 10) : config.ui.port;
@@ -910,13 +922,13 @@ export const serveCommand = new Command("serve")
     }
 
     if (opts.uiOnly) {
-      const server = await Promise.resolve(createApiServer(home, port));
+      const server = await Promise.resolve(createApiServer(home, port, collectionName));
       console.log(`Frozen Ink API server running on http://localhost:${server.port}`);
       return;
     }
 
     // Start both
-    const server = await Promise.resolve(createApiServer(home, port));
+    const server = await Promise.resolve(createApiServer(home, port, collectionName));
     console.log(`Frozen Ink API server running on http://localhost:${server.port}`);
     console.error("Starting Frozen Ink MCP server (STDIO)...");
     await startStdioServer({ frozeninkHome: home });

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -913,7 +913,7 @@ export const serveCommand = new Command("serve")
     const config = loadConfig();
     const port = opts.port ? parseInt(opts.port, 10) : config.ui.port;
 
-    await prepareCollections(home);
+    await prepareCollections(home, console.log, collectionName);
 
     if (opts.mcpOnly) {
       console.error("Starting Frozen Ink MCP server (STDIO)...");


### PR DESCRIPTION
## Summary

Resolves #43.

- Adds an optional `[collection-name]` positional argument to `fink serve`
- When specified, the `/api/collections` API returns only that collection, so the UI's collection picker hides itself automatically (it already hides when ≤1 collection is present)
- Validates the collection exists at startup and exits with a clear error message if not found

## Test plan

- [ ] `fink serve` — works as before, all collections shown with picker
- [ ] `fink serve <valid-collection>` — serves only that collection, no picker dropdown visible
- [ ] `fink serve <invalid-collection>` — exits immediately with `Error: Collection "..." not found.`
- [ ] `fink serve <collection> --ui-only` and `--port` flags still work alongside the new argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)