### PR TITLE
Add fink compact command to vacuum SQLite databases

### DIFF
--- a/packages/cli/src/commands/compact.ts
+++ b/packages/cli/src/commands/compact.ts
@@ -1,0 +1,82 @@
+import { Command } from "commander";
+import { existsSync, statSync } from "fs";
+import {
+  ensureInitialized,
+  listCollections,
+  getCollection,
+  getCollectionDbPath,
+  openDatabase,
+} from "@frozenink/core";
+
+function getDbSizeBytes(dbPath: string): number {
+  let total = 0;
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const p = dbPath + suffix;
+    if (existsSync(p)) {
+      total += statSync(p).size;
+    }
+  }
+  return total;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+export const compactCommand = new Command("compact")
+  .description("Vacuum the SQLite database to reclaim unused space")
+  .argument("<collection>", 'Collection name or "*" for all collections')
+  .action(async (collection: string) => {
+    ensureInitialized();
+
+    let collectionRows =
+      collection === "*"
+        ? listCollections()
+        : (() => {
+            const col = getCollection(collection);
+            if (!col) {
+              console.error(`Collection "${collection}" not found`);
+              process.exit(1);
+            }
+            return [col];
+          })();
+
+    collectionRows = collectionRows.filter((c) => c.enabled);
+
+    if (collectionRows.length === 0) {
+      console.log("No enabled collections to compact");
+      return;
+    }
+
+    for (const col of collectionRows) {
+      const dbPath = getCollectionDbPath(col.name);
+      if (!existsSync(dbPath)) {
+        console.log(`${col.name}: no database found, skipping`);
+        continue;
+      }
+
+      const sizeBefore = getDbSizeBytes(dbPath);
+      console.log(`Compacting "${col.name}" (${formatBytes(sizeBefore)})...`);
+
+      const sqlite = openDatabase(dbPath);
+      try {
+        // Flush WAL into the main database file before vacuuming
+        sqlite.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+        sqlite.exec("VACUUM;");
+      } finally {
+        sqlite.close();
+      }
+
+      const sizeAfter = getDbSizeBytes(dbPath);
+      const saved = sizeBefore - sizeAfter;
+      if (saved > 0) {
+        console.log(
+          `  Done. ${formatBytes(sizeAfter)} (saved ${formatBytes(saved)})`,
+        );
+      } else {
+        console.log(`  Done. ${formatBytes(sizeAfter)} (no space reclaimed)`);
+      }
+    }
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import { tableplusCommand } from "./commands/tableplus";
 import { vscodeCommand } from "./commands/vscode";
 import { cloneCommand } from "./commands/clone";
 import { pullCommand } from "./commands/pull";
+import { compactCommand } from "./commands/compact";
 import { startTui } from "./tui/index";
 
 const program = new Command();
@@ -49,6 +50,7 @@ program.addCommand(tableplusCommand);
 program.addCommand(vscodeCommand);
 program.addCommand(cloneCommand);
 program.addCommand(pullCommand);
+program.addCommand(compactCommand);
 
 // If no arguments passed (just "fink"), launch TUI by default
 const args = process.argv.slice(2);


### PR DESCRIPTION
## Summary

- Adds `fink compact <collection>` command (or `*` for all enabled collections)
- Runs `PRAGMA wal_checkpoint(TRUNCATE)` to flush WAL, then `VACUUM` to rewrite the database and reclaim freed space
- Reports database size before/after compaction with bytes saved

Closes #44

## Test plan

- [ ] Run `fink compact <collection>` on a collection with data — confirm size before/after is reported
- [ ] Run `fink compact *` to compact all collections in one shot
- [ ] Run on a collection with no database — confirm it skips gracefully
- [ ] Run on an unknown collection name — confirm error message and non-zero exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)