### PR TITLE
Fix clone: resolve default collection, generate markdown locally, fix remote rendering

### DIFF
--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -10,6 +10,7 @@ import {
   entities,
   LocalStorageBackend,
   SearchIndexer,
+  MetadataStore,
   splitMarkdownPath,
 } from "@frozenink/core";
 import type { EntityData } from "@frozenink/core";
@@ -22,6 +23,7 @@ import {
   assertSafePath,
   type RemoteEntityData,
 } from "./sync-plan";
+import { createGenerateThemeEngine } from "./generate";
 
 async function runConcurrent<T>(
   items: T[],
@@ -86,6 +88,11 @@ export const cloneCommand = new Command("clone")
     const collectionDir = join(home, "collections", localName);
     const storage = new LocalStorageBackend(collectionDir);
 
+    // Persist the original crawler type so serve/prepare can use the right theme
+    const meta = new MetadataStore(dbPath);
+    meta.setCrawlerType(manifest.collection?.crawlerType ?? null);
+    meta.close();
+
     // Batch-fetch all entity data
     const allExternalIds = entries.map((e) => e.externalId);
     console.log(`Fetching ${allExternalIds.length} entities...`);
@@ -112,22 +119,94 @@ export const cloneCommand = new Command("clone")
         .run();
     }
 
-    // Download markdown files
-    const mdDownloads = remoteEntities.filter((e) => e.markdownPath);
-    console.log(`Downloading ${mdDownloads.length} markdown files...`);
-    let downloaded = 0;
-    await runConcurrent(mdDownloads, 10, async (re) => {
-      const mdPath = re.markdownPath!;
-      assertSafePath(mdPath);
-      const content = await client.getMarkdown(mdPath);
-      if (content) {
-        await storage.write(`content/${mdPath}`, content);
+    // Generate markdown locally using the theme engine (same as generateCollection) so that
+    // the on-disk files match what prepare/serve render — no re-generation needed on first serve.
+    const crawlerType = manifest.collection?.crawlerType ?? "";
+    const themeEngine = createGenerateThemeEngine();
+    const indexer = new SearchIndexer(dbPath);
+
+    if (themeEngine.has(crawlerType)) {
+      // Build cross-entity lookup helpers (same pattern as generateCollection)
+      const entityPathLookup = (externalId: string): string | undefined => {
+        const [row] = colDb
+          .select({ folder: entities.folder, slug: entities.slug })
+          .from(entities)
+          .where(eq(entities.externalId, externalId))
+          .all();
+        if (!row || row.folder == null || row.slug == null) return undefined;
+        return row.folder ? `${row.folder}/${row.slug}` : row.slug;
+      };
+
+      const byExtId = new Map<string, string>();
+      const byStem = new Map<string, string>();
+      for (const re of remoteEntities) {
+        if (!re.markdownPath) continue;
+        const { folder, slug } = splitMarkdownPath(re.markdownPath);
+        if (folder == null || slug == null) continue;
+        const noExt = folder ? `${folder}/${slug}` : slug;
+        byExtId.set(re.externalId, noExt);
+        const stemName = slug.includes("/") ? slug.split("/").pop()! : slug;
+        if (!byStem.has(stemName)) byStem.set(stemName, noExt);
       }
-      downloaded++;
-      if (downloaded % 50 === 0) {
-        console.log(`  ${downloaded}/${mdDownloads.length} downloaded...`);
+      const resolveWikilink = (target: string): string | undefined => {
+        const clean = target.replace(/[#^].*$/, "").trim();
+        if (!clean) return undefined;
+        const withMd = clean.endsWith(".md") ? clean : `${clean}.md`;
+        if (byExtId.has(withMd)) return byExtId.get(withMd);
+        if (byExtId.has(clean)) return byExtId.get(clean);
+        const stemName = clean.includes("/") ? clean.split("/").pop()! : clean;
+        return byStem.get(stemName);
+      };
+
+      const mdEntities = remoteEntities.filter((e) => e.markdownPath);
+      console.log(`Generating ${mdEntities.length} markdown files...`);
+      let generated = 0;
+
+      for (const re of mdEntities) {
+        const entityData = re.data as unknown as EntityData;
+        const ctx = {
+          entity: {
+            externalId: re.externalId,
+            entityType: re.entityType,
+            title: re.title,
+            data: (entityData.source ?? {}) as Record<string, unknown>,
+            url: entityData.url ?? undefined,
+            tags: re.tags ?? [],
+          },
+          collectionName: localName,
+          crawlerType,
+          lookupEntityPath: entityPathLookup,
+          resolveWikilink,
+        };
+        const derivedTitle = themeEngine.getTitle(ctx);
+        const renderCtx = derivedTitle ? { ...ctx, entity: { ...ctx.entity, title: derivedTitle } } : ctx;
+        const markdown = themeEngine.render(renderCtx);
+        await storage.write(`content/${re.markdownPath!}`, markdown);
+
+        // Index inline — content is already in memory, no storage read needed
+        const [dbEntity] = colDb.select().from(entities).where(eq(entities.externalId, re.externalId)).all();
+        if (dbEntity) {
+          indexer.updateIndex({
+            id: dbEntity.id,
+            externalId: re.externalId,
+            entityType: re.entityType,
+            title: derivedTitle ?? re.title,
+            content: markdown,
+            tags: re.tags ?? [],
+          });
+        }
+
+        generated++;
+        if (process.stdout.isTTY) {
+          process.stdout.write(`\r  ${generated}/${mdEntities.length} generated...`);
+        } else if (generated % 50 === 0 || generated === mdEntities.length) {
+          console.log(`  ${generated}/${mdEntities.length} generated...`);
+        }
       }
-    });
+      if (process.stdout.isTTY) process.stdout.write("\n");
+    }
+
+    indexer.close();
 
     // Download asset files
     const assetDownloads: Array<{ path: string; entity: RemoteEntityData }> = [];
@@ -146,32 +225,6 @@ export const cloneCommand = new Command("clone")
         }
       });
     }
-
-    // Build search index
-    const indexer = new SearchIndexer(dbPath);
-    for (const re of remoteEntities) {
-      if (!re.markdownPath) continue;
-      let content = "";
-      try {
-        content = await storage.read(`content/${re.markdownPath}`);
-      } catch { /* file may not exist */ }
-      const [dbEntity] = colDb
-        .select()
-        .from(entities)
-        .where(eq(entities.externalId, re.externalId))
-        .all();
-      if (dbEntity) {
-        indexer.updateIndex({
-          id: dbEntity.id,
-          externalId: re.externalId,
-          entityType: re.entityType,
-          title: re.title,
-          content,
-          tags: ((re.data as Record<string, unknown>)?.tags as string[] | undefined) ?? [],
-        });
-      }
-    }
-    indexer.close();
 
     console.log(`\nCloned "${localName}": ${remoteEntities.length} entities`);
   });

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -8,6 +8,7 @@ import {
   updateCollection,
   ThemeEngine,
   LocalStorageBackend,
+  MetadataStore,
   CollectionEntry,
   type FolderConfig,
   type EntityData,
@@ -313,19 +314,28 @@ export async function prepareCollection(
   const storage = new LocalStorageBackend(collectionDir);
   const basePath = "content";
 
+  // For cloned ("remote") collections, resolve the original crawler type stored
+  // in the DB metadata so that theme rendering and folder configs work correctly.
+  let crawlerType = col.crawler;
+  if (col.crawler === "remote") {
+    const meta = new MetadataStore(dbPath);
+    crawlerType = meta.getCrawlerType() ?? col.crawler;
+    meta.close();
+  }
+
   // Step 1: Write folder yml files and root content.yml (incorporating collection-level hide)
   const collectionHide = col.hide ?? [];
-  const ymlUpdated = await writeFolderConfigFiles(themeEngine, col.crawler, storage, basePath, collectionHide);
+  const ymlUpdated = await writeFolderConfigFiles(themeEngine, crawlerType, storage, basePath, collectionHide);
   if (ymlUpdated) log(`  Folder config files updated`);
 
   // Step 1b: Always write AGENTS.md and CLAUDE.md (at collection root, outside content/)
   await writeAgentFiles(themeEngine, col, storage, log);
 
   // Step 2: Sample check — skip if theme is not registered
-  if (!themeEngine.has(col.crawler)) return;
+  if (!themeEngine.has(crawlerType)) return;
 
   const { sampled, titleMismatches, markdownMismatches, hashMismatches } = await checkSamples(
-    colDb, storage, themeEngine, col.crawler, col.name, basePath, 10,
+    colDb, storage, themeEngine, crawlerType, col.name, basePath, 10,
   );
 
   if (sampled === 0) return;

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -10,6 +10,7 @@ import {
   entities,
   LocalStorageBackend,
   SearchIndexer,
+  MetadataStore,
   entityMarkdownPath,
   splitMarkdownPath,
   resolveCredentials,
@@ -83,6 +84,13 @@ export const pullCommand = new Command("pull")
     // Fetch remote manifest
     console.log("Fetching manifest...");
     const { manifest, entries } = await client.getManifest();
+
+    // Keep crawler.type in sync — repairs clones created before this field existed
+    if (manifest.collection?.crawlerType) {
+      const meta = new MetadataStore(dbPath);
+      meta.setCrawlerType(manifest.collection.crawlerType);
+      meta.close();
+    }
 
     // Build local entity list
     const allLocal = colDb.select().from(entities).all();

--- a/packages/cli/src/commands/remote-client.ts
+++ b/packages/cli/src/commands/remote-client.ts
@@ -61,14 +61,18 @@ export class RemoteClient {
   }
 
   async getManifest(): Promise<{ manifest: ManifestResponse; entries: ManifestEntity[] }> {
-    const manifest = await this.fetchJson<ManifestResponse>("/api/collections/_default/manifest");
-
-    // If the collection name comes back from the server, we use it going forward
-    if (manifest.collection?.name) {
-      this.collectionName = manifest.collection.name;
+    // Try _default alias first; a 404 means the server uses explicit collection names only
+    let manifest: ManifestResponse | undefined;
+    try {
+      manifest = await this.fetchJson<ManifestResponse>("/api/collections/_default/manifest");
+      if (manifest.collection?.name) {
+        this.collectionName = manifest.collection.name;
+      }
+    } catch (err) {
+      if (!(err instanceof Error) || !err.message.startsWith("HTTP 404 ")) throw err;
     }
 
-    // Try with actual collection name
+    // Fall back to enumerating collections when _default is not found or returned no name
     if (!this.collectionName) {
       const collections = await this.fetchJson<Array<{ name: string }>>("/api/collections");
       if (collections.length > 0) {
@@ -81,6 +85,10 @@ export class RemoteClient {
         }
         return { manifest: retried, entries: parseManifestEntities(retried.entities) };
       }
+    }
+
+    if (!manifest) {
+      throw new Error("No collections found on remote site.");
     }
 
     if (manifest.version > 1) {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -11,6 +11,7 @@ import {
   entities,
   SearchIndexer,
   ThemeEngine,
+  MetadataStore,
   loadConfig,
   getModuleDir,
   isBun,
@@ -40,6 +41,23 @@ function createThemeEngine(): ThemeEngine {
   themeEngine.register(gitTheme);
   themeEngine.register(mantisHubTheme);
   return themeEngine;
+}
+
+/**
+ * For cloned ("remote") collections, resolve the original crawler type stored
+ * in the DB metadata at clone time so that theme rendering and folder configs
+ * work correctly.
+ */
+function effectiveCrawlerType(col: ReturnType<typeof getCollection>, dbPath: string): string {
+  if (col!.crawler === "remote" && existsSync(dbPath)) {
+    try {
+      const meta = new MetadataStore(dbPath);
+      const orig = meta.getCrawlerType();
+      meta.close();
+      if (orig) return orig;
+    } catch { /* fall through */ }
+  }
+  return col!.crawler;
 }
 
 const MIME_TYPES: Record<string, string> = {
@@ -389,7 +407,7 @@ export function createApiServer(
           return errorResponse("Collection database not found", 404);
 
         const colDb = getCollectionDb(dbPath);
-        const folderConfigs = themeEngine.getFolderConfigs(col.crawler);
+        const folderConfigs = themeEngine.getFolderConfigs(effectiveCrawlerType(col, dbPath));
         const rows: Array<{ folder: string; slug: string }> = [];
         for (const r of colDb
           .select({ folder: entities.folder, slug: entities.slug })
@@ -428,7 +446,8 @@ export function createApiServer(
 
         if (!entity) return errorResponse("File not found", 404);
 
-        if (!themeEngine.has(col.crawler)) {
+        const crawlerType = effectiveCrawlerType(col, dbPath);
+        if (!themeEngine.has(crawlerType)) {
           return errorResponse("No theme registered for this crawler", 404);
         }
 
@@ -455,7 +474,7 @@ export function createApiServer(
             tags: entityDataObj.tags ?? [],
           },
           collectionName: name,
-          crawlerType: col.crawler,
+          crawlerType,
           lookupEntityPath,
         });
 
@@ -475,13 +494,14 @@ export function createApiServer(
         const col = getCollection(name);
         if (!col) return errorResponse("Collection not found", 404);
 
-        if (!themeEngine.hasHtmlRenderer(col.crawler)) {
-          return errorResponse("HTML rendering not supported for this crawler", 404);
-        }
-
         const dbPath = getCollectionDbPath(name);
         if (!existsSync(dbPath))
           return errorResponse("Collection database not found", 404);
+
+        const htmlCrawlerType = effectiveCrawlerType(col, dbPath);
+        if (!themeEngine.hasHtmlRenderer(htmlCrawlerType)) {
+          return errorResponse("HTML rendering not supported for this crawler", 404);
+        }
 
         const colDb = getCollectionDb(dbPath);
 
@@ -516,7 +536,7 @@ export function createApiServer(
             tags: entityDataObj.tags ?? [],
           },
           collectionName: name,
-          crawlerType: col.crawler,
+          crawlerType: htmlCrawlerType,
           lookupEntityPath,
         });
 
@@ -536,7 +556,8 @@ export function createApiServer(
         const name = decodeURIComponent(htmlSupportMatch[1]);
         const col = getCollection(name);
         if (!col) return errorResponse("Collection not found", 404);
-        return jsonResponse({ supported: themeEngine.hasHtmlRenderer(col.crawler) });
+        const htmlSupportDbPath = getCollectionDbPath(name);
+        return jsonResponse({ supported: themeEngine.hasHtmlRenderer(effectiveCrawlerType(col, htmlSupportDbPath)) });
       }
 
       // GET /api/collections/:name/entities

--- a/packages/core/src/db/metadata.ts
+++ b/packages/core/src/db/metadata.ts
@@ -41,6 +41,7 @@ const K = {
   title: "title",
   description: "description",
   version: "version",
+  crawlerType: "crawler.type",
 } as const;
 
 export class MetadataStore {
@@ -170,6 +171,16 @@ export class MetadataStore {
 
   getCollectionVersion(): string | null {
     return this.getOptional(K.version);
+  }
+
+  /** The crawler type used to render this collection (e.g. "mantishub", "github"). */
+  setCrawlerType(crawlerType: string | null | undefined): void {
+    if (crawlerType == null || crawlerType === "") this.delete(K.crawlerType);
+    else this.set(K.crawlerType, crawlerType);
+  }
+
+  getCrawlerType(): string | null {
+    return this.getOptional(K.crawlerType);
   }
 
   close(): void {


### PR DESCRIPTION
## Summary

- **Fix clone 404 on `_default` collection**: `getManifest()` now catches the 404 and falls back to `GET /api/collections` to discover the actual collection name, instead of crashing
- **Store `crawlerType` in DB metadata**: cloned collections write the original crawler type (e.g. `"mantishub"`) to the `metadata` table so `serve` and `prepare` can resolve the correct theme — `pull` also writes it on every manifest fetch, repairing pre-existing clones
- **Fix rendering for cloned collections**: `serve.ts` adds `effectiveCrawlerType()` which reads `crawler.type` from the DB for `remote` collections; used for markdown, HTML, `html-support`, and `default-file` endpoints
- **Fix folder yml generation**: `prepare.ts` resolves the effective crawler type so folder configs (sort order, visibility) are written correctly for clones
- **Generate markdown locally during clone**: instead of downloading pre-rendered markdown from the worker (which lacks `lookupEntityPath` → no cross-entity links), clone now renders via the local theme engine with full `lookupEntityPath`/`resolveWikilink` context — matching what `prepare` and `serve` produce, eliminating the full re-generation triggered on first serve
- **FTS indexed inline**: search index is built from the rendered content directly, no extra storage-read pass needed
- **In-place progress on TTY**: clone progress overwrites the same line with `\r`
- **`MetadataStore`**: new `getCrawlerType()`/`setCrawlerType()` typed accessors for the `crawler.type` key

Closes #45 (re-generation symptom; worker-side link fix tracked separately)

## Test plan

- [ ] `fink clone <url>` succeeds against a worker that has no `_default` collection
- [ ] Cloned collection renders markdown and HTML correctly in the UI (no loading spinner disappearing)
- [ ] Folder sort order matches the source collection
- [ ] `fink serve` does not trigger re-generation for a freshly cloned collection
- [ ] `fink pull <clone>` on an older clone without `crawler.type` in metadata writes it and fixes rendering
- [ ] `fink pull <clone>` on an up-to-date clone still writes `crawler.type` even when "Already up to date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)