### PR TITLE
Add books favicon to Frozen Ink website

### DIFF
--- a/packages/website/src/favicon.svg
+++ b/packages/website/src/favicon.svg
@@ -1,0 +1,8 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Top book (red) -->
+  <rect x="2" y="3" width="28" height="8" rx="2" fill="#cf222e"/>
+  <!-- Middle book (teal, slightly inset) -->
+  <rect x="3.5" y="12" width="25" height="8" rx="2" fill="#1a9e8f"/>
+  <!-- Bottom book (orange) -->
+  <rect x="2" y="21" width="28" height="8" rx="2" fill="#e36209"/>
+</svg>

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -1,4 +1,5 @@
 import html from "./site.html";
+import faviconSvg from "./favicon.svg";
 import ogImageSvg from "./og-image.svg";
 
 // Base64-encode the PNG at build time isn't possible with text modules,
@@ -70,6 +71,15 @@ export default {
 
     if (path === "/og.svg") {
       return new Response(ogImageSvg, {
+        headers: {
+          "content-type": "image/svg+xml",
+          "cache-control": "public, max-age=86400",
+        },
+      });
+    }
+
+    if (path === "/favicon.svg") {
+      return new Response(faviconSvg, {
         headers: {
           "content-type": "image/svg+xml",
           "cache-control": "public, max-age=86400",

--- a/packages/website/src/site.html
+++ b/packages/website/src/site.html
@@ -27,7 +27,7 @@
 
   <!-- Theme color (used by Slack, Discord, Telegram, and some browsers) -->
   <meta name="theme-color" content="#0969da" />
-  <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABjSURBVFhH7c0xDQAgDEXRHwcuwP5dMA0TYKAlYeAO9CX/TndnZmZmZmZmZmZm/6Kq1t0fvN3dT7MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzOzv/E6d2dmZmZmZn/WcQC9fg7gL4VGPAAAAABJRU5ErkJggg==" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <style>
     /* ===== Reset & Base ===== */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }


### PR DESCRIPTION
## Summary

- Copies the 3-bar books SVG (red/teal/orange) from the UI package into `packages/website/src/favicon.svg`
- Adds a `/favicon.svg` route in the Cloudflare Worker (`index.ts`)
- Replaces the old generic base64 PNG favicon link in `site.html` with `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />`

## Test plan

- [ ] Visit https://frozenink.vboctor.workers.dev and verify the books icon appears in the browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)