### PR TITLE
Add Frozen Ink banner with collection title and dynamic window title

### DIFF
--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -327,10 +327,55 @@ body {
   line-height: 1.5;
 }
 
+#root {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ===== Frozen Ink Banner ===== */
+.frozenink-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  font-size: 0.75rem;
+  font-family: var(--font-sans);
+  flex-shrink: 0;
+}
+
+.frozenink-banner-title {
+  color: var(--text);
+  font-weight: 700;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.frozenink-banner-link {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  text-decoration: none;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  transition: color 0.15s;
+}
+
+.frozenink-banner-link:hover {
+  color: var(--text);
+}
+
 /* ===== Layout ===== */
 .layout {
   display: flex;
-  height: 100vh;
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -146,6 +146,33 @@ function loadUIMode(): UIMode {
   return "browse";
 }
 
+function FrozenInkBanner({ collectionTitle }: { collectionTitle: string | null }) {
+  return (
+    <div className="frozenink-banner">
+      <span className="frozenink-banner-title">{collectionTitle ?? ""}</span>
+      <a
+        href="https://frozen.ink"
+        target="_blank"
+        rel="noopener"
+        className="frozenink-banner-link"
+        aria-label="Powered by Frozen Ink"
+      >
+        <svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <rect x="2" y="3" width="28" height="8" rx="2" fill="#cf222e"/>
+          <rect x="3.5" y="12" width="25" height="8" rx="2" fill="#1a9e8f"/>
+          <rect x="2" y="21" width="28" height="8" rx="2" fill="#e36209"/>
+        </svg>
+        <span>Powered by Frozen Ink</span>
+        <svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+          <polyline points="15 3 21 3 21 9"/>
+          <line x1="10" y1="14" x2="21" y2="3"/>
+        </svg>
+      </a>
+    </div>
+  );
+}
+
 function saveUIMode(mode: UIMode) {
   try { localStorage.setItem("frozenink-ui-mode", mode); } catch {}
 }
@@ -333,6 +360,11 @@ export default function App() {
   useEffect(() => {
     applyTheme(theme);
   }, [theme]);
+
+  useEffect(() => {
+    const title = collections.find((c) => c.name === selectedCollection)?.title ?? selectedCollection;
+    document.title = title ?? "Frozen Ink";
+  }, [selectedCollection, collections]);
 
   useEffect(() => {
     fetch("/api/collections")
@@ -850,7 +882,7 @@ export default function App() {
 
   const canGoBack = navIndex > 0;
   const canGoForward = navIndex < navHistory.length - 1;
-  const showLogout = isPublishedDeployment();
+  const showLogout = isPublishedDeployment() || appMode === "published";
 
   const isDesktop = appMode === "desktop";
 
@@ -1216,6 +1248,11 @@ export default function App() {
 
   return (
     <>
+      {appMode !== "desktop" && (
+        <FrozenInkBanner
+          collectionTitle={collections.find((c) => c.name === selectedCollection)?.title ?? selectedCollection}
+        />
+      )}
       <Layout
         sidebar={sidebar}
         main={main}

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -48,6 +48,11 @@ export function buildRenderContext(
 
 const api = new Hono<{ Bindings: Env }>();
 
+// GET /api/app-info
+api.get("/api/app-info", (c) => {
+  return c.json({ mode: "published" });
+});
+
 // GET /api/collections
 api.get("/api/collections", async (c) => {
   const collections = await getCollections(c.env.BUCKET);


### PR DESCRIPTION
## Summary

- Adds a banner at the top of the UI in `fink serve` and published worker deployments (hidden in desktop app)
- Banner shows the selected **collection title** (bold) on the left and a **"Powered by Frozen Ink"** link on the right (SEO-friendly `rel="noopener"`, links to frozen.ink)
- Window title dynamically reflects the selected collection name
- Worker now returns `{ mode: "published" }` from `/api/app-info` for parity with `fink serve`
- Logout button now also appears on custom-domain worker deployments (not just `*.workers.dev`)

## Test plan

- [ ] Run `fink serve <collection>` — banner appears at top with collection title and "Powered by Frozen Ink" link
- [ ] Publish to worker — banner appears; clicking it opens frozen.ink in a new tab
- [ ] Switching collections updates the banner title and window title
- [ ] Window title shows collection name (no "Frozen Ink" suffix)
- [ ] Desktop app (`fink`) shows no banner
- [ ] Logout button visible on custom-domain worker deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)