### PR TITLE
Prepare CLI for npm publish readiness

### DIFF
--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Victor Boctor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/PUBLISH.md
+++ b/packages/cli/PUBLISH.md
@@ -1,0 +1,118 @@
+# Publishing @vboctor/fink to npm
+
+This guide covers how to build, version, and publish the Frozen Ink CLI to npm.
+
+The CLI is published as `@vboctor/fink`. The build script bundles all workspace
+packages into a single ESM file (`dist/fink.mjs`) so users only need Node.js
+and `better-sqlite3` (installed automatically as a dependency).
+
+## Prerequisites
+
+1. **Node.js >= 20** and **Bun** installed locally
+2. **npm account** with access to the `@vboctor` scope:
+
+   ```bash
+   npm login
+   npm whoami  # should print your npm username
+   ```
+
+3. If this is the first publish under the `@vboctor` scope, ensure the scope
+   is available (either as your npm username or an npm org you own).
+
+## Version management
+
+The version is defined in one place: `packages/cli/package.json` in the
+`version` field. Both the CLI (`fink --version`) and the published npm package
+read from it automatically — the build script inlines the version at bundle
+time.
+
+Bump the version before publishing:
+
+```bash
+cd packages/cli
+npm version patch   # 0.1.0 -> 0.1.1
+npm version minor   # 0.1.0 -> 0.2.0
+npm version major   # 0.1.0 -> 1.0.0
+```
+
+## Build
+
+```bash
+cd packages/cli
+
+# Bundle only (for npm)
+bun run build
+
+# Bundle + standalone executables
+bun run build:all
+```
+
+This produces:
+
+| Output | Purpose |
+|--------|---------|
+| `dist/fink.mjs` | Minified ESM bundle with `#!/usr/bin/env node` shebang |
+| `dist/package.json` | Auto-generated with correct `bin`, `files`, `engines`, and `dependencies` |
+| `dist/README.md` | Copied from source (maintainer sections stripped) |
+| `dist/LICENSE` | Copied from source |
+| `dist/fink-*` | Standalone Bun executables (only with `build:all` or `build:exe`) |
+
+### What the build does
+
+1. **Bundles** all source TypeScript + workspace packages (`@frozenink/core`,
+   `@frozenink/crawlers`, `@frozenink/mcp`) into a single `dist/fink.mjs` via
+   esbuild, targeting Node 20 ESM.
+2. **Externalizes** `better-sqlite3` (native module installed at runtime by npm).
+3. **Generates** `dist/package.json` with the npm package name `@vboctor/fink`,
+   correct `bin`, `engines`, `files`, and `dependencies`.
+4. **Copies** `README.md` (with the "Publishing to npm" section stripped) and
+   `LICENSE` into `dist/`.
+5. **Rewrites** the shebang to `#!/usr/bin/env node` so the npm package runs
+   under Node, not Bun.
+
+## Publish
+
+```bash
+# One-step build + publish
+bun run publish:npm
+```
+
+This runs `bun build.mjs --bundle-only && cd dist && npm publish --access public`.
+
+For a dry run first:
+
+```bash
+bun run build
+cd dist && npm publish --access public --dry-run
+```
+
+## Verify
+
+After publishing, verify the package is installable:
+
+```bash
+npm install -g @vboctor/fink
+fink --version
+fink --help
+```
+
+## Full publish checklist
+
+1. Ensure all changes are committed and CI passes (`bun run ci`)
+2. Bump the version: `cd packages/cli && npm version patch`
+3. Dry run: `bun run build && cd dist && npm publish --access public --dry-run`
+4. Publish: `bun run publish:npm`
+5. Verify: `npm install -g @vboctor/fink && fink --version`
+6. Commit the version bump and push
+
+## Package naming
+
+| Context | Name |
+|---------|------|
+| Monorepo workspace | `@frozenink/cli` (in `packages/cli/package.json`) |
+| Published npm package | `@vboctor/fink` (generated in `dist/package.json`) |
+| CLI binary | `fink` |
+
+The source `package.json` has `"private": true` — this is intentional. The
+`publish:npm` script runs from `dist/`, which has its own generated
+`package.json` without the `private` flag.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,38 +12,14 @@ Frozen Ink creates a unified, queryable, markdown-native workspace from your dat
 npm install -g @vboctor/fink
 ```
 
-Requires Node.js >= 20 and a C++ toolchain for the SQLite native module (`better-sqlite3`).
-
-### Standalone binary (no dependencies)
-
-Download the pre-built binary for your platform from the [releases page](https://github.com/vboctor/fink/releases):
-
-| Platform | Binary |
-|----------|--------|
-| macOS Apple Silicon | `fink-darwin-arm64` |
-| macOS Intel | `fink-darwin-x64` |
-| Linux x64 | `fink-linux-x64` |
-| Linux ARM64 | `fink-linux-arm64` |
-
-```bash
-# Example: macOS Apple Silicon
-curl -L -o fink https://github.com/vboctor/fink/releases/latest/download/fink-darwin-arm64
-chmod +x fink
-sudo mv fink /usr/local/bin/
-```
-
-### From source (development)
-
-```bash
-git clone https://github.com/vboctor/fink.git
-cd fink
-bun install
-cd packages/cli && bun link    # makes `fink` available globally
-```
+Requires Node.js >= 20.
 
 ## Quick Start
 
 ```bash
+# Help
+fink --help
+
 # Initialize (creates ~/.frozenink/)
 fink init
 
@@ -74,61 +50,16 @@ Running `fink` without arguments launches the interactive TUI:
 fink
 ```
 
-The TUI provides keyboard-driven access to all features:
-
-| Key | Screen |
-|-----|--------|
-| `c` | Collections (manage, publish, sync, export) |
-| `s` | Sync all |
-| `f` | Search |
-| `g` | Settings |
-| `ESC` | Go back |
-| `q` | Quit |
-
-## Commands
-
-All commands are also available in headless mode for scripting and CI:
-
-| Command | Description |
-|---------|-------------|
-| `fink` | Launch interactive TUI |
-| `fink init` | Initialize `~/.frozenink/` |
-| `fink add <type>` | Add a collection (github, obsidian, git, mantishub) |
-| `fink sync <name\|"*">` | Sync one or all collections |
-| `fink sync <name> --full` | Full re-sync from scratch |
-| `fink status` | Show sync status |
-| `fink search <query>` | Full-text search |
-| `fink collections list` | List all collections |
-| `fink collections remove <name>` | Delete a collection |
-| `fink collections enable <name>` | Enable a collection |
-| `fink collections disable <name>` | Disable a collection |
-| `fink collections rename <old> <new>` | Rename a collection |
-| `fink update <name>` | Update collection config |
-| `fink config list` | Show configuration |
-| `fink config get <key>` | Get a config value |
-| `fink config set <key> <value>` | Set a config value |
-| `fink generate <name\|"*">` | Re-render markdown from DB |
-| `fink index <name\|"*">` | Rebuild search index |
-| `fink serve` | Start API server + web UI |
-| `fink serve --mcp-only` | Start MCP server only |
-| `fink mcp add --tool <tool> <collection...>` | Register collection-scoped MCP links in a client tool |
-| `fink mcp remove --tool <tool> <collection...>` | Remove collection-scoped MCP links from a client tool |
-| `fink mcp list [--tool <tool>]` | Show MCP link status by collection |
-| `fink mcp serve --collection <name>` | MCP stdio entrypoint used by client tools |
-| `fink daemon start\|stop\|status` | Background sync daemon |
-| `fink publish <collection>` | Publish to Cloudflare |
-| `fink unpublish <collection>` | Remove a published collection |
-| `fink tui` | Launch TUI explicitly |
-
 ## Publishing to Cloudflare
 
-Publish a collection as a password-protected website with remote MCP access:
+Here are the steps to publish to Cloudflare:
 
 ```bash
 # Authenticate with Cloudflare first
 npx wrangler login
 
 # Publish a collection (worker name = collection name)
+# password is optional.
 fink publish my-repo --password secret123
 
 # Update an existing deployment
@@ -142,25 +73,27 @@ Published collections include:
 
 - Web UI for browsing synced data
 - Full-text search
-- MCP endpoint for AI assistants at `https://my-repo.workers.dev/mcp`
+- MCP endpoint for AI assistants at `https://my-collection.my-account.workers.dev/mcp`
 
 ## MCP Server
 
 Frozen Ink includes an MCP server for AI tools (Claude, Codex CLI, etc.):
 
 ```bash
-# Link one or more collections to Claude Code
-fink mcp add --tool claude-code my-repo
-fink mcp add --tool claude-code my-notes
+# Link a local collection to Claude Code (stdio transport)
+fink mcp add --tool claude-code my-vault
 
-# Link to Codex CLI (canonical name)
-fink mcp add --tool codex-cli my-repo
-
-# Legacy alias (still supported)
-fink mcp add --tool codex my-repo
-
-# Or add both in one command
+# Link multiple collections at once
 fink mcp add --tool claude-code my-repo my-notes
+
+# Link a published collection via its remote HTTP endpoint
+fink mcp add --tool claude-code my-vault --http
+
+# Link to Claude Desktop
+fink mcp add --tool claude-desktop my-vault
+
+# Link to Codex CLI (legacy alias: codex)
+fink mcp add --tool codex-cli my-vault
 
 # List link status
 fink mcp list --tool claude-code
@@ -170,22 +103,16 @@ fink mcp remove --tool claude-code my-repo
 
 # MCP stdio command used by clients
 fink mcp serve --collection my-notes
-
-# Or use the published MCP endpoint
-claude mcp add frozenink --transport streamable-http \
-  --url https://my-site.workers.dev/mcp \
-  --header "Authorization: Bearer <password>"
 ```
 
 Behavior notes:
 
-- Installed-user flow uses `fink mcp serve --collection <name>` and does not require Bun.
-- MCP clients launch the stdio command on demand; you do not run a background MCP server manually.
+- MCP clients launch `fink mcp serve` on demand; you do not run a background MCP server.
 - One MCP connection is created per `(tool, collection)`:
   - Add `my-repo` then `my-notes` => 2 connections
   - Add `my-repo my-notes` together => also 2 connections
+- `--http` links the remote HTTP endpoint of a published collection instead of local stdio. The password defaults to the one stored in `credentials.yml` during `fink publish`.
 - `--tool codex-cli` is the canonical Codex option; `--tool codex` remains a legacy alias.
-- Codex CLI support is best-effort and shown only when `codex mcp` commands are detected.
 - ChatGPT Desktop uses a remote MCP endpoint flow. `fink mcp add --tool chatgpt-desktop` returns setup guidance instead of writing local client config.
 
 TUI path: open `fink` -> `Collections` -> select a collection -> press `[m]` for MCP actions.
@@ -217,6 +144,10 @@ All data is stored locally in `~/.frozenink/`:
       content/               # rendered markdown files
       attachments/           # binary files (images, etc.)
 ```
+
+## Publishing to npm
+
+See [PUBLISH.md](PUBLISH.md) for the full build, version management, and publish process.
 
 ## License
 

--- a/packages/cli/build.mjs
+++ b/packages/cli/build.mjs
@@ -10,7 +10,7 @@
  */
 import { build } from "esbuild";
 import { execSync } from "child_process";
-import { existsSync, mkdirSync, writeFileSync, readFileSync, copyFileSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync, readFileSync, copyFileSync, chmodSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -56,6 +56,15 @@ async function bundleJS() {
     jsx: "automatic",
     loader: { ".tsx": "tsx", ".ts": "ts" },
   });
+
+  // Strip duplicate shebang — source has #!/usr/bin/env bun which esbuild
+  // preserves alongside the banner's #!/usr/bin/env node.  Only keep the
+  // banner shebang (node) so the npm bundle runs under Node.
+  const outPath = join(distDir, "fink.mjs");
+  let code = readFileSync(outPath, "utf-8");
+  code = code.replace(/^#!\/usr\/bin\/env bun\n/, "");
+  writeFileSync(outPath, code);
+  chmodSync(outPath, 0o755);
 
   console.log("✓ Bundled dist/fink.mjs");
 }
@@ -154,11 +163,21 @@ if (all || bundleOnly) {
   await bundleJS();
   generateDistPackageJson();
 
-  // Copy README for npm
+  // Copy README for npm, stripping maintainer-only sections
   const readmeSrc = join(__dirname, "README.md");
   if (existsSync(readmeSrc)) {
-    copyFileSync(readmeSrc, join(distDir, "README.md"));
-    console.log("✓ Copied README.md to dist/");
+    let readme = readFileSync(readmeSrc, "utf-8");
+    // Remove "Publishing to npm" section (maintainer docs, not for end users)
+    readme = readme.replace(/\n## Publishing to npm\n[\s\S]*?(?=\n## )/m, "");
+    // Collapse any resulting multiple blank lines
+    readme = readme.replace(/\n{3,}/g, "\n\n");
+    writeFileSync(join(distDir, "README.md"), readme);
+    console.log("✓ Copied README.md to dist/ (stripped maintainer sections)");
+  }
+  const licenseSrc = join(__dirname, "LICENSE");
+  if (existsSync(licenseSrc)) {
+    copyFileSync(licenseSrc, join(distDir, "LICENSE"));
+    console.log("✓ Copied LICENSE to dist/");
   }
 }
 

--- a/packages/cli/src/__tests__/mcp-http-claude-code.test.ts
+++ b/packages/cli/src/__tests__/mcp-http-claude-code.test.ts
@@ -23,7 +23,7 @@ afterEach(() => {
 });
 
 describe("claude-code adapter HTTP transport", () => {
-  it("invokes `claude mcp add --transport http` with the Bearer header", async () => {
+  it("invokes `claude mcp add --http --url` with --password", async () => {
     const { claudeCodeAdapter } = await import("../mcp/tools/claude-code");
 
     await claudeCodeAdapter.addConnection({
@@ -40,15 +40,15 @@ describe("claude-code adapter HTTP transport", () => {
       "mcp",
       "add",
       "fink-my-vault",
-      "--transport",
-      "http",
+      "--http",
+      "--url",
       "https://example.workers.dev/mcp",
-      "--header",
-      "Authorization: Bearer secret",
+      "--password",
+      "secret",
     ]);
   });
 
-  it("omits --header when no bearer token is provided", async () => {
+  it("omits --password when no bearer token is provided", async () => {
     const { claudeCodeAdapter } = await import("../mcp/tools/claude-code");
 
     await claudeCodeAdapter.addConnection({
@@ -64,8 +64,8 @@ describe("claude-code adapter HTTP transport", () => {
       "mcp",
       "add",
       "fink-public",
-      "--transport",
-      "http",
+      "--http",
+      "--url",
       "https://example.workers.dev/mcp",
     ]);
   });

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -32,6 +32,26 @@ export const addCommand = new Command("add")
   .option("--open-only", "Only sync open issues/PRs, delete closed ones (for github)")
   .option("--sync-entities <types>", "Comma-separated entity types to sync: issues,pages,users (for mantishub)")
   .option("--credentials <name>", "Use a named credential set from ~/.frozenink/credentials.yml")
+  .addHelpText("after", `
+Examples:
+  # Add a GitHub repository
+  fink add github --name my-repo --token ghp_xxx --repo owner/repo
+
+  # Add a GitHub repo with limits (open issues only, max 500)
+  fink add github --name my-repo --token ghp_xxx --repo owner/repo --open-only --max 500
+
+  # Add a local Obsidian vault
+  fink add obsidian --name my-notes --path ~/Documents/MyVault
+
+  # Add a local Git repository
+  fink add git --name my-code --path ~/projects/my-project
+
+  # Add a Git repo with commit diffs included
+  fink add git --name my-code --path ~/projects/my-project --include-diffs
+
+  # Add a MantisHub project
+  fink add mantishub --name bugs --url https://myproject.mantishub.io --token xxx --project-name MyProject
+`)
   .action(async (crawlerType: string, opts: Record<string, string>) => {
     ensureInitialized();
 

--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -46,6 +46,17 @@ export const cloneCommand = new Command("clone")
   .option("--name <name>", "Local collection name (defaults to remote collection name)")
   .option("--password <password>", "Password for protected sites")
   .option("--dry-run", "Show sync plan without making changes")
+  .addHelpText("after", `
+Examples:
+  # Clone a published site
+  fink clone https://my-fink.workers.dev --password secret123
+
+  # Clone with a custom local name
+  fink clone https://my-fink.workers.dev --name team-kb --password secret123
+
+  # Preview what would be synced
+  fink clone https://my-fink.workers.dev --password secret123 --dry-run
+`)
   .action(async (url: string, opts: { name?: string; password?: string; dryRun?: boolean }) => {
     ensureInitialized();
     const home = getFrozenInkHome();

--- a/packages/cli/src/commands/collections.ts
+++ b/packages/cli/src/commands/collections.ts
@@ -177,6 +177,15 @@ const updateCommand = new Command("update")
 
 export const collectionsCommand = new Command("collections")
   .description("Manage collections")
+  .addHelpText("after", `
+Examples:
+  fink collections list
+  fink collections remove my-repo
+  fink collections enable my-repo
+  fink collections disable my-repo
+  fink collections rename old-name new-name
+  fink collections update my-repo --title "My Project" --description "Bug tracker"
+`)
   .addCommand(listCommand)
   .addCommand(removeCommand)
   .addCommand(enableCommand)

--- a/packages/cli/src/commands/compact.ts
+++ b/packages/cli/src/commands/compact.ts
@@ -28,6 +28,11 @@ function formatBytes(bytes: number): string {
 export const compactCommand = new Command("compact")
   .description("Vacuum the SQLite database to reclaim unused space")
   .argument("<collection>", 'Collection name or "*" for all collections')
+  .addHelpText("after", `
+Examples:
+  fink compact my-vault
+  fink compact "*"
+`)
   .action(async (collection: string) => {
     ensureInitialized();
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -98,6 +98,14 @@ const listConfigCommand = new Command("list")
 
 export const configCommand = new Command("config")
   .description("Manage configuration")
+  .addHelpText("after", `
+Examples:
+  fink config list
+  fink config get sync.interval
+  fink config set sync.interval 1800
+  fink config set sync.concurrency 2
+  fink config set logging.level debug
+`)
   .addCommand(getCommand)
   .addCommand(setCommand)
   .addCommand(listConfigCommand);

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -171,6 +171,12 @@ const statusSubCommand = new Command("status")
 
 export const daemonCommand = new Command("daemon")
   .description("Manage the background sync daemon")
+  .addHelpText("after", `
+Examples:
+  fink daemon start
+  fink daemon status
+  fink daemon stop
+`)
   .addCommand(startCommand)
   .addCommand(stopCommand)
   .addCommand(statusSubCommand);

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -275,6 +275,11 @@ export const generateCommand = new Command("generate")
     "Re-generate markdown files from existing entity data (re-renders without re-syncing; handles file renames)",
   )
   .argument("<collection>", 'Collection name or "*" for all collections')
+  .addHelpText("after", `
+Examples:
+  fink generate my-vault
+  fink generate "*"
+`)
   .action(async (collection: string) => {
     ensureInitialized();
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -21,6 +21,11 @@ export const indexCommand = new Command("index")
     "Re-index collections (rebuild search index and links from existing markdown)",
   )
   .argument("<collection>", 'Collection name or "*" for all collections')
+  .addHelpText("after", `
+Examples:
+  fink index my-vault
+  fink index "*"
+`)
   .action(async (collection: string) => {
     ensureInitialized();
 

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -71,6 +71,23 @@ mcpCommand
   .option("--http", "Link the remote HTTP MCP endpoint of a published collection instead of local stdio")
   .option("--password <value>", "Bearer token for --http (defaults to the password stored in credentials.yml)")
   .argument("<collections...>", "Collection names")
+  .addHelpText("after", `
+Examples:
+  # Link a local collection to Claude Code (stdio transport)
+  fink mcp add --tool claude-code my-vault
+
+  # Link multiple collections at once
+  fink mcp add --tool claude-code my-vault my-project-issues
+
+  # Link a published collection via its remote HTTP endpoint
+  fink mcp add --tool claude-code my-vault --http
+
+  # Link to Claude Desktop instead
+  fink mcp add --tool claude-desktop my-vault
+
+  # Link to Codex CLI (legacy alias: codex)
+  fink mcp add --tool codex-cli my-vault
+`)
   .action(async (collectionNames: string[], opts: {
     tool: string;
     description?: string;
@@ -105,6 +122,11 @@ mcpCommand
   .description("Remove MCP tool links for one or more collections")
   .requiredOption("--tool <tool>", `Target MCP client tool (${TOOL_HELP})`)
   .argument("<collections...>", "Collection names")
+  .addHelpText("after", `
+Examples:
+  fink mcp remove --tool claude-code my-vault
+  fink mcp remove --tool claude-desktop my-vault my-notes
+`)
   .action(async (collectionNames: string[], opts: { tool: string }) => {
     requireInitialized();
     const tool = parseTool(opts.tool);
@@ -130,6 +152,14 @@ mcpCommand
   .command("list")
   .description("List MCP tool links by collection")
   .option("--tool <tool>", `Filter by tool (${TOOL_HELP})`)
+  .addHelpText("after", `
+Examples:
+  # List all MCP links across all tools
+  fink mcp list
+
+  # List links for a specific tool
+  fink mcp list --tool claude-code
+`)
   .action(async (opts: { tool?: string }) => {
     requireInitialized();
 

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -586,6 +586,23 @@ export const publishCommand = new Command("publish")
   .option("--public", "Explicitly allow public access on initial publish (skip confirmation prompt)")
   .option("--tool-description <description>", "Tool description advertised to MCP clients")
   .option("--worker-only", "Deploy worker code only (skip D1/R2 data upload)")
+  .addHelpText("after", `
+Examples:
+  # Publish with password protection
+  fink publish my-repo --password secret123
+
+  # Update an existing deployment (reuses stored password)
+  fink publish my-repo
+
+  # Publish without password (public access)
+  fink publish my-repo --public
+
+  # Deploy only the worker code (skip data upload)
+  fink publish my-repo --worker-only
+
+  # Set a description for MCP clients
+  fink publish my-repo --password secret123 --tool-description "Team bug tracker"
+`)
   .action(async (collectionNameArg: string, opts: {
     password?: string;
     removePassword?: boolean;
@@ -653,9 +670,10 @@ export const publishCommand = new Command("publish")
       console.log(`MCP URL: ${result.mcpUrl}`);
       if (opts.password) {
         console.log(`\nMCP Setup (Claude Code):`);
-        console.log(`  claude mcp add frozenink --transport streamable-http \\`);
+        console.log(`  claude mcp add frozenink --http \\`);
         console.log(`    --url ${result.mcpUrl} \\`);
-        console.log(`    --header "Authorization: Bearer <password>"`);
+        console.log(`    --password "<password>"`);
+
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -46,6 +46,11 @@ export const pullCommand = new Command("pull")
   .description("Pull updates from a remote published site into a cloned collection")
   .argument("<collection>", "Collection name (must have crawler: remote)")
   .option("--dry-run", "Show sync plan without making changes")
+  .addHelpText("after", `
+Examples:
+  fink pull team-kb
+  fink pull team-kb --dry-run
+`)
   .action(async (collection: string, opts: { dryRun?: boolean }) => {
     ensureInitialized();
     const home = getFrozenInkHome();

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -16,6 +16,20 @@ export const searchCommand = new Command("search")
   .option("--type <type>", "Filter by entity type (e.g., issue, pull_request)")
   .option("--limit <n>", "Maximum results", "20")
   .option("--json", "Output results as JSON")
+  .addHelpText("after", `
+Examples:
+  # Search across all collections
+  fink search "authentication bug"
+
+  # Search within a specific collection
+  fink search "login flow" --collection my-repo
+
+  # Filter by entity type
+  fink search "performance" --type issue
+
+  # Output as JSON for scripting
+  fink search "API design" --json --limit 5
+`)
   .action(
     (
       query: string,

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -918,6 +918,20 @@ export const serveCommand = new Command("serve")
   .option("--mcp-only", "Start only the MCP server (no REST API)")
   .option("--ui-only", "Start only the REST API server (no MCP)")
   .option("--port <port>", "Port for the REST API server")
+  .addHelpText("after", `
+Examples:
+  # Start API server + web UI for all collections
+  fink serve
+
+  # Serve a single collection
+  fink serve my-vault
+
+  # Start MCP server only (no web UI)
+  fink serve --mcp-only
+
+  # Start on a custom port
+  fink serve --port 8080
+`)
   .action(async (collectionName: string | undefined, opts: { mcpOnly?: boolean; uiOnly?: boolean; port?: string }) => {
     const home = getFrozenInkHome();
 

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -26,6 +26,20 @@ export const syncCommand = new Command("sync")
   .option("--max <count>", "Maximum entities per type to sync (overrides collection config)", parseInt)
   .option("--max-issues <count>", "Maximum issues to sync (overrides collection config)", parseInt)
   .option("--max-prs <count>", "Maximum pull requests to sync (overrides collection config)", parseInt)
+  .addHelpText("after", `
+Examples:
+  # Sync a single collection
+  fink sync my-repo
+
+  # Sync all collections
+  fink sync "*"
+
+  # Full re-sync from scratch (ignores cursors)
+  fink sync my-repo --full
+
+  # Sync with a limit on entities
+  fink sync my-repo --max 100
+`)
   .action(async (collection: string, opts: { full?: boolean; max?: number; maxIssues?: number; maxPrs?: number }) => {
     ensureInitialized();
 

--- a/packages/cli/src/commands/unpublish.ts
+++ b/packages/cli/src/commands/unpublish.ts
@@ -87,6 +87,11 @@ export const unpublishCommand = new Command("unpublish")
   .description("Remove a published collection from Cloudflare")
   .argument("<collection>", "Collection name to unpublish")
   .option("--force", "Skip confirmation")
+  .addHelpText("after", `
+Examples:
+  fink unpublish my-repo
+  fink unpublish my-repo --force
+`)
   .action(async (collectionName: string, opts: {
     force?: boolean;
   }) => {

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -14,6 +14,17 @@ export const updateCommand = new Command("update")
   .option("--max-prs <count>", "Maximum pull requests to sync", parseInt)
   .option("--sync-comments [value]", "Sync comments (true/false)")
   .option("--sync-check-statuses [value]", "Sync check statuses (true/false)")
+  .addHelpText("after", `
+Examples:
+  # Switch to open issues/PRs only
+  fink update my-repo --open-only
+
+  # Set max entities to sync
+  fink update my-repo --max 500
+
+  # Enable comment syncing
+  fink update my-repo --sync-comments true
+`)
   .action(async (collection: string, opts: Record<string, unknown>) => {
     ensureInitialized();
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env bun
 import { Command } from "commander";
+import pkg from "../package.json";
+
+const version: string = pkg.version;
 import { initCommand } from "./commands/init";
 import { addCommand } from "./commands/add";
 import { syncCommand } from "./commands/sync";
@@ -28,7 +31,7 @@ const program = new Command();
 program
   .name("fink")
   .description("Frozen Ink - Local data replica manager")
-  .version("0.1.0");
+  .version(version);
 
 program.addCommand(initCommand);
 program.addCommand(addCommand);

--- a/packages/cli/src/mcp/tools/claude-code.ts
+++ b/packages/cli/src/mcp/tools/claude-code.ts
@@ -90,9 +90,9 @@ export const claudeCodeAdapter: McpToolAdapter = {
 
   async addConnection(spec: ToolConnectionSpec): Promise<void> {
     if (spec.transport === "http") {
-      const args = ["mcp", "add", spec.connectionName, "--transport", "http", spec.httpUrl];
+      const args = ["mcp", "add", spec.connectionName, "--http", "--url", spec.httpUrl];
       if (spec.bearerToken) {
-        args.push("--header", `Authorization: Bearer ${spec.bearerToken}`);
+        args.push("--password", spec.bearerToken);
       }
       if (spec.description) {
         args.push("--description", spec.description);

--- a/packages/website/src/docs/cloud-mcp.ts
+++ b/packages/website/src/docs/cloud-mcp.ts
@@ -129,12 +129,12 @@ export const cloudMcpPage = renderDocsPage({
   <p>From v0.2 onward, <code>fink mcp add --http</code> registers the remote MCP endpoint automatically for Claude Code and Claude Desktop, reusing the password stored in <code>credentials.yml</code> when you published:</p>
 
   <pre><code><span class="cmt"># Claude Code</span>
-fink mcp add <span class="flag">--http</span> <span class="flag">--tool</span> claude-code my-vault
+fink mcp add <span class="flag">--tool</span> claude-code my-vault <span class="flag">--http</span>
 
 <span class="cmt"># Claude Desktop</span>
-fink mcp add <span class="flag">--http</span> <span class="flag">--tool</span> claude-desktop my-vault</code></pre>
+fink mcp add <span class="flag">--tool</span> claude-desktop my-vault <span class="flag">--http</span></code></pre>
 
-  <p>Pass <code>--password &lt;value&gt;</code> if you want to override the stored token (useful when sharing a deployment across machines). For other MCP clients that don't yet support <code>--http</code>, edit the configuration file by hand:</p>
+  <p>The password is read automatically from <code>credentials.yml</code> (stored when you published). For other MCP clients that don't yet support <code>--http</code>, edit the configuration file by hand:</p>
 
   <p>Example for Claude Code's <code>~/.claude/mcp_servers.json</code>:</p>
   <pre><code>{
@@ -245,8 +245,8 @@ fink publish github-issues architecture-notes runbooks \
     <tbody>
       <tr>
         <td><strong>Setup</strong></td>
-        <td><code>fink mcp add --tool claude-code</code></td>
-        <td><code>fink mcp add --http --tool claude-code</code> (after publish)</td>
+        <td><code>fink mcp add --tool claude-code my-vault</code></td>
+        <td><code>fink mcp add --tool claude-code my-vault --http</code> (after publish)</td>
       </tr>
       <tr>
         <td><strong>Data location</strong></td>


### PR DESCRIPTION
## Summary

- Fix double shebang bug in build output — npm bundle was running under `bun` instead of `node`
- Add MIT LICENSE file and copy it to `dist/` during build
- Strip maintainer-only sections from the npm-published README automatically
- Read CLI version from `package.json` instead of hardcoding — single source of truth
- Update MCP commands to use correct `claude mcp add --http --url --password` syntax across code, tests, and docs
- Add informative `--help` examples to all CLI commands (add, sync, search, publish, clone, serve, mcp, config, collections, daemon, etc.)
- Create `PUBLISH.md` with full publish checklist, version management, and package naming guide
- Update cloud-mcp website docs with consistent command syntax

## Test plan

- [x] `bun run ci` passes (lint, typecheck, all test suites, UI build, worker build)
- [x] `bun run build` produces correct `dist/` output with single shebang, LICENSE, and stripped README
- [x] `fink --version` reads from `package.json` in both dev and bundled modes
- [x] All `fink <command> --help` outputs show relevant examples


🤖 Generated with [Claude Code](https://claude.com/claude-code)