### PR TITLE
Desktop sync + publish improvements; unify fink sync/pull

### DIFF
--- a/packages/cli/src/__tests__/prepare-hash.test.ts
+++ b/packages/cli/src/__tests__/prepare-hash.test.ts
@@ -88,7 +88,7 @@ afterEach(() => {
 });
 
 describe("prepareCollection — content hash verification", () => {
-  it("detects a stale content_hash and triggers regenerate", async () => {
+  it("detects a stale content_hash and warns without auto-regenerating", async () => {
     const { themeEngine } = await seedCollection();
 
     const dbPath = getCollectionDbPath("prep-test");
@@ -109,14 +109,18 @@ describe("prepareCollection — content hash verification", () => {
     };
     await prepareCollection(col as any, getFrozenInkHome(), themeEngine, (m) => logs.push(m));
 
-    // Prepare logged the hash mismatch reason
-    const regenLog = logs.find((l) => l.includes("outdated"));
-    expect(regenLog).toBeDefined();
-    expect(regenLog).toContain("hash");
+    // Prepare logged the hash mismatch reason and the suggested command
+    const warnLog = logs.find((l) => l.includes("outdated"));
+    expect(warnLog).toBeDefined();
+    expect(warnLog).toContain("hash");
+    expect(warnLog).toContain("fink generate");
 
-    // After regenerate, every row has a correct hash
+    // Prepare must NOT auto-fix hashes — the user runs `fink generate` explicitly.
+    // Every row should still have the corrupted hash we wrote above.
     const rows = colDb.select().from(entities).all();
     for (const row of rows) {
+      expect(row.contentHash).toBe("deadbeef");
+      // Sanity: the expected hash is different, confirming we did detect staleness.
       const expected = computeEntityHash({
         entityType: row.entityType,
         title: row.title,
@@ -124,7 +128,7 @@ describe("prepareCollection — content hash verification", () => {
         slug: row.slug ?? null,
         data: row.data as EntityData,
       });
-      expect(row.contentHash).toBe(expected);
+      expect(expected).not.toBe("deadbeef");
     }
   });
 

--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -82,7 +82,7 @@ Examples:
     // Fail if collection already exists
     const existingCol = getCollection(localName);
     if (existingCol !== null) {
-      console.error(`Collection "${localName}" already exists. Use 'fink pull' to update it.`);
+      console.error(`Collection "${localName}" already exists. Use 'fink sync' to update it.`);
       process.exit(1);
     }
 

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -647,10 +647,12 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
       // Remote/cloned collections use pullCollection — no prepare or crawler needed
       if (col.crawler === "remote") {
         syncProgress = { ...syncProgress, collectionName: name, status: `syncing ${name}` };
+        console.log(`[sync:${name}] starting (remote/cloned)`);
         try {
           const result = await pullCollection(name, {
             onProgress: (msg) => {
               syncProgress = { ...syncProgress, status: msg };
+              console.log(`[sync:${name}] ${msg}`);
             },
           });
           totalCreated += result.created;
@@ -680,6 +682,10 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
 
       const crawler = factory();
       try {
+        const credRef = typeof col.credentials === "string"
+          ? `name:"${col.credentials}" (from ${join(home, "credentials.yml")})`
+          : `inline(${Object.keys(col.credentials).join(",")})`;
+        console.log(`[sync] "${name}" (${col.crawler}) credentials=${credRef}`);
         await crawler.initialize(
           col.config as Record<string, unknown>,
           resolveCredentials(col.credentials),
@@ -711,11 +717,16 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
               updated: totalUpdated,
             };
           },
+          onProgress: (msg) => {
+            syncProgress = { ...syncProgress, status: `${name}: ${msg}` };
+            console.log(`[sync:${name}] ${msg}`);
+          },
         });
 
         const result = await engine.run({ syncType: full ? "full" : "incremental" });
         totalDeleted += result.deleted;
         syncProgress = { ...syncProgress, deleted: totalDeleted };
+        console.log(`[sync:${name}] done: +${result.created} ~${result.updated} -${result.deleted}`);
       } finally {
         await crawler.dispose();
       }
@@ -730,6 +741,7 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
       deleted: totalDeleted,
       error: null,
     };
+    console.log(`[sync] completed: +${totalCreated} ~${totalUpdated} -${totalDeleted} across ${collectionNames.length} collection(s)`);
   } catch (err) {
     syncProgress = {
       ...syncProgress,
@@ -737,6 +749,7 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
       status: "failed",
       error: String(err),
     };
+    console.error(`[sync] failed: ${err}`);
   }
 }
 

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -38,6 +38,7 @@ import {
 } from "@frozenink/crawlers";
 import { prepareCollection } from "./prepare";
 import { createGenerateThemeEngine } from "./generate";
+import { pullCollection } from "./pull";
 
 // --- In-memory sync/publish/export progress tracking ---
 
@@ -642,6 +643,25 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
     for (const name of collectionNames) {
       const col = getCollection(name);
       if (!col) continue;
+
+      // Remote/cloned collections use pullCollection — no prepare or crawler needed
+      if (col.crawler === "remote") {
+        syncProgress = { ...syncProgress, collectionName: name, status: `syncing ${name}` };
+        try {
+          const result = await pullCollection(name, {
+            onProgress: (msg) => {
+              syncProgress = { ...syncProgress, status: msg };
+            },
+          });
+          totalCreated += result.created;
+          totalUpdated += result.updated;
+          totalDeleted += result.deleted;
+          syncProgress = { ...syncProgress, created: totalCreated, updated: totalUpdated, deleted: totalDeleted };
+        } catch (err) {
+          console.error(`  Sync failed for "${name}": ${err}`);
+        }
+        continue;
+      }
 
       // Run prepare before incremental sync: schema migrations, folder ymls, stale markdown check
       if (!full) {

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -3,7 +3,7 @@
  * These routes handle collection CRUD, sync triggering, publish orchestration,
  * export, and configuration — all gated behind mode === "desktop".
  */
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, readdirSync } from "fs";
 import { join } from "path";
 import yaml from "js-yaml";
 import {
@@ -106,6 +106,32 @@ let publishCollectionsOverride: PublishCollectionsFn | null = null;
 
 export function setPublishCollectionsOverride(fn: PublishCollectionsFn | null): void {
   publishCollectionsOverride = fn;
+}
+
+// --- Helpers ---
+
+/** Recursively sum file sizes in a directory. */
+function getDirectorySize(dirPath: string): number {
+  if (!existsSync(dirPath)) return 0;
+  let total = 0;
+  try {
+    for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+      const fullPath = join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        total += getDirectorySize(fullPath);
+      } else {
+        try { total += statSync(fullPath).size; } catch {}
+      }
+    }
+  } catch {}
+  return total;
+}
+
+/** Get disk size in bytes for a collection (db + content). */
+function getCollectionDiskSize(name: string): number {
+  const home = getFrozenInkHome();
+  const colDir = join(home, "collections", name);
+  return getDirectorySize(colDir);
 }
 
 // --- Mode detection ---
@@ -247,6 +273,23 @@ export function handleManagementRequest(req: Request): Response | null {
     });
   }
 
+  // GET /api/collections/:name/config — returns full collection YAML config for editing
+  const getConfigMatch = path.match(/^\/api\/collections\/([^/]+)\/config$/);
+  if (getConfigMatch && method === "GET") {
+    const name = decodeURIComponent(getConfigMatch[1]);
+    const col = getCollection(name);
+    if (!col) return errorResponse("Collection not found", 404);
+    // Return the full config including credentials key (string name or inline object)
+    return jsonResponse({
+      title: col.title,
+      description: col.description,
+      crawler: col.crawler,
+      enabled: col.enabled,
+      config: col.config ?? {},
+      credentials: col.credentials ?? {},
+    });
+  }
+
   // POST /api/collections/:name/prepare
   const prepareColMatch = path.match(/^\/api\/collections\/([^/]+)\/prepare$/);
   if (prepareColMatch && method === "POST") {
@@ -290,9 +333,11 @@ export function handleManagementRequest(req: Request): Response | null {
       entityCount = colDb.select().from(entities).all().length;
     }
 
+    const diskSizeBytes = getCollectionDiskSize(name);
     const sync = getCollectionSyncState(dbPath);
     return jsonResponse({
       entityCount,
+      diskSizeBytes,
       lastSyncRun: sync.lastAt ? {
         status: sync.lastStatus,
         startedAt: sync.lastAt,

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -57,6 +57,8 @@ export interface PublishProgress {
   step: string;
   detail: string;
   error: string | null;
+  /** Unix timestamp in ms when the publish run started, for elapsed-time display. */
+  startedAt: number | null;
 }
 
 export interface ExportProgress {
@@ -82,6 +84,7 @@ let publishProgress: PublishProgress = {
   step: "idle",
   detail: "",
   error: null,
+  startedAt: null,
 };
 
 let exportProgress: ExportProgress = {
@@ -596,7 +599,7 @@ export function handleManagementRequest(req: Request): Response | null {
     return handleAsync(async () => {
       const name = decodeURIComponent(publishColMatch[1]);
       const body = await readBody(req);
-      publishProgress = { active: true, step: "starting", detail: "", error: null };
+      publishProgress = { active: true, step: "starting", detail: "", error: null, startedAt: Date.now() };
       // Fire and forget — the UI polls /api/publish/status
       triggerPublish({ ...body, collectionName: name }).catch(() => {});
       return jsonResponse({ ok: true });
@@ -756,7 +759,8 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
 // --- Publish logic ---
 
 async function triggerPublish(opts: Record<string, unknown>): Promise<void> {
-  publishProgress = { active: true, step: "starting", detail: "Starting publish...", error: null };
+  const startedAt = publishProgress.startedAt ?? Date.now();
+  publishProgress = { active: true, step: "starting", detail: "Starting publish...", error: null, startedAt };
   try {
     const publishCollections = publishCollectionsOverride
       ?? (await import("./publish")).publishCollections;
@@ -773,8 +777,8 @@ async function triggerPublish(opts: Record<string, unknown>): Promise<void> {
       },
     );
 
-    publishProgress = { active: false, step: "done", detail: "Publish completed", error: null };
+    publishProgress = { active: false, step: "done", detail: "Publish completed", error: null, startedAt };
   } catch (err) {
-    publishProgress = { active: false, step: "failed", detail: "", error: String(err) };
+    publishProgress = { active: false, step: "failed", detail: "", error: String(err), startedAt };
   }
 }

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -5,7 +5,6 @@ import {
   getCollectionDb,
   getCollectionDbPath,
   listCollections,
-  updateCollection,
   ThemeEngine,
   LocalStorageBackend,
   MetadataStore,
@@ -17,8 +16,7 @@ import {
   computeEntityHash,
 } from "@frozenink/core";
 import { eq, sql } from "drizzle-orm";
-import { createDefaultRegistry } from "@frozenink/crawlers";
-import { generateCollection, createGenerateThemeEngine } from "./generate";
+import { createGenerateThemeEngine } from "./generate";
 
 type Log = (msg: string) => void;
 
@@ -345,23 +343,13 @@ export async function prepareCollection(
     return;
   }
 
-  // Step 3: Mismatch — regenerate all entities
+  // Step 3: Mismatch — warn the user and suggest running generate
   const reasons = [
     titleMismatches > 0 ? `${titleMismatches} title${titleMismatches === 1 ? "" : "s"}` : "",
     markdownMismatches > 0 ? `${markdownMismatches} markdown` : "",
     hashMismatches > 0 ? `${hashMismatches} hash${hashMismatches === 1 ? "" : "es"}` : "",
   ].filter(Boolean).join(", ");
-  log(`  ${reasons} outdated (${totalMismatches}/${sampled} samples) — regenerating all...`);
-  const summary = await generateCollection(col, home, themeEngine);
-  if (summary) {
-    log(`  ${summary}`);
-    // Stamp the current crawler version so subsequent prepare runs skip the check
-    const registry = createDefaultRegistry();
-    const factory = registry.get(col.crawler);
-    if (factory) {
-      updateCollection(col.name, { version: factory().metadata.version ?? "1.0" });
-    }
-  }
+  log(`  Warning: ${reasons} outdated (${totalMismatches}/${sampled} samples). Run: fink generate ${JSON.stringify(col.name)}`);
 }
 
 /**

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -1,4 +1,3 @@
-import { Command } from "commander";
 import { existsSync } from "fs";
 import { join } from "path";
 import {
@@ -42,239 +41,250 @@ async function runConcurrent<T>(
   await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
 }
 
-export const pullCommand = new Command("pull")
-  .description("Pull updates from a remote published site into a cloned collection")
-  .argument("<collection>", "Collection name (must have crawler: remote)")
-  .option("--dry-run", "Show sync plan without making changes")
-  .addHelpText("after", `
-Examples:
-  fink pull team-kb
-  fink pull team-kb --dry-run
-`)
-  .action(async (collection: string, opts: { dryRun?: boolean }) => {
-    ensureInitialized();
-    const home = getFrozenInkHome();
+export interface PullCollectionOptions {
+  dryRun?: boolean;
+  onProgress?: (msg: string) => void;
+}
 
-    const col = getCollection(collection);
-    if (!col) {
-      console.error(`Collection "${collection}" not found`);
-      process.exit(1);
+export interface PullCollectionResult {
+  created: number;
+  updated: number;
+  deleted: number;
+}
+
+/**
+ * Pull updates from a remote published site into a cloned collection.
+ * The collection must exist and have crawler === "remote".
+ */
+export async function pullCollection(collectionName: string, opts: PullCollectionOptions = {}): Promise<PullCollectionResult> {
+  ensureInitialized();
+  const home = getFrozenInkHome();
+  const log = opts.onProgress ?? ((msg: string) => console.log(msg));
+
+  const col = getCollection(collectionName);
+  if (!col) {
+    throw new Error(`Collection "${collectionName}" not found`);
+  }
+
+  if (col.crawler !== "remote") {
+    throw new Error(`Collection "${collectionName}" is not a remote clone (crawler: ${col.crawler})`);
+  }
+
+  const sourceUrl = (col.config as any)?.sourceUrl;
+  if (!sourceUrl) {
+    throw new Error(`Collection "${collectionName}" has no sourceUrl in config`);
+  }
+
+  const resolved = resolveCredentials(col.credentials);
+  const password = (resolved as any)?.password;
+  const client = new RemoteClient(sourceUrl, password);
+
+  const dbPath = getCollectionDbPath(collectionName);
+  if (!existsSync(dbPath)) {
+    throw new Error(`Collection "${collectionName}" database not found. Run 'fink clone' first.`);
+  }
+
+  const colDb = getCollectionDb(dbPath);
+  const collectionDir = join(home, "collections", collectionName);
+  const storage = new LocalStorageBackend(collectionDir);
+
+  // Fetch remote manifest
+  log("Fetching manifest...");
+  const { manifest, entries } = await client.getManifest();
+
+  // Keep crawler.type in sync — repairs clones created before this field existed
+  if (manifest.collection?.crawlerType) {
+    const meta = new MetadataStore(dbPath);
+    meta.setCrawlerType(manifest.collection.crawlerType);
+    meta.close();
+  }
+
+  // Build local entity list
+  const allLocal = colDb.select().from(entities).all();
+  const localEntities: LocalEntity[] = allLocal.map((e: any) => ({
+    externalId: e.externalId,
+    entityType: e.entityType,
+    title: e.title,
+    data: e.data as unknown as EntityData,
+    contentHash: e.contentHash,
+    markdownPath: entityMarkdownPath(e.folder, e.slug),
+  }));
+
+  // Compute sync plan
+  const plan = computeSyncPlan(localEntities, entries);
+
+  if (isSyncPlanEmpty(plan)) {
+    log("Already up to date.");
+    return { created: 0, updated: 0, deleted: 0 };
+  }
+
+  printSyncPlan(plan);
+
+  if (opts.dryRun) {
+    return { created: plan.entities.add.length, updated: plan.entities.update.length, deleted: plan.entities.delete.length };
+  }
+
+  // Fetch full data for added and updated entities
+  const fetchIds = [
+    ...plan.entities.add.map((e) => e.externalId),
+    ...plan.entities.update.map((e) => e.externalId),
+  ];
+
+  let remoteEntities: RemoteEntityData[] = [];
+  if (fetchIds.length > 0) {
+    log(`Fetching ${fetchIds.length} entities...`);
+    remoteEntities = await client.getEntitiesBulk(fetchIds);
+  }
+  const remoteByExtId = new Map<string, RemoteEntityData>();
+  for (const re of remoteEntities) {
+    remoteByExtId.set(re.externalId, re);
+  }
+
+  // Execute file moves first (no network)
+  for (const move of plan.files.move) {
+    assertSafePath(move.from);
+    assertSafePath(move.to);
+    try {
+      const content = await storage.read(`content/${move.from}`);
+      await storage.write(`content/${move.to}`, content);
+      await storage.delete(`content/${move.from}`);
+    } catch {
+      // Fall through — will be re-downloaded
     }
+  }
 
-    if (col.crawler !== "remote") {
-      console.error(`Collection "${collection}" is not a remote clone (crawler: ${col.crawler})`);
-      process.exit(1);
-    }
-
-    const sourceUrl = (col.config as any)?.sourceUrl;
-    if (!sourceUrl) {
-      console.error(`Collection "${collection}" has no sourceUrl in config`);
-      process.exit(1);
-    }
-
-    const resolved = resolveCredentials(col.credentials);
-    const password = (resolved as any)?.password;
-    const client = new RemoteClient(sourceUrl, password);
-
-    const dbPath = getCollectionDbPath(collection);
-    if (!existsSync(dbPath)) {
-      console.error(`Collection "${collection}" database not found. Run 'fink clone' first.`);
-      process.exit(1);
-    }
-
-    const colDb = getCollectionDb(dbPath);
-    const collectionDir = join(home, "collections", collection);
-    const storage = new LocalStorageBackend(collectionDir);
-
-    // Fetch remote manifest
-    console.log("Fetching manifest...");
-    const { manifest, entries } = await client.getManifest();
-
-    // Keep crawler.type in sync — repairs clones created before this field existed
-    if (manifest.collection?.crawlerType) {
-      const meta = new MetadataStore(dbPath);
-      meta.setCrawlerType(manifest.collection.crawlerType);
-      meta.close();
-    }
-
-    // Build local entity list
-    const allLocal = colDb.select().from(entities).all();
-    const localEntities: LocalEntity[] = allLocal.map((e: any) => ({
-      externalId: e.externalId,
-      entityType: e.entityType,
-      title: e.title,
-      data: e.data as unknown as EntityData,
-      contentHash: e.contentHash,
-      markdownPath: entityMarkdownPath(e.folder, e.slug),
-    }));
-
-    // Compute sync plan
-    const plan = computeSyncPlan(localEntities, entries);
-
-    if (isSyncPlanEmpty(plan)) {
-      console.log("Already up to date.");
-      return;
-    }
-
-    printSyncPlan(plan);
-
-    if (opts.dryRun) {
-      return;
-    }
-
-    // Fetch full data for added and updated entities
-    const fetchIds = [
-      ...plan.entities.add.map((e) => e.externalId),
-      ...plan.entities.update.map((e) => e.externalId),
-    ];
-
-    let remoteEntities: RemoteEntityData[] = [];
-    if (fetchIds.length > 0) {
-      console.log(`Fetching ${fetchIds.length} entities...`);
-      remoteEntities = await client.getEntitiesBulk(fetchIds);
-    }
-    const remoteByExtId = new Map<string, RemoteEntityData>();
-    for (const re of remoteEntities) {
-      remoteByExtId.set(re.externalId, re);
-    }
-
-    // Execute file moves first (no network)
-    for (const move of plan.files.move) {
-      assertSafePath(move.from);
-      assertSafePath(move.to);
-      try {
-        const content = await storage.read(`content/${move.from}`);
-        await storage.write(`content/${move.to}`, content);
-        await storage.delete(`content/${move.from}`);
-      } catch {
-        // Fall through — will be re-downloaded
+  // Download new/updated markdown files
+  const mdDownloads = remoteEntities.filter((e) => e.markdownPath);
+  if (mdDownloads.length > 0) {
+    log(`Downloading ${mdDownloads.length} files...`);
+    await runConcurrent(mdDownloads, 10, async (re) => {
+      const mdPath = re.markdownPath!;
+      assertSafePath(mdPath);
+      const content = await client.getMarkdown(mdPath);
+      if (content) {
+        await storage.write(`content/${mdPath}`, content);
       }
-    }
+    });
+  }
 
-    // Download new/updated markdown files
-    const mdDownloads = remoteEntities.filter((e) => e.markdownPath);
-    if (mdDownloads.length > 0) {
-      console.log(`Downloading ${mdDownloads.length} files...`);
-      await runConcurrent(mdDownloads, 10, async (re) => {
-        const mdPath = re.markdownPath!;
-        assertSafePath(mdPath);
-        const content = await client.getMarkdown(mdPath);
-        if (content) {
-          await storage.write(`content/${mdPath}`, content);
-        }
-      });
+  // Download new/changed assets
+  const assetDownloads: Array<{ path: string }> = [];
+  for (const re of remoteEntities) {
+    for (const asset of (re.data as unknown as EntityData).assets ?? []) {
+      assetDownloads.push({ path: asset.storagePath });
     }
-
-    // Download new/changed assets
-    const assetDownloads: Array<{ path: string }> = [];
-    for (const re of remoteEntities) {
-      for (const asset of (re.data as unknown as EntityData).assets ?? []) {
-        assetDownloads.push({ path: asset.storagePath });
+  }
+  if (assetDownloads.length > 0) {
+    log(`Downloading ${assetDownloads.length} assets...`);
+    await runConcurrent(assetDownloads, 10, async ({ path }) => {
+      assertSafePath(path);
+      const content = await client.getFile(path);
+      if (content) {
+        await storage.write(`attachments/${path}`, Buffer.from(content));
       }
-    }
-    if (assetDownloads.length > 0) {
-      console.log(`Downloading ${assetDownloads.length} assets...`);
-      await runConcurrent(assetDownloads, 10, async ({ path }) => {
-        assertSafePath(path);
-        const content = await client.getFile(path);
-        if (content) {
-          await storage.write(`attachments/${path}`, Buffer.from(content));
-        }
-      });
-    }
+    });
+  }
 
-    // Delete files for removed entities
-    for (const fileOp of plan.files.delete) {
-      const prefix = fileOp.type === "asset" ? "attachments" : "content";
-      try {
-        await storage.delete(`${prefix}/${fileOp.path}`);
-      } catch {
-        // File may already be gone
-      }
+  // Delete files for removed entities
+  for (const fileOp of plan.files.delete) {
+    const prefix = fileOp.type === "asset" ? "attachments" : "content";
+    try {
+      await storage.delete(`${prefix}/${fileOp.path}`);
+    } catch {
+      // File may already be gone
     }
+  }
 
-    // Apply DB changes: insert new entities
-    for (const entry of plan.entities.add) {
-      const re = remoteByExtId.get(entry.externalId);
-      if (!re) continue;
-      const { folder, slug } = splitMarkdownPath(re.markdownPath);
-      colDb
-        .insert(entities)
-        .values({
-          externalId: re.externalId,
-          entityType: re.entityType,
-          title: re.title,
-          data: re.data as unknown as EntityData,
-          contentHash: re.hash,
-          folder,
-          slug,
-        })
-        .run();
-    }
-
-    // Apply DB changes: update existing entities
-    for (const entry of plan.entities.update) {
-      const re = remoteByExtId.get(entry.externalId);
-      if (!re) continue;
-      const { folder, slug } = splitMarkdownPath(re.markdownPath);
-      colDb
-        .update(entities)
-        .set({
-          entityType: re.entityType,
-          title: re.title,
-          data: re.data as unknown as EntityData,
-          contentHash: re.hash,
-          folder,
-          slug,
-          updatedAt: new Date().toISOString().replace("T", " ").replace("Z", ""),
-        })
-        .where(eq(entities.externalId, entry.externalId))
-        .run();
-    }
-
-    // Collect numeric IDs for deleted entities before removing them from DB
-    const deletedEntityIds: number[] = [];
-    for (const extId of plan.entities.delete) {
-      const [row] = colDb
-        .select({ id: entities.id })
-        .from(entities)
-        .where(eq(entities.externalId, extId))
-        .all();
-      if (row) deletedEntityIds.push(row.id);
-      colDb.delete(entities).where(eq(entities.externalId, extId)).run();
-    }
-
-    // Rebuild search index for changed entities
-    const indexer = new SearchIndexer(dbPath);
-    for (const re of remoteEntities) {
-      const [dbEntity] = colDb
-        .select()
-        .from(entities)
-        .where(eq(entities.externalId, re.externalId))
-        .all();
-      if (!dbEntity) continue;
-
-      let content = "";
-      if (re.markdownPath) {
-        try {
-          content = await storage.read(`content/${re.markdownPath}`);
-        } catch { /* ok */ }
-      }
-      indexer.updateIndex({
-        id: dbEntity.id,
+  // Apply DB changes: insert new entities
+  for (const entry of plan.entities.add) {
+    const re = remoteByExtId.get(entry.externalId);
+    if (!re) continue;
+    const { folder, slug } = splitMarkdownPath(re.markdownPath);
+    colDb
+      .insert(entities)
+      .values({
         externalId: re.externalId,
         entityType: re.entityType,
         title: re.title,
-        content,
-        tags: ((re.data as Record<string, unknown>)?.tags as string[] | undefined) ?? [],
-      });
-    }
-    for (const entityId of deletedEntityIds) {
-      indexer.removeIndex(entityId);
-    }
-    indexer.close();
+        data: re.data as unknown as EntityData,
+        contentHash: re.hash,
+        folder,
+        slug,
+      })
+      .run();
+  }
 
-    console.log(
-      `\nPulled: +${plan.entities.add.length} added, ~${plan.entities.update.length} updated, -${plan.entities.delete.length} deleted`,
-    );
-  });
+  // Apply DB changes: update existing entities
+  for (const entry of plan.entities.update) {
+    const re = remoteByExtId.get(entry.externalId);
+    if (!re) continue;
+    const { folder, slug } = splitMarkdownPath(re.markdownPath);
+    colDb
+      .update(entities)
+      .set({
+        entityType: re.entityType,
+        title: re.title,
+        data: re.data as unknown as EntityData,
+        contentHash: re.hash,
+        folder,
+        slug,
+        updatedAt: new Date().toISOString().replace("T", " ").replace("Z", ""),
+      })
+      .where(eq(entities.externalId, entry.externalId))
+      .run();
+  }
+
+  // Collect numeric IDs for deleted entities before removing them from DB
+  const deletedEntityIds: number[] = [];
+  for (const extId of plan.entities.delete) {
+    const [row] = colDb
+      .select({ id: entities.id })
+      .from(entities)
+      .where(eq(entities.externalId, extId))
+      .all();
+    if (row) deletedEntityIds.push(row.id);
+    colDb.delete(entities).where(eq(entities.externalId, extId)).run();
+  }
+
+  // Rebuild search index for changed entities
+  const indexer = new SearchIndexer(dbPath);
+  for (const re of remoteEntities) {
+    const [dbEntity] = colDb
+      .select()
+      .from(entities)
+      .where(eq(entities.externalId, re.externalId))
+      .all();
+    if (!dbEntity) continue;
+
+    let content = "";
+    if (re.markdownPath) {
+      try {
+        content = await storage.read(`content/${re.markdownPath}`);
+      } catch { /* ok */ }
+    }
+    indexer.updateIndex({
+      id: dbEntity.id,
+      externalId: re.externalId,
+      entityType: re.entityType,
+      title: re.title,
+      content,
+      tags: ((re.data as Record<string, unknown>)?.tags as string[] | undefined) ?? [],
+    });
+  }
+  for (const entityId of deletedEntityIds) {
+    indexer.removeIndex(entityId);
+  }
+  indexer.close();
+
+  const result: PullCollectionResult = {
+    created: plan.entities.add.length,
+    updated: plan.entities.update.length,
+    deleted: plan.entities.delete.length,
+  };
+
+  log(
+    `Synced: +${result.created} added, ~${result.updated} updated, -${result.deleted} deleted`,
+  );
+
+  return result;
+}

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -153,6 +153,7 @@ Examples:
           });
           console.log(`  page ids: ${ids.join(",")}`);
         },
+        onProgress: (msg) => console.log(`  ${msg}`),
       });
 
       try {

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -18,11 +18,13 @@ import { sql } from "drizzle-orm";
 import { createDefaultRegistry, gitHubTheme, obsidianTheme, gitTheme, mantisHubTheme } from "@frozenink/crawlers";
 import { prepareCollection } from "./prepare";
 import { createGenerateThemeEngine } from "./generate";
+import { pullCollection } from "./pull";
 
 export const syncCommand = new Command("sync")
   .description("Sync collections")
   .argument("<collection>", 'Collection name or "*" for all collections')
   .option("--full", "Full re-sync (ignore cursors)")
+  .option("--dry-run", "Show sync plan without making changes (remote/cloned collections only)")
   .option("--max <count>", "Maximum entities per type to sync (overrides collection config)", parseInt)
   .option("--max-issues <count>", "Maximum issues to sync (overrides collection config)", parseInt)
   .option("--max-prs <count>", "Maximum pull requests to sync (overrides collection config)", parseInt)
@@ -34,13 +36,19 @@ Examples:
   # Sync all collections
   fink sync "*"
 
+  # Sync a cloned (remote) collection
+  fink sync team-kb
+
   # Full re-sync from scratch (ignores cursors)
   fink sync my-repo --full
+
+  # Preview changes for a cloned collection
+  fink sync team-kb --dry-run
 
   # Sync with a limit on entities
   fink sync my-repo --max 100
 `)
-  .action(async (collection: string, opts: { full?: boolean; max?: number; maxIssues?: number; maxPrs?: number }) => {
+  .action(async (collection: string, opts: { full?: boolean; dryRun?: boolean; max?: number; maxIssues?: number; maxPrs?: number }) => {
     ensureInitialized();
 
     const home = getFrozenInkHome();
@@ -74,7 +82,11 @@ Examples:
 
     for (const col of collectionRows) {
       if (col.crawler === "remote") {
-        console.error(`Cannot sync "${col.name}": crawler is "remote". Use 'fink pull' instead.`);
+        try {
+          await pullCollection(col.name, { dryRun: opts.dryRun });
+        } catch (err) {
+          console.error(`  Sync failed for "${col.name}": ${err}`);
+        }
         continue;
       }
 

--- a/packages/cli/src/commands/wrangler-api.ts
+++ b/packages/cli/src/commands/wrangler-api.ts
@@ -119,6 +119,16 @@ export async function getCredentials(): Promise<CfCredentials> {
   return cachedCredentials;
 }
 
+/**
+ * Force re-read of credentials on the next getCredentials() call.
+ * Useful when an API call returns 401 — typically because wrangler's OAuth
+ * token on disk was refreshed while we held a stale cached copy in memory
+ * (common in long-running processes like the desktop app).
+ */
+export function invalidateCredentials(): void {
+  cachedCredentials = null;
+}
+
 export async function checkWranglerAuth(): Promise<void> {
   try {
     await getCredentials();
@@ -191,16 +201,17 @@ export async function executeD1File(dbName: string, sqlFilePath: string): Promis
  * a wrangler subprocess per batch (saves ~500ms-1s per call).
  */
 export async function executeD1Query(databaseId: string, sql: string): Promise<void> {
-  const { apiToken, accountId } = await getCredentials();
-  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/query`;
-  const res = await fetchWithRetry(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiToken}`,
-      "Content-Type": "application/json",
+  const res = await fetchCloudflareApi(({ apiToken, accountId }) => ({
+    url: `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/query`,
+    init: {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql }),
     },
-    body: JSON.stringify({ sql }),
-  });
+  }));
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`D1 query failed: ${res.status} ${text.slice(0, 500)}`);
@@ -248,6 +259,25 @@ async function fetchWithRetry(
   return fetch(url, init);
 }
 
+/**
+ * Make an authenticated Cloudflare API request. On 401, invalidates the
+ * cached OAuth token and retries once with fresh credentials — long-running
+ * processes (desktop app) can hold a stale cached token after wrangler
+ * refreshes it on disk.
+ */
+async function fetchCloudflareApi(
+  build: (creds: CfCredentials) => { url: string; init: RequestInit },
+): Promise<Response> {
+  const { url, init } = build(await getCredentials());
+  let res = await fetchWithRetry(url, init);
+  if (res.status === 401) {
+    invalidateCredentials();
+    const fresh = build(await getCredentials());
+    res = await fetchWithRetry(fresh.url, fresh.init);
+  }
+  return res;
+}
+
 // --- R2 operations (bucket via wrangler CLI, objects via HTTP for speed) ---
 
 export async function createR2Bucket(name: string): Promise<void> {
@@ -267,20 +297,24 @@ export async function putR2Object(
   filePath: string,
   contentType?: string,
 ): Promise<void> {
-  const { apiToken, accountId } = await getCredentials();
   const body = readFileSync(filePath);
-  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects/${encodeURIComponent(key)}`;
-  const res = await fetchWithRetry(url, {
-    method: "PUT",
-    headers: {
-      Authorization: `Bearer ${apiToken}`,
-      ...(contentType ? { "Content-Type": contentType } : {}),
+  const res = await fetchCloudflareApi(({ apiToken, accountId }) => ({
+    url: `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects/${encodeURIComponent(key)}`,
+    init: {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        ...(contentType ? { "Content-Type": contentType } : {}),
+      },
+      body,
     },
-    body,
-  });
+  }));
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`R2 upload failed for ${key}: ${res.status} ${text.slice(0, 200)}`);
+    const hint = res.status === 401
+      ? " — the Cloudflare OAuth token looks expired. Run `wrangler login` again, or restart the desktop app to refresh the cached credentials."
+      : "";
+    throw new Error(`R2 upload failed for ${key}: ${res.status} ${text.slice(0, 200)}${hint}`);
   }
 }
 
@@ -290,13 +324,14 @@ export async function putR2String(
   content: string,
   contentType: string = "text/plain",
 ): Promise<void> {
-  const { apiToken, accountId } = await getCredentials();
-  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects/${encodeURIComponent(key)}`;
-  const res = await fetchWithRetry(url, {
-    method: "PUT",
-    headers: { Authorization: `Bearer ${apiToken}`, "Content-Type": contentType },
-    body: content,
-  });
+  const res = await fetchCloudflareApi(({ apiToken, accountId }) => ({
+    url: `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects/${encodeURIComponent(key)}`,
+    init: {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${apiToken}`, "Content-Type": contentType },
+      body: content,
+    },
+  }));
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`R2 upload failed for ${key}: ${res.status} ${text.slice(0, 200)}`);
@@ -304,24 +339,26 @@ export async function putR2String(
 }
 
 export async function getR2String(bucket: string, key: string): Promise<string | null> {
-  const { apiToken, accountId } = await getCredentials();
-  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects/${encodeURIComponent(key)}`;
-  const res = await fetchWithRetry(url, {
-    method: "GET",
-    headers: { Authorization: `Bearer ${apiToken}` },
-  });
+  const res = await fetchCloudflareApi(({ apiToken, accountId }) => ({
+    url: `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects/${encodeURIComponent(key)}`,
+    init: {
+      method: "GET",
+      headers: { Authorization: `Bearer ${apiToken}` },
+    },
+  }));
   if (res.status === 404) return null;
   if (!res.ok) return null;
   return res.text();
 }
 
 export async function deleteR2Object(bucket: string, key: string): Promise<void> {
-  const { apiToken, accountId } = await getCredentials();
-  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects/${encodeURIComponent(key)}`;
-  const res = await fetchWithRetry(url, {
-    method: "DELETE",
-    headers: { Authorization: `Bearer ${apiToken}` },
-  });
+  const res = await fetchCloudflareApi(({ apiToken, accountId }) => ({
+    url: `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects/${encodeURIComponent(key)}`,
+    init: {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${apiToken}` },
+    },
+  }));
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`R2 delete failed for ${key}: ${res.status} ${text.slice(0, 200)}`);
@@ -346,17 +383,21 @@ export async function deleteR2Bucket(name: string): Promise<void> {
 }
 
 export async function listR2Objects(bucket: string, prefix?: string): Promise<Array<{ key: string; size: number }>> {
-  const { apiToken, accountId } = await getCredentials();
   const objects: Array<{ key: string; size: number }> = [];
   let cursor: string | undefined;
   for (;;) {
-    const params = new URLSearchParams({ per_page: "1000" });
-    if (prefix) params.set("prefix", prefix);
-    if (cursor) params.set("cursor", cursor);
-    const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects?${params}`;
-    const res = await fetchWithRetry(url, {
-      method: "GET",
-      headers: { Authorization: `Bearer ${apiToken}` },
+    const pageCursor = cursor;
+    const res = await fetchCloudflareApi(({ apiToken, accountId }) => {
+      const params = new URLSearchParams({ per_page: "1000" });
+      if (prefix) params.set("prefix", prefix);
+      if (pageCursor) params.set("cursor", pageCursor);
+      return {
+        url: `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects?${params}`,
+        init: {
+          method: "GET",
+          headers: { Authorization: `Bearer ${apiToken}` },
+        },
+      };
     });
     if (!res.ok) break;
     const data = await res.json() as { result: Array<{ key: string; size: number }>; result_info?: { cursor?: string } };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,7 +22,7 @@ import { mcpCommand } from "./commands/mcp";
 import { tableplusCommand } from "./commands/tableplus";
 import { vscodeCommand } from "./commands/vscode";
 import { cloneCommand } from "./commands/clone";
-import { pullCommand } from "./commands/pull";
+
 import { compactCommand } from "./commands/compact";
 import { startTui } from "./tui/index";
 
@@ -52,7 +52,7 @@ program.addCommand(mcpCommand);
 program.addCommand(tableplusCommand);
 program.addCommand(vscodeCommand);
 program.addCommand(cloneCommand);
-program.addCommand(pullCommand);
+
 program.addCommand(compactCommand);
 
 // If no arguments passed (just "fink"), launch TUI by default

--- a/packages/cli/src/tui/components/CollectionList.tsx
+++ b/packages/cli/src/tui/components/CollectionList.tsx
@@ -36,6 +36,7 @@ import { SearchView } from "./SearchView.js";
 import { McpConfigView } from "./McpConfigView.js";
 import { publishCollections, type PublishOptions } from "../../commands/publish.js";
 import { unpublishCollection } from "../../commands/unpublish.js";
+import { pullCollection } from "../../commands/pull.js";
 import type { Screen } from "./App.js";
 
 type Mode =
@@ -641,6 +642,16 @@ export function CollectionList({
     };
 
     try {
+      if (col.crawler === "remote") {
+        await pullCollection(name, {
+          onProgress: (msg) => {
+            setSyncProgress((p) => [...p, msg]);
+          },
+        });
+        const elapsed = formatElapsed(Date.now() - syncStart);
+        setSyncProgress((p) => [...p, `Completed in ${elapsed}`]);
+        setMessage(`Sync complete for "${name}"`);
+      } else {
       const registry = createDefaultRegistry();
       const themeEngine = new ThemeEngine();
       themeEngine.register(gitHubTheme);
@@ -681,6 +692,7 @@ export function CollectionList({
       setSyncProgress((p) => [...p, `+${stats.created} ~${stats.updated} -${stats.deleted} (${total} total) in ${elapsed}`]);
       await crawler.dispose();
       setMessage(`Sync complete for "${name}"`);
+      }
     } catch (err) {
       setSyncFetchedCounts({});
       setSyncProgress((p) => [...p, `Error: ${err instanceof Error ? err.message : String(err)}`]);

--- a/packages/cli/src/tui/components/CollectionList.tsx
+++ b/packages/cli/src/tui/components/CollectionList.tsx
@@ -683,6 +683,9 @@ export function CollectionList({
         onVersionUpdate: (version: string) => {
           updateCollection(name, { version });
         },
+        onProgress: (msg: string) => {
+          setSyncProgress((p) => [...p, msg]);
+        },
       });
       const stats = await engine.run({ syncType: syncType ?? "incremental" });
       setSyncFetchedCounts({});

--- a/packages/cli/src/tui/components/SyncView.tsx
+++ b/packages/cli/src/tui/components/SyncView.tsx
@@ -200,6 +200,9 @@ export function SyncView(): React.ReactElement {
             setFetchedCount((c) => c + externalIds.length);
           }
         },
+        onProgress: (msg: string) => {
+          setProgress((p) => [...p, `  ${msg}`]);
+        },
       });
 
       try {

--- a/packages/core/src/crawler/interface.ts
+++ b/packages/core/src/crawler/interface.ts
@@ -63,4 +63,11 @@ export interface Crawler {
    * match the filter, avoiding unnecessary network requests and errors.
    */
   setAssetFilter?(filter: AssetFilter): void;
+  /**
+   * Optional: set a progress callback that the crawler will invoke during
+   * sync() with short human-readable messages about what it's doing
+   * (e.g. "Scanning issues (page 3)", "Fetching 42 updated issues"). Used
+   * by the UI/TUI to show what's happening under the hood.
+   */
+  setProgressCallback?(callback: (message: string) => void): void;
 }

--- a/packages/core/src/crawler/sync-engine.ts
+++ b/packages/core/src/crawler/sync-engine.ts
@@ -109,6 +109,8 @@ export interface SyncEngineOptions {
   }) => void;
   /** Called after a successful sync with the crawler version, so callers can update .config. */
   onVersionUpdate?: (version: string) => void;
+  /** Called with human-readable status messages describing what the sync is doing. */
+  onProgress?: (message: string) => void;
 }
 
 export class SyncEngine {
@@ -125,6 +127,7 @@ export class SyncEngine {
   private onEntityProcessed?: SyncEngineOptions["onEntityProcessed"];
   private onBatchFetched?: SyncEngineOptions["onBatchFetched"];
   private onVersionUpdate?: SyncEngineOptions["onVersionUpdate"];
+  private onProgress?: SyncEngineOptions["onProgress"];
 
   /**
    * Check version compatibility between a collection and crawler.
@@ -155,6 +158,7 @@ export class SyncEngine {
     this.onEntityProcessed = options.onEntityProcessed;
     this.onBatchFetched = options.onBatchFetched;
     this.onVersionUpdate = options.onVersionUpdate;
+    this.onProgress = options.onProgress;
   }
 
   async run(options?: { syncType?: "full" | "incremental" }): Promise<{ created: number; updated: number; deleted: number }> {
@@ -167,6 +171,10 @@ export class SyncEngine {
       maxSizeBytes: this.maxAssetSizeBytes,
       allowedExtensions: this.allowedExtensions,
     });
+    // Forward progress messages from the crawler to the UI.
+    if (this.onProgress) {
+      this.crawler.setProgressCallback?.(this.onProgress);
+    }
 
     const metadata = new MetadataStore(this.dbPath);
 
@@ -252,10 +260,12 @@ export class SyncEngine {
       metadata.setCollectionVersion(currentVersion);
       updateCollection(this.collectionName, { version: currentVersion });
 
-      // Reconcile filesystem with DB
-      await this.reconcile(crawlerType);
+      // Reconcile filesystem with DB — orphan cleanup only. Entity markdown is
+      // already written during the sync loop, so there's no need to re-render.
+      await this.reconcile();
 
       // Write folder config yml files (visible/sort settings)
+      this.onProgress?.("Writing folder config files");
       await this.writeFolderConfigFiles(crawlerType);
 
       // Notify caller to update collection version in .config
@@ -351,6 +361,24 @@ export class SyncEngine {
         }
         // Handle assets (update data.assets)
         await this.syncAssets(existing.id, entityData);
+
+        // Restore the markdown file if it was deleted from disk. Cheap: one
+        // existence check per entity; only re-renders when actually missing.
+        if (existing.folder != null && existing.slug != null) {
+          const filePath = existing.folder ? `${existing.folder}/${existing.slug}.md` : `${existing.slug}.md`;
+          const storagePath = this.toStoragePath(filePath);
+          let fileExists = true;
+          try {
+            await this.storage.read(storagePath);
+          } catch {
+            fileExists = false;
+          }
+          if (!fileExists) {
+            const markdown = this.renderMarkdown(entityData, crawlerType);
+            await this.storage.write(storagePath, markdown);
+          }
+        }
+
         // Defer link syncing
         if (deferredLinks) {
           // We need to re-read the markdown to re-sync links, but source hasn't changed
@@ -776,47 +804,15 @@ export class SyncEngine {
     }
   }
 
-  private async reconcile(crawlerType: string): Promise<void> {
+  private async reconcile(): Promise<void> {
     const allEntities = this.db.select().from(entities).all();
 
-    // 1. Re-render every entity's markdown from stored source data and write to disk.
-    for (const entity of allEntities) {
-      if (entity.folder == null || entity.slug == null) continue;
-      const markdownPath = entity.folder ? `${entity.folder}/${entity.slug}.md` : `${entity.slug}.md`;
-      const storagePath = this.toStoragePath(markdownPath);
+    // Note: entity markdown is written by upsertEntity during the sync loop.
+    // Reconcile only handles orphan cleanup — do NOT re-render every entity
+    // here; that would be equivalent to running `generate` and is wasteful
+    // for incremental syncs (which may only touch a handful of entities).
 
-      const entityData = (entity.data as EntityData) ?? { source: {} };
-      const entityTagNames = this.getEntityTagNames(entity.id);
-      const rendered = this.themeEngine.render({
-        entity: {
-          externalId: entity.externalId,
-          entityType: entity.entityType,
-          title: entity.title,
-          data: entityData.source,
-          url: entityData.url ?? undefined,
-          tags: entityTagNames,
-        },
-        collectionName: this.collectionName,
-        crawlerType,
-        lookupEntityPath: this.makeLookupEntityPath(),
-        resolveWikilink: this.makeResolveWikilink(),
-      });
-
-      // Read-before-write: preserve mtime when content is unchanged
-      let needsWrite = true;
-      try {
-        const existing = await this.storage.read(storagePath);
-        if (existing === rendered) needsWrite = false;
-      } catch {
-        // File doesn't exist yet
-      }
-      if (needsWrite) {
-        await this.storage.write(storagePath, rendered);
-        this.recomputeHash(entity.id);
-      }
-    }
-
-    // 2. Delete orphaned markdown files (on disk but no matching entity in DB)
+    // Delete orphaned markdown files (on disk but no matching entity in DB)
     // Skip paths containing hidden directories (e.g. .git, .obsidian) — those
     // are tool index files that belong to other applications and will be
     // recreated by them; we must not touch them.
@@ -833,6 +829,8 @@ export class SyncEngine {
       const entityAssets: Array<{ storagePath: string }> = entityData.assets ?? [];
       for (const att of entityAssets) dbAssetStoragePaths.add(att.storagePath);
     }
+    this.onProgress?.("Scanning filesystem for orphaned markdown files");
+    let orphanedMd = 0;
     try {
       const diskMarkdownFiles = await this.storage.list(this.markdownBasePath);
       for (const diskPath of diskMarkdownFiles) {
@@ -842,6 +840,7 @@ export class SyncEngine {
         if (!dbStoragePaths.has(diskPath)) {
           try {
             await this.storage.delete(diskPath);
+            orphanedMd++;
           } catch {
             // ignore
           }
@@ -850,8 +849,11 @@ export class SyncEngine {
     } catch {
       // markdown directory may not exist yet
     }
+    if (orphanedMd > 0) {
+      this.onProgress?.(`Removed ${orphanedMd} orphaned markdown file(s)`);
+    }
 
-    // 3. Delete orphaned asset files (on disk but no matching record in entity JSON)
+    // Delete orphaned asset files (on disk but no matching record in entity JSON)
     const dbAssetPaths = new Set<string>();
     const assetDirs = new Set<string>();
     for (const entity of allEntities) {
@@ -868,6 +870,8 @@ export class SyncEngine {
     for (const dir of ["content/assets", "assets", "attachments"]) {
       assetDirs.add(dir);
     }
+    this.onProgress?.("Scanning filesystem for orphaned asset files");
+    let orphanedAssets = 0;
     for (const assetsDir of assetDirs) {
       try {
         const diskAssetFiles = await this.storage.list(assetsDir);
@@ -876,6 +880,7 @@ export class SyncEngine {
           if (!dbAssetPaths.has(diskPath)) {
             try {
               await this.storage.delete(diskPath);
+              orphanedAssets++;
             } catch {
               // ignore
             }
@@ -884,6 +889,9 @@ export class SyncEngine {
       } catch {
         // directory may not exist yet
       }
+    }
+    if (orphanedAssets > 0) {
+      this.onProgress?.(`Removed ${orphanedAssets} orphaned asset file(s)`);
     }
   }
 

--- a/packages/crawlers/src/mantishub/__tests__/crawler.test.ts
+++ b/packages/crawlers/src/mantishub/__tests__/crawler.test.ts
@@ -50,12 +50,15 @@ function routingFetch(
       return jsonResponse({ issues: [issue] });
     }
     const res = await listFn(url);
-    // Clone and peek at the body to track the last page
-    const cloned = res.clone();
-    try {
-      const data = (await cloned.json()) as { issues?: MantisHubIssue[] };
-      lastPage = data.issues ?? [];
-    } catch { /* ignore */ }
+    // Clone and peek at the body to track the last page.
+    // Skip lightweight scan responses (select=id,updated_at) — they lack full issue data.
+    if (!url.includes("select=")) {
+      const cloned = res.clone();
+      try {
+        const data = (await cloned.json()) as { issues?: MantisHubIssue[] };
+        lastPage = data.issues ?? [];
+      } catch { /* ignore */ }
+    }
     return res;
   };
 }
@@ -73,13 +76,25 @@ describe("MantisHubCrawler", () => {
 
   it("stores updatedSince cursor and filters incremental updates", async () => {
     let call = 0;
-    crawler.setFetch(routingFetch(async () => {
+    crawler.setFetch(routingFetch(async (url: string) => {
       call += 1;
+      // Call 1: full sync — page 1 issues list
       if (call === 1) {
         return jsonResponse({
           issues: [sampleIssue({ id: 1, updated_at: "2024-01-02T00:00:00Z" })],
         });
       }
+      // Call 3+: incremental scan (select=id,updated_at) and individual fetches
+      if (url.includes("select=")) {
+        return jsonResponse({
+          issues: [
+            { id: 2, updated_at: "2024-01-03T00:00:00Z" },
+            { id: 1, updated_at: "2024-01-02T00:00:00Z" },
+            { id: 3, updated_at: "2024-01-01T00:00:00Z" },
+          ],
+        });
+      }
+      // Individual issue fetches and full list fallback
       return jsonResponse({
         issues: [
           sampleIssue({ id: 2, updated_at: "2024-01-03T00:00:00Z" }),
@@ -101,27 +116,43 @@ describe("MantisHubCrawler", () => {
     expect(usersPhase.hasMore).toBe(false);
     expect(usersPhase.nextCursor).toEqual({ updatedSince: "2024-01-02T00:00:00Z" });
 
-    // Incremental issues phase: filters by updatedSince, returns issues 2 and 1.
-    const incr = await crawler.sync(usersPhase.nextCursor);
-    expect(incr.entities.filter((e) => e.entityType === "issue").map((e) => e.externalId))
+    // Incremental scan phase: lightweight scan identifies issues 2 and 1 as updated.
+    const scan = await crawler.sync(usersPhase.nextCursor);
+    expect(scan.entities).toHaveLength(0); // scan phase emits no entities
+    expect(scan.hasMore).toBe(true);
+    expect((scan.nextCursor as any)._incrementalIds).toEqual([2, 1]);
+
+    // Incremental fetch phase: fetches full data for identified issues.
+    const fetch = await crawler.sync(scan.nextCursor);
+    expect(fetch.entities.filter((e) => e.entityType === "issue").map((e) => e.externalId))
       .toEqual(["issue:2", "issue:1"]);
-    expect((incr.nextCursor as any).phase).toBe("users");
-    expect((incr.nextCursor as any).updatedSince).toBe("2024-01-03T00:00:00Z");
+    expect((fetch.nextCursor as any).phase).toBe("users");
+    expect((fetch.nextCursor as any).updatedSince).toBe("2024-01-03T00:00:00Z");
 
     // Incremental users+projects phase.
-    const incrUsers = await crawler.sync(incr.nextCursor);
+    const incrUsers = await crawler.sync(fetch.nextCursor);
     expect(incrUsers.hasMore).toBe(false);
     expect(incrUsers.nextCursor).toEqual({ updatedSince: "2024-01-03T00:00:00Z" });
   });
 
   it("includes entities with updated_at equal to updatedSince", async () => {
-    crawler.setFetch(routingFetch(async () =>
-      jsonResponse({
+    crawler.setFetch(routingFetch(async (url: string) => {
+      if (url.includes("select=")) {
+        return jsonResponse({
+          issues: [{ id: 9, updated_at: "2024-02-01T12:00:00Z" }],
+        });
+      }
+      return jsonResponse({
         issues: [sampleIssue({ id: 9, updated_at: "2024-02-01T12:00:00Z" })],
-      }),
-    ));
+      });
+    }));
 
-    const result = await crawler.sync({ updatedSince: "2024-02-01T12:00:00Z" });
+    // Scan phase
+    const scan = await crawler.sync({ updatedSince: "2024-02-01T12:00:00Z" });
+    expect((scan.nextCursor as any)._incrementalIds).toEqual([9]);
+
+    // Fetch phase
+    const result = await crawler.sync(scan.nextCursor);
     expect(result.entities).toHaveLength(1);
     expect(result.entities[0].externalId).toBe("issue:9");
   });
@@ -137,30 +168,64 @@ describe("MantisHubCrawler", () => {
     expect(requestedUrl).toContain("page=1");
   });
 
-  it("stops paginating when the API repeats the same page", async () => {
-    const repeatedPage = Array.from({ length: 25 }, (_, i) =>
-      sampleIssue({
-        id: i + 1,
-        updated_at: "2024-02-01T00:00:00Z",
-      }),
-    );
+  it("skips incremental scan when no issues match updatedSince", async () => {
+    crawler.setFetch(routingFetch(async (url: string) => {
+      if (url.includes("select=")) {
+        // All issues are older than updatedSince
+        return jsonResponse({
+          issues: [
+            { id: 1, updated_at: "2024-01-01T00:00:00Z" },
+            { id: 2, updated_at: "2024-01-01T00:00:00Z" },
+          ],
+        });
+      }
+      return jsonResponse({ issues: [] });
+    }));
 
-    crawler.setFetch(routingFetch(async () => jsonResponse({ issues: repeatedPage })));
+    // Scan finds no matching issues — transitions directly to users phase
+    const result = await crawler.sync({ updatedSince: "2024-06-01T00:00:00Z" });
+    expect(result.entities.filter((e) => e.entityType === "issue")).toHaveLength(0);
+    expect((result.nextCursor as any).phase).toBe("users");
+  });
 
-    const first = await crawler.sync({ updatedSince: "2024-01-01T00:00:00Z" });
-    expect(first.hasMore).toBe(true);
-    expect(first.nextCursor).toBeTruthy();
+  it("stops scanning once a full page has zero matches (last_updated DESC order)", async () => {
+    const pageRequests: number[] = [];
+    // Build 3 pages: page 1 & 2 have matches, page 3 has zero matches (all older)
+    // The scan should stop after page 3 without fetching page 4.
+    const matchingPage = Array.from({ length: 100 }, (_, i) => ({
+      id: 1000 - i,
+      updated_at: "2024-06-01T00:00:00Z",
+    }));
+    const noMatchPage = Array.from({ length: 100 }, (_, i) => ({
+      id: 500 - i,
+      updated_at: "2023-01-01T00:00:00Z",
+    }));
 
-    // Second call detects repeated page signature and transitions to users phase.
-    const second = await crawler.sync(first.nextCursor);
-    expect(second.hasMore).toBe(true);
-    expect((second.nextCursor as any).phase).toBe("users");
-    expect(second.entities).toHaveLength(0);
+    crawler.setFetch(routingFetch(async (url: string) => {
+      const pageMatch = url.match(/[?&]page=(\d+)/);
+      const page = pageMatch ? parseInt(pageMatch[1], 10) : 0;
+      pageRequests.push(page);
+      if (page <= 2) return jsonResponse({ issues: matchingPage });
+      if (page === 3) return jsonResponse({ issues: noMatchPage });
+      return jsonResponse({ issues: [] }); // would never reach
+    }));
 
-    // Users+projects phase: emits 1 project entity (no users in sample issues).
-    const third = await crawler.sync(second.nextCursor);
-    expect(third.hasMore).toBe(false);
-    expect(third.nextCursor).toEqual({ updatedSince: "2024-02-01T00:00:00Z" });
+    await crawler.sync({ updatedSince: "2024-01-01T00:00:00Z" });
+    expect(pageRequests.filter((p) => p > 0)).toEqual([1, 2, 3]);
+  });
+
+  it("uses select=id,updated_at with page_size=100 for incremental scan", async () => {
+    const urls: string[] = [];
+    crawler.setFetch(routingFetch(async (url: string) => {
+      urls.push(url);
+      return jsonResponse({ issues: [] });
+    }));
+
+    await crawler.sync({ updatedSince: "2024-01-01T00:00:00Z" });
+    const scanUrl = urls.find((u) => u.includes("select="));
+    expect(scanUrl).toBeTruthy();
+    expect(scanUrl).toContain("select=id,updated_at");
+    expect(scanUrl).toContain("page_size=100");
   });
 
   it("advances to page 2 with in-run cursor state", async () => {

--- a/packages/crawlers/src/mantishub/crawler.ts
+++ b/packages/crawlers/src/mantishub/crawler.ts
@@ -41,10 +41,14 @@ interface MantisHubSyncCursor extends SyncCursor {
   _pagesProjectIds?: number[];
   /** Current browse page within the current project's pages. */
   _pagesBrowsePage?: number;
+  /** Issue IDs to fetch during incremental sync (populated by lightweight scan). */
+  _incrementalIds?: number[];
 }
 
 const PAGE_SIZE = 25;
+const SCAN_PAGE_SIZE = 100;
 const PAGE_DELAY_MS = 100;
+const SCAN_PAGE_DELAY_MS = 20;
 
 function parseTimestamp(value: string | undefined): number | null {
   if (!value) return null;
@@ -123,9 +127,18 @@ export class MantisHubCrawler implements Crawler {
   private syncEntities?: MantisHubEntityType[];
   private fetchFn: typeof fetch = globalThis.fetch;
   private assetFilter: AssetFilter | null = null;
+  private progressCallback: ((msg: string) => void) | null = null;
 
   setAssetFilter(filter: AssetFilter): void {
     this.assetFilter = filter;
+  }
+
+  setProgressCallback(callback: (msg: string) => void): void {
+    this.progressCallback = callback;
+  }
+
+  private reportProgress(msg: string): void {
+    this.progressCallback?.(msg);
   }
 
   /** Returns true if the attachment should be downloaded based on extension and size. */
@@ -165,6 +178,16 @@ export class MantisHubCrawler implements Crawler {
     this.maxEntities = cfg.maxEntities;
     this.mantisHubMode = isMantisHub(this.baseUrl);
     this.syncEntities = cfg.entities;
+
+    // Log credential diagnostics (safe — no secret values) so misloaded tokens
+    // can be identified by fingerprint in the error message.
+    const credKeys = Object.keys(credentials);
+    const tokenFingerprint = this.token
+      ? `${this.token.slice(0, 4)}…(${this.token.length} chars)`
+      : "<none>";
+    console.log(
+      `[mantishub] initialized baseUrl=${this.baseUrl} credentialKeys=[${credKeys.join(",")}] token=${tokenFingerprint}`,
+    );
 
     // Use stored project.id if available (persisted at creation time);
     // otherwise resolve project.name to project.id via API.
@@ -227,6 +250,19 @@ export class MantisHubCrawler implements Crawler {
     }
 
     // ── Issues phase ─────────────────────────────────────────────
+
+    // Incremental sync: use lightweight scan + targeted fetch approach.
+    // 1. Scan all issues with select=id,updated_at (100/page, tiny payloads)
+    // 2. Collect IDs where updated_at >= updatedSince
+    // 3. Fetch only those issues individually for full data
+    if (c.updatedSince && !c._incrementalIds) {
+      return this.scanForIncrementalIds(c);
+    }
+    if (c._incrementalIds) {
+      return this.fetchIncrementalBatch(c);
+    }
+
+    // Full sync: paginate through all issues.
     const isLegacyPageCursor =
       c.page !== undefined &&
       c.updatedSince === undefined &&
@@ -234,13 +270,13 @@ export class MantisHubCrawler implements Crawler {
       c.lastPageSignature === undefined;
     const page = isLegacyPageCursor ? 1 : (c.page ?? 1);
     const fetched = isLegacyPageCursor ? 0 : (c.fetched ?? 0);
-    const updatedSinceTs = parseTimestamp(c.updatedSince);
 
     // Throttle requests: sleep between pages to avoid overloading the server
     if (page > 1) {
       await new Promise((resolve) => setTimeout(resolve, PAGE_DELAY_MS));
     }
 
+    this.reportProgress(`Full sync: fetching issues page ${page} (${fetched} synced so far)`);
     let url = `${this.baseUrl}/api/rest/issues?page_size=${PAGE_SIZE}&page=${page}`;
     if (this.projectId) {
       url += `&project_id=${this.projectId}`;
@@ -266,13 +302,6 @@ export class MantisHubCrawler implements Crawler {
     }
 
     let issuesToProcess = issues;
-    if (updatedSinceTs !== null) {
-      issuesToProcess = issues.filter((issue) => {
-        const issueUpdatedAtTs = parseTimestamp(issue.updated_at);
-        return issueUpdatedAtTs !== null && issueUpdatedAtTs >= updatedSinceTs;
-      });
-    }
-
     let remaining = issuesToProcess.length;
     if (this.maxEntities) {
       remaining = Math.max(0, this.maxEntities - fetched);
@@ -332,7 +361,6 @@ export class MantisHubCrawler implements Crawler {
         nextCursor: {
           page: page + 1,
           fetched: newFetched,
-          updatedSince: c.updatedSince,
           newestSeenUpdatedAt,
           lastPageSignature: pageSignature,
           repeatedPageCount,
@@ -351,13 +379,147 @@ export class MantisHubCrawler implements Crawler {
     };
   }
 
+  /**
+   * Lightweight scan: fetch all issues using select=id,updated_at with large
+   * page size to quickly identify which issues need syncing. Stores matching
+   * IDs in the cursor for the fetch phase. Servers that don't support select=
+   * return the full issue payload — still correct, just less efficient.
+   */
+  private async scanForIncrementalIds(c: MantisHubSyncCursor): Promise<SyncResult> {
+    const updatedSinceTs = parseTimestamp(c.updatedSince)!;
+    const ids: number[] = [];
+    let newestSeenUpdatedAt = c.newestSeenUpdatedAt;
+    let page = 1;
+
+    this.reportProgress(`Scanning issues updated since ${c.updatedSince}`);
+    while (true) {
+      if (page > 1) {
+        await new Promise((resolve) => setTimeout(resolve, SCAN_PAGE_DELAY_MS));
+      }
+
+      this.reportProgress(`Scanning issues: page ${page} (${ids.length} updated so far)`);
+      let url = `${this.baseUrl}/api/rest/issues?select=id,updated_at&page_size=${SCAN_PAGE_SIZE}&page=${page}`;
+      if (this.projectId) url += `&project_id=${this.projectId}`;
+
+      const response = await this.apiFetch(url);
+      const data = (await response.json()) as { issues: Array<{ id: number; updated_at: string }> };
+      const issues = data.issues ?? [];
+
+      let pageMatchCount = 0;
+      for (const issue of issues) {
+        newestSeenUpdatedAt = maxTimestamp(newestSeenUpdatedAt, issue.updated_at);
+        const ts = parseTimestamp(issue.updated_at);
+        if (ts !== null && ts >= updatedSinceTs) {
+          ids.push(issue.id);
+          pageMatchCount++;
+        }
+      }
+
+      // Partial page → we've reached the end of the dataset
+      if (issues.length < SCAN_PAGE_SIZE) break;
+      // MantisBT returns issues sorted by last_updated DESC. Once a full page
+      // has zero matches, every subsequent page will also be older than
+      // updatedSince — safe to stop scanning.
+      if (pageMatchCount === 0 && issues.length > 0) break;
+
+      page++;
+    }
+    this.reportProgress(`Scan complete: ${ids.length} updated issues found across ${page} page(s)`);
+
+    if (ids.length === 0) {
+      // No issues need syncing — transition directly
+      const finalUpdatedSince = maxTimestamp(c.updatedSince, newestSeenUpdatedAt);
+      return {
+        entities: [],
+        ...this.transitionFromIssues(finalUpdatedSince),
+      };
+    }
+
+    // Apply maxEntities limit
+    let idsToFetch = ids;
+    if (this.maxEntities && ids.length > this.maxEntities) {
+      idsToFetch = ids.slice(0, this.maxEntities);
+    }
+
+    // Store IDs in cursor for the fetch phase
+    return {
+      entities: [],
+      nextCursor: {
+        updatedSince: c.updatedSince,
+        newestSeenUpdatedAt,
+        _incrementalIds: idsToFetch,
+        _users: Object.fromEntries(this.collectedUsers),
+        _projects: Object.fromEntries(this.collectedProjects),
+      },
+      hasMore: true,
+      deletedExternalIds: [],
+    };
+  }
+
+  /**
+   * Fetch phase of incremental sync: fetch full issue data for IDs
+   * identified during the scan phase, in batches of PAGE_SIZE.
+   */
+  private async fetchIncrementalBatch(c: MantisHubSyncCursor): Promise<SyncResult> {
+    const ids = c._incrementalIds ?? [];
+    const batch = ids.slice(0, PAGE_SIZE);
+    const remaining = ids.slice(PAGE_SIZE);
+
+    const entities: CrawlerEntityData[] = [];
+    for (let i = 0; i < batch.length; i++) {
+      const id = batch[i];
+      this.reportProgress(`Fetching issue #${id} (${i + 1}/${batch.length} in batch, ${remaining.length + batch.length - i - 1} remaining)`);
+      let fullIssue: MantisHubIssue;
+      try {
+        fullIssue = await this.fetchIssue(id);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to sync entity type=issue id=${id}: ${message}`);
+      }
+      this.collectUsersAndProjects(fullIssue);
+      entities.push(await this.buildIssueEntity(fullIssue));
+    }
+
+    const serializedCollected = {
+      _users: Object.fromEntries(this.collectedUsers),
+      _projects: Object.fromEntries(this.collectedProjects),
+    };
+
+    if (remaining.length > 0) {
+      return {
+        entities,
+        nextCursor: {
+          updatedSince: c.updatedSince,
+          newestSeenUpdatedAt: c.newestSeenUpdatedAt,
+          _incrementalIds: remaining,
+          ...serializedCollected,
+        },
+        hasMore: true,
+        deletedExternalIds: [],
+      };
+    }
+
+    // All IDs fetched — transition to next phase
+    const finalUpdatedSince = maxTimestamp(c.updatedSince, c.newestSeenUpdatedAt);
+    return {
+      entities,
+      ...this.transitionFromIssues(finalUpdatedSince),
+    };
+  }
+
   private async syncUsersAndProjects(c: MantisHubSyncCursor): Promise<SyncResult> {
     const entities: CrawlerEntityData[] = [];
 
     // Fetch full user profiles; fall back to basic data on error.
     if (this.shouldSync("users")) {
-      for (const basic of this.collectedUsers.values()) {
-        if (!basic.name) continue; // Skip users without a name
+      const users = Array.from(this.collectedUsers.values()).filter((u) => u.name);
+      if (users.length > 0) {
+        this.reportProgress(`Fetching ${users.length} user profile(s)`);
+      }
+      let i = 0;
+      for (const basic of users) {
+        i++;
+        this.reportProgress(`Fetching user ${basic.name} (${i}/${users.length})`);
         try {
           const profile = await this.fetchUser(basic.id);
           entities.push(this.buildUserEntity(profile));
@@ -375,6 +537,9 @@ export class MantisHubCrawler implements Crawler {
     }
 
     // Emit project entities (data already collected from issues).
+    if (this.collectedProjects.size > 0) {
+      this.reportProgress(`Building ${this.collectedProjects.size} project entit${this.collectedProjects.size === 1 ? "y" : "ies"}`);
+    }
     for (const project of this.collectedProjects.values()) {
       entities.push(this.buildProjectEntity(project));
     }
@@ -444,8 +609,19 @@ export class MantisHubCrawler implements Crawler {
         const text = await response.text();
         if (text.trim()) bodySnippet = ` — ${text.trim().slice(0, 300)}`;
       } catch { /* ignore body read errors */ }
+      // Include a safe token fingerprint (length + first 4 chars) to help diagnose
+      // credential misloading without leaking the full token.
+      const tokenFingerprint = this.token
+        ? `${this.token.slice(0, 4)}…(${this.token.length} chars)`
+        : "<none>";
+      let hint = "";
+      if (response.status === 403) {
+        hint = " (MantisBT 403: token is in the DB, but the user account is likely disabled or lacks view access. Check the user account status and project access level.)";
+      } else if (response.status === 401) {
+        hint = " (MantisBT 401: token is invalid/unknown, or missing. Verify the token in credentials.yml matches a valid API token.)";
+      }
       throw new Error(
-        `MantisHub API error: GET ${url} → ${response.status} ${response.statusText}${bodySnippet}`,
+        `MantisHub API error: GET ${url} → ${response.status} ${response.statusText}${bodySnippet} [token=${tokenFingerprint}]${hint}`,
       );
     }
     return response;
@@ -617,6 +793,7 @@ export class MantisHubCrawler implements Crawler {
     try {
       // Browse all pages for this project (with pagination).
       const browsePage = c._pagesBrowsePage ?? 1;
+      this.reportProgress(`Fetching wiki pages for project ${currentProjectId} (page ${browsePage})`);
       const browseResult = await this.browsePages(currentProjectId, browsePage);
 
       // Fetch full details for each page and build entities.

--- a/packages/desktop/build.mjs
+++ b/packages/desktop/build.mjs
@@ -7,6 +7,7 @@
  * - Externalizes electron, better-sqlite3, and Node builtins (native / provided at runtime)
  */
 import { build } from "esbuild";
+import { execSync } from "child_process";
 
 const common = {
   bundle: true,
@@ -47,5 +48,9 @@ await build({
   entryPoints: ["src/preload/index.ts"],
   outfile: "dist/preload/index.js",
 });
+
+// Rebuild native modules (better-sqlite3) against Electron's Node.js version
+console.log("Rebuilding native modules for Electron...");
+execSync("electron-rebuild -m .", { stdio: "inherit" });
 
 console.log("Desktop build complete: dist/main/index.mjs, dist/preload/index.js");

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "main": "dist/main/index.mjs",
   "scripts": {
+    "rebuild-native": "electron-rebuild -m .",
     "compile": "bun build.mjs",
     "start": "bun build.mjs && electron .",
     "dist": "bun build.mjs && electron-builder",

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, shell, nativeImage, Menu } from "electron";
 import { join, dirname } from "path";
 import { existsSync } from "fs";
+import { homedir } from "os";
 import { fileURLToPath } from "url";
 
 const __desktopFilename = fileURLToPath(import.meta.url);
@@ -13,6 +14,10 @@ import { createApiServer } from "../../../cli/src/commands/serve";
 
 let mainWindow: BrowserWindow | null = null;
 let apiServer: { port: number; stop?: () => void } | null = null;
+
+function getDefaultHome(): string {
+  return join(homedir(), ".frozenink");
+}
 
 async function startApiServer(workspacePath: string): Promise<{ port: number; stop?: () => void }> {
   // Set environment before importing core modules
@@ -145,19 +150,14 @@ app.whenReady().then(async () => {
     },
   });
 
-  // Check for last workspace
-  const lastWorkspace = getLastWorkspace();
+  // Always use ~/.frozenink as the home directory for collections
+  const home = getDefaultHome();
 
-  if (lastWorkspace && existsSync(lastWorkspace)) {
-    // Auto-open last workspace
-    try {
-      apiServer = await startApiServer(lastWorkspace);
-      mainWindow.loadURL(`http://localhost:${apiServer.port}`);
-    } catch (err) {
-      console.error("Failed to start API server:", err);
-      showWelcomeScreen();
-    }
-  } else {
+  try {
+    apiServer = await startApiServer(home);
+    mainWindow.loadURL(`http://localhost:${apiServer.port}`);
+  } catch (err) {
+    console.error("Failed to start API server:", err);
     showWelcomeScreen();
   }
 });

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -3150,6 +3150,11 @@ select.form-input { cursor: pointer; }
   margin-bottom: 8px;
 }
 .sync-progress-collection { font-weight: 500; font-size: 13px; }
+.sync-progress-elapsed {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
 .sync-progress-counters {
   display: flex;
   gap: 12px;

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -1206,6 +1206,22 @@ body {
   color: var(--text);
 }
 
+.empty-state-action {
+  margin-top: 8px;
+  padding: 6px 16px;
+  font-size: 13px;
+  font-family: var(--font-sans);
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.empty-state-action:hover {
+  background: var(--bg-hover, var(--border));
+}
+
 .loading {
   padding: 24px;
   color: var(--text-muted);
@@ -2877,6 +2893,14 @@ body {
   box-shadow: 0 0 0 2px var(--accent-bg);
 }
 select.form-input { cursor: pointer; }
+.path-field {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.path-field .form-input {
+  flex: 1;
+}
 .form-error {
   color: #cf222e;
   font-size: 13px;
@@ -2900,16 +2924,45 @@ select.form-input { cursor: pointer; }
   padding: 5px 0;
   cursor: pointer;
 }
-.checkbox-label input[type="checkbox"] {
+.checkbox-label input[type="checkbox"],
+.checkbox-label input[type="radio"] {
   margin: 0;
   flex-shrink: 0;
   width: 16px;
   height: 16px;
 }
+.cred-mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+.cred-mode-toggle label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  margin: 0;
+  color: var(--text);
+}
+.cred-mode-toggle input[type="radio"] {
+  margin: 0;
+  width: 16px;
+  height: 16px;
+}
+.cred-mode-inline-select {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.cred-mode-inline-select select {
+  flex: 1;
+}
 .toggle-label {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   font-size: 12px;
   cursor: pointer;
 }
@@ -2935,10 +2988,16 @@ select.form-input { cursor: pointer; }
   margin-bottom: 4px;
 }
 .collection-card-type {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-size: 11px;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
+}
+.collection-card-type svg {
+  flex-shrink: 0;
 }
 .collection-card-name {
   margin: 0 0 6px;
@@ -2961,6 +3020,36 @@ select.form-input { cursor: pointer; }
   margin-top: 10px;
   padding-top: 10px;
   border-top: 1px solid var(--border);
+}
+.collection-card-clickable {
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.collection-card-clickable:hover {
+  border-color: var(--accent, var(--text-muted));
+}
+.collection-card-badges {
+  display: flex;
+  gap: 6px;
+}
+.collection-card-desc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin: 0 0 8px;
+  line-height: 1.4;
+}
+.detail-section {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.detail-section h3 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 10px;
+}
+.detail-section-danger {
+  border-top-color: var(--danger, #cf222e);
 }
 
 /* Crawler Picker */

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -1269,6 +1269,39 @@ body {
   background: transparent;
 }
 
+.sync-dialog {
+  width: 480px;
+  max-height: none;
+}
+
+.sync-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sync-dialog-header h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.sync-dialog-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sync-dialog-footer {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: flex-end;
+}
+
 .search-input::placeholder {
   color: var(--text-muted);
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -8,6 +8,7 @@ import SearchBar, { type FileEntry } from "./components/SearchBar";
 import FullTextSearch from "./components/FullTextSearch";
 import ThemeSwitcher, { type ThemeId } from "./components/ThemeSwitcher";
 import ViewModeToggle, { type ViewMode } from "./components/ViewModeToggle";
+import BrowseSyncButton from "./components/BrowseSyncButton";
 import TabBar, { type Tab } from "./components/TabBar";
 import LinksPanel, { type Backlink, type LinkItem } from "./components/LinksPanel";
 import ModeSwitcher from "./components/ModeSwitcher";
@@ -997,6 +998,12 @@ export default function App() {
               htmlAvailable={htmlAvailable}
               onChange={setViewMode}
             />
+            {appMode !== "published" && selectedCollection && (
+              <BrowseSyncButton
+                collectionName={selectedCollection}
+                onSyncComplete={() => setRefreshKey((k) => k + 1)}
+              />
+            )}
             <button
               className="nav-btn"
               onClick={() => setSearchOpen(true)}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -14,10 +14,7 @@ import ModeSwitcher from "./components/ModeSwitcher";
 import ManageNav, { type ManageSection } from "./components/manage/ManageNav";
 import CollectionList from "./components/manage/CollectionList";
 import CollectionForm from "./components/manage/CollectionForm";
-import PublishPanel from "./components/manage/PublishPanel";
-import ExportPanel from "./components/manage/ExportPanel";
-import SettingsPanel from "./components/manage/SettingsPanel";
-import McpPanel from "./components/manage/McpPanel";
+import CollectionDetail from "./components/manage/CollectionDetail";
 import type { Collection, TreeNode, AppInfo, UIMode } from "./types";
 
 function loadTheme(): ThemeId {
@@ -185,6 +182,7 @@ export default function App() {
   const [manageSection, setManageSection] = useState<ManageSection>("collections");
   const [editingCollection, setEditingCollection] = useState<string | null>(null);
   const [addingCollection, setAddingCollection] = useState(false);
+  const [viewingCollection, setViewingCollection] = useState<string | null>(null);
   // refreshKey: increment to force collections + file tree to re-fetch
   const [refreshKey, setRefreshKey] = useState(0);
   const [collections, setCollections] = useState<Collection[]>([]);
@@ -363,7 +361,7 @@ export default function App() {
 
   useEffect(() => {
     const title = collections.find((c) => c.name === selectedCollection)?.title ?? selectedCollection;
-    document.title = title ?? "Frozen Ink";
+    document.title = title ? `${title} - Frozen Ink` : "Frozen Ink";
   }, [selectedCollection, collections]);
 
   useEffect(() => {
@@ -884,12 +882,12 @@ export default function App() {
   const canGoForward = navIndex < navHistory.length - 1;
   const showLogout = isPublishedDeployment() || appMode === "published";
 
-  const isDesktop = appMode === "desktop";
+  const canManage = appMode !== "published";
 
   const sidebar = (
     <>
       <ThemeSwitcher current={theme} onChange={handleThemeChange} />
-      {isDesktop && <ModeSwitcher mode={uiMode} onChange={handleUIModeChange} />}
+      {canManage && <ModeSwitcher mode={uiMode} onChange={handleUIModeChange} />}
       {uiMode === "browse" && (
         <>
           <CollectionPicker
@@ -905,18 +903,19 @@ export default function App() {
           />
         </>
       )}
-      {uiMode === "manage" && isDesktop && (
+      {uiMode === "manage" && canManage && (
         <ManageNav active={manageSection} onSelect={(section) => {
           setManageSection(section);
           // Close any open forms when navigating between manage pages
           setEditingCollection(null);
           setAddingCollection(false);
+          setViewingCollection(null);
         }} />
       )}
     </>
   );
 
-  const manageContent = isDesktop && uiMode === "manage" ? (
+  const manageContent = canManage && uiMode === "manage" ? (
     <div className="manage-content">
       {addingCollection ? (
         <CollectionForm
@@ -926,28 +925,23 @@ export default function App() {
       ) : editingCollection ? (
         <CollectionForm
           editName={editingCollection}
-          editConfig={(() => {
-            const col = collections.find((c) => c.name === editingCollection);
-            return col ? { title: col.title, description: col.description, crawler: col.crawlerType, config: {}, credentials: {} } : undefined;
-          })()}
-          onSave={() => { setEditingCollection(null); triggerRefresh(); }}
+          onSave={() => { setEditingCollection(null); setViewingCollection(editingCollection); triggerRefresh(); }}
           onCancel={() => setEditingCollection(null)}
+        />
+      ) : manageSection === "collections" && viewingCollection ? (
+        <CollectionDetail
+          name={viewingCollection}
+          onBack={() => setViewingCollection(null)}
+          onEdit={(n) => setEditingCollection(n)}
+          onCollectionsChanged={triggerRefresh}
         />
       ) : manageSection === "collections" ? (
         <CollectionList
-          onEdit={(name) => setEditingCollection(name)}
+          onSelect={(name) => setViewingCollection(name)}
           onAdd={() => setAddingCollection(true)}
           onSyncComplete={triggerRefresh}
           onCollectionsChanged={triggerRefresh}
         />
-      ) : manageSection === "publish" ? (
-        <PublishPanel />
-      ) : manageSection === "mcp" ? (
-        <McpPanel />
-      ) : manageSection === "export" ? (
-        <ExportPanel />
-      ) : manageSection === "settings" ? (
-        <SettingsPanel />
       ) : null}
     </div>
   ) : null;
@@ -1141,7 +1135,21 @@ export default function App() {
               </p>
             </div>
           )}
-          {!selectedFile && !loading && !fileNotFound && (
+          {!selectedFile && !loading && !fileNotFound && canManage && browseCollections.length === 0 && (
+            <div className="empty-state">
+              <p>No collections yet</p>
+              <p className="hint">
+                Use <strong>Manage</strong> in the sidebar to add a collection and start syncing.
+              </p>
+              <button
+                className="empty-state-action"
+                onClick={() => handleUIModeChange("manage")}
+              >
+                Go to Manage
+              </button>
+            </div>
+          )}
+          {!selectedFile && !loading && !fileNotFound && !(canManage && browseCollections.length === 0) && (
             <div className="empty-state">
               <p>{isMobile ? "Tap the sidebar icon below to browse files" : "Select a file from the sidebar to view its contents"}</p>
               {!isMobile && (

--- a/packages/ui/src/components/BrowseSyncButton.tsx
+++ b/packages/ui/src/components/BrowseSyncButton.tsx
@@ -1,0 +1,117 @@
+import { useState, useEffect, useRef } from "react";
+import type { SyncProgress as SyncProgressType } from "../types";
+
+interface BrowseSyncButtonProps {
+  collectionName: string;
+  onSyncComplete?: () => void;
+}
+
+export default function BrowseSyncButton({ collectionName, onSyncComplete }: BrowseSyncButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [progress, setProgress] = useState<SyncProgressType | null>(null);
+  const intervalRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  const startSync = () => {
+    setOpen(true);
+    setSyncing(true);
+    setProgress(null);
+
+    fetch(`/api/sync/${encodeURIComponent(collectionName)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ full: false }),
+    }).catch(console.error);
+
+    const poll = () => {
+      fetch("/api/sync/status")
+        .then((r) => r.json())
+        .then((data: SyncProgressType) => {
+          setProgress(data);
+          if (!data.active) {
+            if (intervalRef.current) clearInterval(intervalRef.current);
+            setSyncing(false);
+            onSyncComplete?.();
+          }
+        })
+        .catch(() => {});
+    };
+    poll();
+    intervalRef.current = window.setInterval(poll, 500);
+  };
+
+  const close = () => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    setOpen(false);
+    setSyncing(false);
+  };
+
+  return (
+    <>
+      <button
+        className="nav-btn icon-btn"
+        onClick={startSync}
+        title="Sync collection"
+        aria-label="Sync collection"
+        disabled={syncing}
+      >
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="23 4 23 10 17 10" />
+          <polyline points="1 20 1 14 7 14" />
+          <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="search-overlay" onClick={close}>
+          <div className="search-dialog sync-dialog" onClick={(e) => e.stopPropagation()}>
+            <div className="sync-dialog-header">
+              <h3>Sync "{collectionName}"</h3>
+              <button className="nav-btn icon-btn" onClick={close} aria-label="Close">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+            <div className="sync-dialog-body">
+              {progress ? (
+                <>
+                  <div className="sync-progress-header">
+                    <span className={`status-badge status-${progress.active ? "running" : progress.error ? "failed" : "completed"}`}>
+                      {progress.active ? "Syncing" : progress.error ? "Failed" : "Done"}
+                    </span>
+                  </div>
+                  <div className="sync-progress-counters">
+                    <span className="counter counter-created">{progress.created} created</span>
+                    <span className="counter counter-updated">{progress.updated} updated</span>
+                    <span className="counter counter-deleted">{progress.deleted} deleted</span>
+                  </div>
+                  {progress.status && progress.status !== "idle" && (
+                    <div className="sync-progress-status">{progress.status}</div>
+                  )}
+                  {progress.error && (
+                    <div className="form-error">{progress.error}</div>
+                  )}
+                </>
+              ) : (
+                <div className="sync-progress-status">Starting...</div>
+              )}
+            </div>
+            {!syncing && (
+              <div className="sync-dialog-footer">
+                <button className="btn btn-primary btn-sm" onClick={close}>Close</button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/ui/src/components/manage/CollectionDetail.tsx
+++ b/packages/ui/src/components/manage/CollectionDetail.tsx
@@ -71,6 +71,14 @@ function formatSize(bytes: number): string {
   return `${mb % 1 < 0.05 ? mb.toFixed(0) : mb.toFixed(1)} MB`;
 }
 
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}m ${sec}s`;
+}
+
 function formatCount(n: number): string {
   return n.toLocaleString();
 }
@@ -91,6 +99,12 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
   const [removePassword, setRemovePassword] = useState(false);
   const [publishError, setPublishError] = useState<string | null>(null);
   const publishPollRef = useRef<number | null>(null);
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    if (!publishing) return;
+    const tick = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(tick);
+  }, [publishing]);
 
   // MCP state
   const [mcpStatuses, setMcpStatuses] = useState<McpLinkStatus[]>([]);
@@ -432,6 +446,11 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
               <span className={`status-badge status-${publishProgress.active ? "running" : publishProgress.error ? "failed" : "completed"}`}>
                 {publishProgress.active ? "Publishing" : publishProgress.error ? "Failed" : "Done"}
               </span>
+              {publishProgress.startedAt != null && (
+                <span className="sync-progress-elapsed">
+                  {formatElapsed(now - publishProgress.startedAt)}
+                </span>
+              )}
             </div>
             <div className="sync-progress-status">{publishProgress.detail || publishProgress.step}</div>
           </div>

--- a/packages/ui/src/components/manage/CollectionDetail.tsx
+++ b/packages/ui/src/components/manage/CollectionDetail.tsx
@@ -1,0 +1,554 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import SyncProgress from "./SyncProgress";
+import {
+  formatTimestamp,
+  type Collection,
+  type CollectionStatus,
+  type SyncRun,
+  type PublishProgress,
+  type McpLinkStatus,
+} from "../../types";
+
+interface CollectionDetailProps {
+  name: string;
+  onBack: () => void;
+  onEdit: (name: string) => void;
+  onCollectionsChanged?: () => void;
+}
+
+const CRAWLER_LABELS: Record<string, string> = {
+  github: "GitHub",
+  obsidian: "Obsidian",
+  git: "Git",
+  mantishub: "MantisHub",
+  remote: "Cloned",
+};
+
+function CrawlerIcon({ type }: { type: string }) {
+  const size = 14;
+  switch (type) {
+    case "github":
+      return (
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
+        </svg>
+      );
+    case "obsidian":
+      return (
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+          <path d="M19.355 18.538a68.967 68.959 0 0 0 1.858-2.954.81.81 0 0 0-.062-.9c-.516-.685-1.504-2.075-2.042-3.362-.553-1.321-.636-3.375-.64-4.377a1.707 1.707 0 0 0-.358-1.05l-3.198-4.064a3.744 3.744 0 0 1-.076.543c-.106.503-.307 1.004-.536 1.5-.134.29-.29.6-.446.914l-.31.626c-.516 1.068-.997 2.227-1.132 3.59-.124 1.26.046 2.73.815 4.481.128.011.257.025.386.044a6.363 6.363 0 0 1 3.326 1.505c.916.79 1.744 1.922 2.415 3.5zM8.199 22.569c.073.012.146.02.22.02.78.024 2.095.092 3.16.29.87.16 2.593.64 4.01 1.055 1.083.316 2.198-.548 2.355-1.664.114-.814.33-1.735.725-2.58l-.01.005c-.67-1.87-1.522-3.078-2.416-3.849a5.295 5.295 0 0 0-2.778-1.257c-1.54-.216-2.952.19-3.84.45.532 2.218.368 4.829-1.425 7.531zM5.533 9.938c-.023.1-.056.197-.098.29L2.82 16.059a1.602 1.602 0 0 0 .313 1.772l4.116 4.24c2.103-3.101 1.796-6.02.836-8.3-.728-1.73-1.832-3.081-2.55-3.831zM9.32 14.01c.615-.183 1.606-.465 2.745-.534-.683-1.725-.848-3.233-.716-4.577.154-1.552.7-2.847 1.235-3.95.113-.235.223-.454.328-.664.149-.297.288-.577.419-.86.217-.47.379-.885.46-1.27.08-.38.08-.72-.014-1.043-.095-.325-.297-.675-.68-1.06a1.6 1.6 0 0 0-1.475.36l-4.95 4.452a1.602 1.602 0 0 0-.513.952l-.427 2.83c.672.59 2.328 2.316 3.335 4.711.09.21.175.43.253.653z"/>
+        </svg>
+      );
+    case "mantishub":
+      return (
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+          <path d="M14,12H10V10H14M14,16H10V14H14M20,8H17.19C16.74,7.22 16.12,6.55 15.37,6.04L17,4.41L15.59,3L13.42,5.17C12.96,5.06 12.5,5 12,5C11.5,5 11.04,5.06 10.59,5.17L8.41,3L7,4.41L8.62,6.04C7.88,6.55 7.26,7.22 6.81,8H4V10H6.09C6.04,10.33 6,10.66 6,11V12H4V14H6V15C6,15.34 6.04,15.67 6.09,16H4V18H6.81C7.85,19.79 9.78,21 12,21C14.22,21 16.15,19.79 17.19,18H20V16H17.91C17.96,15.67 18,15.34 18,15V14H20V12H18V11C18,10.66 17.96,10.33 17.91,10H20V8Z"/>
+        </svg>
+      );
+    case "git":
+      return (
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+          <path d="M23.546 10.93L13.067.452c-.604-.603-1.582-.603-2.188 0L8.708 2.627l2.76 2.76c.645-.215 1.379-.07 1.889.441.516.515.658 1.258.438 1.9l2.658 2.66c.645-.223 1.387-.078 1.9.435.721.72.721 1.884 0 2.604-.719.719-1.881.719-2.6 0-.539-.541-.674-1.337-.404-1.996L12.86 8.955v6.525c.176.086.342.203.488.348.713.721.713 1.883 0 2.6-.719.721-1.889.721-2.609 0-.719-.719-.719-1.879 0-2.598.182-.18.387-.316.605-.406V8.835c-.217-.091-.424-.222-.6-.401-.545-.545-.676-1.342-.396-2.009L7.636 3.7.45 10.881c-.6.605-.6 1.584 0 2.189l10.48 10.477c.604.604 1.582.604 2.186 0l10.43-10.43c.605-.603.605-1.582 0-2.187"/>
+        </svg>
+      );
+    case "remote":
+      return (
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/>
+          <path d="M13 6h3a2 2 0 0 1 2 2v7"/><path d="M6 9v12"/>
+        </svg>
+      );
+    default:
+      return null;
+  }
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb % 1 === 0 ? kb.toFixed(0) : kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  return `${mb % 1 < 0.05 ? mb.toFixed(0) : mb.toFixed(1)} MB`;
+}
+
+function formatCount(n: number): string {
+  return n.toLocaleString();
+}
+
+export default function CollectionDetail({ name, onBack, onEdit, onCollectionsChanged }: CollectionDetailProps) {
+  const [collection, setCollection] = useState<Collection | null>(null);
+  const [status, setStatus] = useState<CollectionStatus | null>(null);
+  const [syncHistory, setSyncHistory] = useState<SyncRun[]>([]);
+  const [syncing, setSyncing] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+
+  // Publish state
+  const [publishing, setPublishing] = useState(false);
+  const [publishProgress, setPublishProgress] = useState<PublishProgress | null>(null);
+  const [publishPassword, setPublishPassword] = useState("");
+  const [removePassword, setRemovePassword] = useState(false);
+  const [publishError, setPublishError] = useState<string | null>(null);
+  const publishPollRef = useRef<number | null>(null);
+
+  // MCP state
+  const [mcpStatuses, setMcpStatuses] = useState<McpLinkStatus[]>([]);
+  const [mcpBusyKey, setMcpBusyKey] = useState<string | null>(null);
+  const [mcpError, setMcpError] = useState<string | null>(null);
+
+  const isRemote = collection?.crawlerType === "remote";
+
+  const loadCollection = useCallback(() => {
+    fetch("/api/collections")
+      .then((r) => r.json())
+      .then((data: Collection[]) => {
+        const col = data.find((c) => c.name === name);
+        if (col) setCollection(col);
+      })
+      .catch(console.error);
+  }, [name]);
+
+  const loadStatus = useCallback(() => {
+    fetch(`/api/collections/${encodeURIComponent(name)}/status`)
+      .then((r) => r.json())
+      .then(setStatus)
+      .catch(() => {});
+  }, [name]);
+
+  const loadHistory = useCallback(() => {
+    fetch(`/api/collections/${encodeURIComponent(name)}/sync-runs`)
+      .then((r) => r.json())
+      .then(setSyncHistory)
+      .catch(() => {});
+  }, [name]);
+
+  const loadMcp = useCallback(async () => {
+    try {
+      const res = await fetch("/api/mcp/status");
+      if (res.ok) setMcpStatuses(await res.json());
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    loadCollection();
+    loadStatus();
+    loadHistory();
+    loadMcp();
+  }, [loadCollection, loadStatus, loadHistory, loadMcp]);
+
+  useEffect(() => {
+    return () => {
+      if (publishPollRef.current) clearInterval(publishPollRef.current);
+    };
+  }, []);
+
+  // --- Sync ---
+  const handleSync = (full: boolean) => {
+    setSyncing(true);
+    fetch(`/api/sync/${encodeURIComponent(name)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ full }),
+    }).catch(console.error);
+  };
+
+  const handleSyncComplete = () => {
+    setSyncing(false);
+    loadStatus();
+    loadHistory();
+    onCollectionsChanged?.();
+  };
+
+  // --- Enable/Disable ---
+  const handleToggle = (enabled: boolean) => {
+    fetch(`/api/collections/${encodeURIComponent(name)}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled }),
+    }).then(() => { loadCollection(); onCollectionsChanged?.(); });
+  };
+
+  // --- Delete ---
+  const handleDelete = () => {
+    if (deleting) {
+      fetch(`/api/collections/${encodeURIComponent(name)}`, { method: "DELETE" })
+        .then(() => { onCollectionsChanged?.(); onBack(); })
+        .finally(() => setDeleting(false));
+    } else {
+      setDeleting(true);
+    }
+  };
+
+  // --- Publish ---
+  const doPublish = () => {
+    const isInitial = !collection?.publish;
+    if (isInitial && !publishPassword && !removePassword) {
+      const confirmed = window.confirm(
+        "No password is configured for this initial publish. Collection data will be publicly accessible. Continue?",
+      );
+      if (!confirmed) return;
+    }
+
+    setPublishing(true);
+    setPublishProgress(null);
+    setPublishError(null);
+
+    fetch(`/api/collections/${encodeURIComponent(name)}/publish`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        password: publishPassword || undefined,
+        removePassword: removePassword || undefined,
+        forcePublic: isInitial && !publishPassword && !removePassword ? true : undefined,
+      }),
+    }).catch(() => {});
+
+    publishPollRef.current = window.setInterval(async () => {
+      try {
+        const res = await fetch("/api/publish/status");
+        const data: PublishProgress = await res.json();
+        setPublishProgress(data);
+        if (!data.active) {
+          if (publishPollRef.current) clearInterval(publishPollRef.current);
+          setPublishing(false);
+          if (data.error) setPublishError(data.error);
+          loadCollection();
+        }
+      } catch {}
+    }, 1000);
+
+    setPublishPassword("");
+    setRemovePassword(false);
+  };
+
+  const handleUnpublish = async () => {
+    const confirmed = window.confirm(
+      `Unpublish "${name}"? This will delete its Cloudflare worker, D1 database, and R2 bucket.`,
+    );
+    if (!confirmed) return;
+
+    setPublishError(null);
+    try {
+      const res = await fetch(`/api/collections/${encodeURIComponent(name)}/unpublish`, { method: "POST" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: "Unpublish failed" }));
+        setPublishError(data.error || "Unpublish failed");
+      } else {
+        loadCollection();
+      }
+    } catch (err) {
+      setPublishError(String(err));
+    }
+  };
+
+  // --- MCP ---
+  const handleMcpLink = async (tool: string, transport: "stdio" | "http") => {
+    const key = `${tool}:${transport}`;
+    setMcpBusyKey(key);
+    setMcpError(null);
+    try {
+      const body = {
+        tool,
+        collections: [name],
+        transport,
+      };
+      const res = await fetch("/api/mcp/add", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({ error: "Link failed" }))) as { error?: string };
+        throw new Error(data.error || "Link failed");
+      }
+      await loadMcp();
+    } catch (err) {
+      setMcpError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setMcpBusyKey(null);
+    }
+  };
+
+  const handleMcpUnlink = async (tool: string) => {
+    const key = `${tool}:unlink`;
+    setMcpBusyKey(key);
+    setMcpError(null);
+    try {
+      const res = await fetch("/api/mcp/remove", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tool, collections: [name] }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({ error: "Unlink failed" }))) as { error?: string };
+        throw new Error(data.error || "Unlink failed");
+      }
+      await loadMcp();
+    } catch (err) {
+      setMcpError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setMcpBusyKey(null);
+    }
+  };
+
+  if (!collection) return <div className="loading">Loading...</div>;
+
+  // Filter MCP tools to only those relevant for this collection
+  const hasCloud = !!collection.publish;
+
+  return (
+    <div className="manage-panel">
+      {/* Header with back button */}
+      <div className="manage-panel-header">
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <button className="btn btn-sm" onClick={onBack} title="Back to collections">
+            &larr; Back
+          </button>
+          <h2>{collection.title || collection.name}</h2>
+          <span className="collection-card-type">
+            <CrawlerIcon type={collection.crawlerType} />
+            {CRAWLER_LABELS[collection.crawlerType] ?? collection.crawlerType}
+          </span>
+        </div>
+        <div className="sync-actions">
+          <button className="btn btn-sm" onClick={() => onEdit(name)}>Edit</button>
+          <label className="toggle-label">
+            <input
+              type="checkbox"
+              checked={collection.enabled}
+              onChange={(e) => handleToggle(e.target.checked)}
+            />
+            <span className="toggle-text">Enabled</span>
+          </label>
+        </div>
+      </div>
+
+      {collection.description && (
+        <p className="manage-panel-subtitle">{collection.description}</p>
+      )}
+
+      {/* --- Sync Section --- */}
+      <div className="detail-section">
+        <h3>{isRemote ? "Data" : "Sync"}</h3>
+        <div className="collection-card-stats">
+          <span>{status?.entityCount != null ? formatCount(status.entityCount) : "—"} entities</span>
+          {status?.diskSizeBytes != null && status.diskSizeBytes > 0 && (
+            <span>{formatSize(status.diskSizeBytes)}</span>
+          )}
+          {status?.lastSyncRun && (
+            <span>
+              Last {isRemote ? "pull" : "sync"}: {formatTimestamp(status.lastSyncRun.startedAt)}
+              {!isRemote && (
+                <>
+                  {" "}
+                  <span className={`sync-type-badge sync-type-${status.lastSyncRun.syncType || "incremental"}`}>
+                    {status.lastSyncRun.syncType === "full" ? "full" : "incr"}
+                  </span>
+                </>
+              )}
+            </span>
+          )}
+        </div>
+        <div className="collection-card-actions" style={{ marginTop: 8 }}>
+          {isRemote ? (
+            <button className="btn btn-sm" onClick={() => handleSync(true)} disabled={syncing}>
+              Pull
+            </button>
+          ) : (
+            <>
+              <button className="btn btn-sm" onClick={() => handleSync(false)} disabled={syncing}>
+                Sync
+              </button>
+              <button className="btn btn-sm btn-secondary" onClick={() => handleSync(true)} disabled={syncing}>
+                Full Sync
+              </button>
+            </>
+          )}
+          {syncHistory.length > 0 && (
+            <button
+              className={`btn btn-sm${showHistory ? " active" : ""}`}
+              onClick={() => setShowHistory(!showHistory)}
+            >
+              History
+            </button>
+          )}
+        </div>
+        {syncing && <SyncProgress onComplete={handleSyncComplete} />}
+        {showHistory && syncHistory.length > 0 && (
+          <div className="collection-card-history" style={{ marginTop: 8 }}>
+            <table className="sync-history-table">
+              <thead>
+                <tr>
+                  <th>Status</th>
+                  <th>Type</th>
+                  <th>Created</th>
+                  <th>Updated</th>
+                  <th>Deleted</th>
+                  <th>Started</th>
+                </tr>
+              </thead>
+              <tbody>
+                {syncHistory.slice(0, 10).map((run) => (
+                  <tr key={run.id}>
+                    <td><span className={`status-badge status-${run.status}`}>{run.status}</span></td>
+                    <td>
+                      <span className={`sync-type-badge sync-type-${run.syncType || "incremental"}`}>
+                        {run.syncType === "full" ? "full" : "incr"}
+                      </span>
+                    </td>
+                    <td>{run.entitiesCreated}</td>
+                    <td>{run.entitiesUpdated}</td>
+                    <td>{run.entitiesDeleted}</td>
+                    <td>{formatTimestamp(run.startedAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* --- Publish Section --- */}
+      <div className="detail-section">
+        <h3>Publish</h3>
+        {publishError && <div className="form-error">{publishError}</div>}
+
+        {publishProgress && (publishing || publishProgress.error) && (
+          <div className="sync-progress">
+            <div className="sync-progress-header">
+              <span className={`status-badge status-${publishProgress.active ? "running" : publishProgress.error ? "failed" : "completed"}`}>
+                {publishProgress.active ? "Publishing" : publishProgress.error ? "Failed" : "Done"}
+              </span>
+            </div>
+            <div className="sync-progress-status">{publishProgress.detail || publishProgress.step}</div>
+          </div>
+        )}
+
+        {collection.publish ? (
+          <div>
+            <div className="collection-card-stats">
+              <span>
+                <a href={collection.publish.url} target="_blank" rel="noopener noreferrer">
+                  {collection.publish.url.replace("https://", "")}
+                </a>
+              </span>
+              {collection.publish.protected && <span>Password protected</span>}
+              <span>Published {formatTimestamp(collection.publish.publishedAt)}</span>
+            </div>
+            <div className="collection-card-actions" style={{ marginTop: 8 }}>
+              <button className="btn btn-sm btn-primary" onClick={doPublish} disabled={publishing}>
+                {publishing ? "Publishing..." : "Republish"}
+              </button>
+              <button className="btn btn-sm btn-danger" onClick={handleUnpublish} disabled={publishing}>
+                Unpublish
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div className="form-group">
+              <label>Password (optional)</label>
+              <input
+                type="password"
+                value={publishPassword}
+                onChange={(e) => { setPublishPassword(e.target.value); if (e.target.value) setRemovePassword(false); }}
+                placeholder="Leave blank for public access"
+                className="form-input"
+                disabled={removePassword}
+              />
+            </div>
+            <button className="btn btn-primary btn-sm" onClick={doPublish} disabled={publishing}>
+              {publishing ? "Publishing..." : "Publish"}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* --- MCP Section --- */}
+      <div className="detail-section">
+        <h3>MCP</h3>
+        {mcpError && <div className="form-error">{mcpError}</div>}
+        {mcpStatuses.length > 0 ? (
+          <table className="sync-history-table">
+            <thead>
+              <tr>
+                <th>Tool</th>
+                <th>Local</th>
+                {hasCloud && <th>Cloud</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {mcpStatuses.map((s) => {
+                const link = s.links.find((l) => l.collection === name);
+                const linked = !!link?.linked;
+                const localBusy = mcpBusyKey === `${s.tool}:stdio`;
+                const cloudBusy = mcpBusyKey === `${s.tool}:http`;
+                const unlinkBusy = mcpBusyKey === `${s.tool}:unlink`;
+
+                // Local: only show if the tool is detected locally (available + supports stdio)
+                const showLocal = s.available && s.supportsStdio;
+                // Cloud: only if collection is published and tool supports http
+                const showCloud = hasCloud && s.supportsHttp;
+
+                // Skip tools that have neither local nor cloud available
+                if (!showLocal && !showCloud) return null;
+
+                return (
+                  <tr key={s.tool}>
+                    <td>
+                      <strong>{s.displayName}</strong>
+                    </td>
+                    <td>
+                      {showLocal ? (
+                        linked ? (
+                          <button className="btn btn-sm btn-danger" onClick={() => handleMcpUnlink(s.tool)} disabled={unlinkBusy}>
+                            {unlinkBusy ? "..." : "Unlink"}
+                          </button>
+                        ) : (
+                          <button className="btn btn-sm btn-primary" onClick={() => handleMcpLink(s.tool, "stdio")} disabled={localBusy}>
+                            {localBusy ? "..." : "Link"}
+                          </button>
+                        )
+                      ) : (
+                        <span className="text-muted">—</span>
+                      )}
+                    </td>
+                    {hasCloud && (
+                      <td>
+                        {showCloud ? (
+                          <div style={{ display: "flex", gap: 4 }}>
+                            <button className="btn btn-sm btn-primary" onClick={() => handleMcpLink(s.tool, "http")} disabled={cloudBusy}>
+                              {cloudBusy ? "..." : "Link"}
+                            </button>
+                            <button className="btn btn-sm btn-danger" onClick={() => handleMcpUnlink(s.tool)} disabled={unlinkBusy}>
+                              {unlinkBusy ? "..." : "Unlink"}
+                            </button>
+                          </div>
+                        ) : (
+                          <span className="text-muted">—</span>
+                        )}
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        ) : (
+          <p className="text-muted">No MCP tools available.</p>
+        )}
+      </div>
+
+      {/* --- Danger Zone --- */}
+      <div className="detail-section detail-section-danger">
+        <h3>Danger Zone</h3>
+        <button
+          className={`btn btn-sm btn-danger${deleting ? " confirm" : ""}`}
+          onClick={handleDelete}
+        >
+          {deleting ? "Click again to confirm deletion" : "Delete Collection"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/manage/CollectionDetail.tsx
+++ b/packages/ui/src/components/manage/CollectionDetail.tsx
@@ -96,8 +96,6 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
   const [mcpBusyKey, setMcpBusyKey] = useState<string | null>(null);
   const [mcpError, setMcpError] = useState<string | null>(null);
 
-  const isRemote = collection?.crawlerType === "remote";
-
   const loadCollection = useCallback(() => {
     fetch("/api/collections")
       .then((r) => r.json())
@@ -329,7 +327,7 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
 
       {/* --- Sync Section --- */}
       <div className="detail-section">
-        <h3>{isRemote ? "Data" : "Sync"}</h3>
+        <h3>Sync</h3>
         <div className="collection-card-stats">
           <span>{status?.entityCount != null ? formatCount(status.entityCount) : "—"} entities</span>
           {status?.diskSizeBytes != null && status.diskSizeBytes > 0 && (
@@ -337,8 +335,8 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
           )}
           {status?.lastSyncRun && (
             <span>
-              Last {isRemote ? "pull" : "sync"}: {formatTimestamp(status.lastSyncRun.startedAt)}
-              {!isRemote && (
+              Last sync: {formatTimestamp(status.lastSyncRun.startedAt)}
+              {collection?.crawlerType !== "remote" && (
                 <>
                   {" "}
                   <span className={`sync-type-badge sync-type-${status.lastSyncRun.syncType || "incremental"}`}>
@@ -350,9 +348,9 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
           )}
         </div>
         <div className="collection-card-actions" style={{ marginTop: 8 }}>
-          {isRemote ? (
-            <button className="btn btn-sm" onClick={() => handleSync(true)} disabled={syncing}>
-              Pull
+          {collection?.crawlerType === "remote" ? (
+            <button className="btn btn-sm" onClick={() => handleSync(false)} disabled={syncing}>
+              Sync
             </button>
           ) : (
             <>

--- a/packages/ui/src/components/manage/CollectionDetail.tsx
+++ b/packages/ui/src/components/manage/CollectionDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import SyncProgress from "./SyncProgress";
+import SyncProgress, { type SyncResult } from "./SyncProgress";
 import {
   formatTimestamp,
   type Collection,
@@ -80,6 +80,7 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
   const [status, setStatus] = useState<CollectionStatus | null>(null);
   const [syncHistory, setSyncHistory] = useState<SyncRun[]>([]);
   const [syncing, setSyncing] = useState(false);
+  const [lastSyncResult, setLastSyncResult] = useState<SyncResult | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
 
@@ -143,6 +144,7 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
   // --- Sync ---
   const handleSync = (full: boolean) => {
     setSyncing(true);
+    setLastSyncResult(null);
     fetch(`/api/sync/${encodeURIComponent(name)}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -150,12 +152,13 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
     }).catch(console.error);
   };
 
-  const handleSyncComplete = () => {
+  const handleSyncComplete = useCallback((result: SyncResult) => {
     setSyncing(false);
+    setLastSyncResult(result);
     loadStatus();
     loadHistory();
     onCollectionsChanged?.();
-  };
+  }, [loadStatus, loadHistory, onCollectionsChanged]);
 
   // --- Enable/Disable ---
   const handleToggle = (enabled: boolean) => {
@@ -372,6 +375,18 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
           )}
         </div>
         {syncing && <SyncProgress onComplete={handleSyncComplete} />}
+        {!syncing && lastSyncResult && (
+          <div className="sync-result" style={{ marginTop: 8 }}>
+            {lastSyncResult.error ? (
+              <div className="form-error">{lastSyncResult.error}</div>
+            ) : (
+              <span className="collection-card-stats">
+                <span>{lastSyncResult.created} created, {lastSyncResult.updated} updated, {lastSyncResult.deleted} deleted</span>
+                {status?.lastSyncRun && <span>Last sync: {formatTimestamp(status.lastSyncRun.startedAt)}</span>}
+              </span>
+            )}
+          </div>
+        )}
         {showHistory && syncHistory.length > 0 && (
           <div className="collection-card-history" style={{ marginTop: 8 }}>
             <table className="sync-history-table">

--- a/packages/ui/src/components/manage/CollectionForm.tsx
+++ b/packages/ui/src/components/manage/CollectionForm.tsx
@@ -1,5 +1,14 @@
 import { useState, useEffect, useRef } from "react";
 
+declare global {
+  interface Window {
+    frozenink?: {
+      openDirectoryPicker: () => Promise<string | null>;
+      platform?: string;
+    };
+  }
+}
+
 interface NamedCredential {
   name: string;
   keys: string[];
@@ -8,13 +17,6 @@ interface NamedCredential {
 interface CollectionFormProps {
   /** If provided, editing existing collection; else creating new */
   editName?: string;
-  editConfig?: {
-    title: string;
-    description?: string;
-    crawler: string;
-    config: Record<string, unknown>;
-    credentials: string | Record<string, unknown>;
-  };
   onSave: () => void;
   onCancel: () => void;
 }
@@ -26,29 +28,39 @@ const CRAWLER_TYPES = [
   { id: "mantishub", label: "MantisHub", description: "Issues from a MantisHub instance" },
 ];
 
-export default function CollectionForm({ editName, editConfig, onSave, onCancel }: CollectionFormProps) {
-  const [step, setStep] = useState(editConfig ? 2 : 1);
-  const [crawler, setCrawler] = useState(editConfig?.crawler ?? "");
+const NO_CREDENTIALS_CRAWLERS = ["obsidian", "git", "remote"];
+
+function configToStrings(obj: Record<string, unknown>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    result[k] = typeof v === "string" ? v : JSON.stringify(v);
+  }
+  return result;
+}
+
+export default function CollectionForm({ editName, onSave, onCancel }: CollectionFormProps) {
+  const [loading, setLoading] = useState(!!editName);
+  const [step, setStep] = useState(editName ? 2 : 1);
+  const [crawler, setCrawler] = useState("");
   const [name, setName] = useState(editName ?? "");
-  const [title, setTitle] = useState(editConfig?.title ?? "");
-  const [description, setDescription] = useState(editConfig?.description ?? "");
-  const [config, setConfig] = useState<Record<string, string>>(
-    configToStrings(editConfig?.config ?? {}),
-  );
-  const editCredsIsNamed = typeof editConfig?.credentials === "string";
-  const [credMode, setCredMode] = useState<"inline" | "named">(editCredsIsNamed ? "named" : "inline");
-  const [selectedCredName, setSelectedCredName] = useState<string>(
-    editCredsIsNamed ? (editConfig?.credentials as string) : "",
-  );
-  const [credentials, setCredentials] = useState<Record<string, string>>(
-    editCredsIsNamed ? {} : configToStrings((editConfig?.credentials as Record<string, unknown>) ?? {}),
-  );
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [enabled, setEnabled] = useState(true);
+  const [config, setConfig] = useState<Record<string, string>>({});
+  const [credMode, setCredMode] = useState<"inline" | "named">("inline");
+  const [selectedCredName, setSelectedCredName] = useState<string>("");
+  const [credentials, setCredentials] = useState<Record<string, string>>({});
   const [namedCredentials, setNamedCredentials] = useState<NamedCredential[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [discardPrompt, setDiscardPrompt] = useState(false);
 
-  // Fetch available named credentials
+  // Track original values for unsaved-change detection
+  const originalRef = useRef<{
+    title: string; description: string; config: string; credMode: string; selectedCredName: string; credentials: string; enabled: boolean;
+  } | null>(null);
+
+  // Fetch named credentials
   useEffect(() => {
     fetch("/api/credentials")
       .then((res) => res.json())
@@ -56,16 +68,57 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
       .catch(() => {});
   }, []);
 
+  // Fetch full config when editing
+  useEffect(() => {
+    if (!editName) return;
+    fetch(`/api/collections/${encodeURIComponent(editName)}/config`)
+      .then((r) => r.json())
+      .then((data: { title: string; description?: string; crawler: string; enabled: boolean; config: Record<string, unknown>; credentials: string | Record<string, unknown> }) => {
+        setCrawler(data.crawler);
+        setTitle(data.title ?? "");
+        setDescription(data.description ?? "");
+        setEnabled(data.enabled);
+        const cfg = configToStrings(data.config ?? {});
+        setConfig(cfg);
+
+        const isNamed = typeof data.credentials === "string";
+        if (isNamed) {
+          setCredMode("named");
+          setSelectedCredName(data.credentials as string);
+        } else {
+          setCredMode("inline");
+          setCredentials(configToStrings((data.credentials as Record<string, unknown>) ?? {}));
+        }
+
+        originalRef.current = {
+          title: data.title ?? "",
+          description: data.description ?? "",
+          config: JSON.stringify(cfg),
+          credMode: isNamed ? "named" : "inline",
+          selectedCredName: isNamed ? (data.credentials as string) : "",
+          credentials: isNamed ? "{}" : JSON.stringify(configToStrings((data.credentials as Record<string, unknown>) ?? {})),
+          enabled: data.enabled,
+        };
+
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(String(err));
+        setLoading(false);
+      });
+  }, [editName]);
+
   function hasUnsavedChanges(): boolean {
-    if (!editName) return false; // creating new — no prior state to compare
-    const credsChanged = editCredsIsNamed
-      ? (credMode !== "named" || selectedCredName !== (editConfig?.credentials as string))
-      : (credMode !== "inline" || JSON.stringify(credentials) !== JSON.stringify(configToStrings((editConfig?.credentials as Record<string, unknown>) ?? {})));
+    if (!editName || !originalRef.current) return false;
+    const o = originalRef.current;
     return (
-      title !== (editConfig?.title ?? "") ||
-      description !== (editConfig?.description ?? "") ||
-      JSON.stringify(config) !== JSON.stringify(configToStrings(editConfig?.config ?? {})) ||
-      credsChanged
+      title !== o.title ||
+      description !== o.description ||
+      enabled !== o.enabled ||
+      JSON.stringify(config) !== o.config ||
+      credMode !== o.credMode ||
+      selectedCredName !== o.selectedCredName ||
+      JSON.stringify(credentials) !== o.credentials
     );
   }
 
@@ -77,26 +130,16 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
     }
   }
 
-  // Keep a ref to always call the latest handleCancel without re-registering the listener
   const handleCancelRef = useRef(handleCancel);
   handleCancelRef.current = handleCancel;
 
-  // ESC dismisses the form (with confirmation if there are unsaved changes)
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape") handleCancelRef.current();
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, []); // register once on mount
-
-  function configToStrings(obj: Record<string, unknown>): Record<string, string> {
-    const result: Record<string, string> = {};
-    for (const [k, v] of Object.entries(obj)) {
-      result[k] = typeof v === "string" ? v : JSON.stringify(v);
-    }
-    return result;
-  }
+  }, []);
 
   const handleSubmit = async () => {
     setSaving(true);
@@ -122,7 +165,7 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
         await fetch(`/api/collections/${encodeURIComponent(editName)}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ title, description: description || undefined, config: parsedConfig, credentials: credsPayload }),
+          body: JSON.stringify({ title, description: description || undefined, enabled, config: parsedConfig, credentials: credsPayload }),
         });
       } else {
         const res = await fetch("/api/collections", {
@@ -149,6 +192,8 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
       setSaving(false);
     }
   };
+
+  if (loading) return <div className="loading">Loading...</div>;
 
   if (discardPrompt) {
     return (
@@ -232,6 +277,16 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
           className="form-input form-textarea"
           rows={3}
         />
+        {editName && (
+          <label className="toggle-label" style={{ marginTop: 8 }}>
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+            />
+            <span className="toggle-text">Enabled</span>
+          </label>
+        )}
       </div>
 
       <div className="form-group">
@@ -239,52 +294,51 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
         {renderConfigFields(crawler, config, setConfig)}
       </div>
 
-      <div className="form-group">
-        <h3>Credentials</h3>
-        {namedCredentials.length > 0 && (
-          <div className="cred-mode-toggle">
-            <label>
-              <input
-                type="radio"
-                name="credMode"
-                value="inline"
-                checked={credMode === "inline"}
-                onChange={() => setCredMode("inline")}
-              />
-              {" "}Enter directly
-            </label>
-            <label style={{ marginLeft: "1rem" }}>
-              <input
-                type="radio"
-                name="credMode"
-                value="named"
-                checked={credMode === "named"}
-                onChange={() => setCredMode("named")}
-              />
-              {" "}Use saved credentials
-            </label>
-          </div>
-        )}
-        {credMode === "named" ? (
-          <div>
-            <label>Credential Set</label>
-            <select
-              className="form-input"
-              value={selectedCredName}
-              onChange={(e) => setSelectedCredName(e.target.value)}
-            >
-              <option value="">Select...</option>
-              {namedCredentials.map((nc) => (
-                <option key={nc.name} value={nc.name}>
-                  {nc.name} ({nc.keys.join(", ")})
-                </option>
-              ))}
-            </select>
-          </div>
-        ) : (
-          renderCredentialFields(crawler, credentials, setCredentials)
-        )}
-      </div>
+      {!NO_CREDENTIALS_CRAWLERS.includes(crawler) && (
+        <div className="form-group">
+          <h3>Credentials</h3>
+          {namedCredentials.length > 0 && (
+            <div className="cred-mode-toggle">
+              <label>
+                <input
+                  type="radio"
+                  name="credMode"
+                  value="inline"
+                  checked={credMode === "inline"}
+                  onChange={() => setCredMode("inline")}
+                />
+                Enter directly
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="credMode"
+                  value="named"
+                  checked={credMode === "named"}
+                  onChange={() => setCredMode("named")}
+                />
+                Use saved credentials
+                {credMode === "named" && (
+                  <select
+                    className="form-input"
+                    value={selectedCredName}
+                    onChange={(e) => setSelectedCredName(e.target.value)}
+                    style={{ marginLeft: 8, minWidth: 160 }}
+                  >
+                    <option value="">Select...</option>
+                    {namedCredentials.map((nc) => (
+                      <option key={nc.name} value={nc.name}>
+                        {nc.name} ({nc.keys.join(", ")})
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </label>
+            </div>
+          )}
+          {credMode === "inline" && renderCredentialFields(crawler, credentials, setCredentials)}
+        </div>
+      )}
 
       {error && <div className="form-error">{error}</div>}
 
@@ -302,15 +356,47 @@ export default function CollectionForm({ editName, editConfig, onSave, onCancel 
   );
 }
 
+function PathField({ label, value, onChange, placeholder }: {
+  label: string; value: string; onChange: (v: string) => void; placeholder: string;
+}) {
+  const handleBrowse = async () => {
+    const path = await window.frozenink?.openDirectoryPicker();
+    if (path) onChange(path);
+  };
+
+  return (
+    <div>
+      <label>{label}</label>
+      <div className="path-field">
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="form-input"
+        />
+        {window.frozenink?.openDirectoryPicker && (
+          <button type="button" className="btn btn-sm" onClick={handleBrowse} title="Browse...">
+            ...
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function renderConfigFields(
   crawler: string,
   config: Record<string, string>,
   setConfig: (c: Record<string, string>) => void,
 ) {
   const set = (key: string, val: string) => setConfig({ ...config, [key]: val });
-  const field = (key: string, label: string, placeholder: string, type = "text") => (
+  const field = (key: string, label: string, placeholder: string, hint?: string, type = "text") => (
     <div key={key}>
-      <label>{label}</label>
+      <label>
+        {label}
+        {hint && <span className="form-label-hint"> — {hint}</span>}
+      </label>
       <input
         type={type}
         value={config[key] ?? ""}
@@ -327,8 +413,8 @@ function renderConfigFields(
         <>
           {field("owner", "Owner", "octocat")}
           {field("repo", "Repository", "hello-world")}
-          {field("maxIssues", "Max Issues", "1000", "number")}
-          {field("maxPullRequests", "Max Pull Requests", "1000", "number")}
+          {field("maxIssues", "Max Issues", "1000", undefined, "number")}
+          {field("maxPullRequests", "Max Pull Requests", "1000", undefined, "number")}
           <div>
             <label>
               <input
@@ -342,18 +428,34 @@ function renderConfigFields(
         </>
       );
     case "obsidian":
-      return field("vaultPath", "Vault Path", "/path/to/vault");
+      return (
+        <PathField
+          label="Vault Path"
+          value={config.vaultPath ?? ""}
+          onChange={(v) => set("vaultPath", v)}
+          placeholder="/path/to/vault"
+        />
+      );
     case "git":
-      return field("repoPath", "Repository Path", "/path/to/repo");
+      return (
+        <PathField
+          label="Repository Path"
+          value={config.repoPath ?? ""}
+          onChange={(v) => set("repoPath", v)}
+          placeholder="/path/to/repo"
+        />
+      );
     case "mantishub":
       return (
         <>
-          {field("baseUrl", "MantisHub URL", "https://mantis.example.com")}
-          {field("projectName", "Project Name", "My Project")}
+          {field("url", "URL", "https://mantis.example.com")}
+          {field("project", "Project", "mantisbt, plugins", "optional — comma-separated project names")}
         </>
       );
+    case "remote":
+      return field("sourceUrl", "Source URL", "https://example.workers.dev");
     default:
-      return <p>Unknown crawler type</p>;
+      return <p className="text-muted">No configuration needed.</p>;
   }
 }
 
@@ -384,6 +486,8 @@ function renderCredentialFields(
     case "obsidian":
     case "git":
       return <p className="text-muted">No credentials needed for local sources.</p>;
+    case "remote":
+      return <p className="text-muted">Credentials are inherited from the source.</p>;
     default:
       return null;
   }

--- a/packages/ui/src/components/manage/CollectionList.tsx
+++ b/packages/ui/src/components/manage/CollectionList.tsx
@@ -1,28 +1,77 @@
 import { useState, useEffect } from "react";
 import SyncProgress from "./SyncProgress";
-import { formatTimestamp, type Collection, type CollectionStatus, type SyncRun } from "../../types";
+import { formatTimestamp, type Collection, type CollectionStatus } from "../../types";
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb % 1 === 0 ? kb.toFixed(0) : kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  return `${mb % 1 < 0.05 ? mb.toFixed(0) : mb.toFixed(1)} MB`;
+}
+
+function formatCount(n: number): string {
+  return n.toLocaleString();
+}
 
 const CRAWLER_LABELS: Record<string, string> = {
   github: "GitHub",
   obsidian: "Obsidian",
   git: "Git",
   mantishub: "MantisHub",
+  remote: "Cloned",
 };
 
+function CrawlerIcon({ type }: { type: string }) {
+  const size = 14;
+  switch (type) {
+    case "github":
+      return (
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
+        </svg>
+      );
+    case "obsidian":
+      return (
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+          <path d="M19.355 18.538a68.967 68.959 0 0 0 1.858-2.954.81.81 0 0 0-.062-.9c-.516-.685-1.504-2.075-2.042-3.362-.553-1.321-.636-3.375-.64-4.377a1.707 1.707 0 0 0-.358-1.05l-3.198-4.064a3.744 3.744 0 0 1-.076.543c-.106.503-.307 1.004-.536 1.5-.134.29-.29.6-.446.914l-.31.626c-.516 1.068-.997 2.227-1.132 3.59-.124 1.26.046 2.73.815 4.481.128.011.257.025.386.044a6.363 6.363 0 0 1 3.326 1.505c.916.79 1.744 1.922 2.415 3.5zM8.199 22.569c.073.012.146.02.22.02.78.024 2.095.092 3.16.29.87.16 2.593.64 4.01 1.055 1.083.316 2.198-.548 2.355-1.664.114-.814.33-1.735.725-2.58l-.01.005c-.67-1.87-1.522-3.078-2.416-3.849a5.295 5.295 0 0 0-2.778-1.257c-1.54-.216-2.952.19-3.84.45.532 2.218.368 4.829-1.425 7.531zM5.533 9.938c-.023.1-.056.197-.098.29L2.82 16.059a1.602 1.602 0 0 0 .313 1.772l4.116 4.24c2.103-3.101 1.796-6.02.836-8.3-.728-1.73-1.832-3.081-2.55-3.831zM9.32 14.01c.615-.183 1.606-.465 2.745-.534-.683-1.725-.848-3.233-.716-4.577.154-1.552.7-2.847 1.235-3.95.113-.235.223-.454.328-.664.149-.297.288-.577.419-.86.217-.47.379-.885.46-1.27.08-.38.08-.72-.014-1.043-.095-.325-.297-.675-.68-1.06a1.6 1.6 0 0 0-1.475.36l-4.95 4.452a1.602 1.602 0 0 0-.513.952l-.427 2.83c.672.59 2.328 2.316 3.335 4.711.09.21.175.43.253.653z"/>
+        </svg>
+      );
+    case "mantishub":
+      return (
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+          <path d="M14,12H10V10H14M14,16H10V14H14M20,8H17.19C16.74,7.22 16.12,6.55 15.37,6.04L17,4.41L15.59,3L13.42,5.17C12.96,5.06 12.5,5 12,5C11.5,5 11.04,5.06 10.59,5.17L8.41,3L7,4.41L8.62,6.04C7.88,6.55 7.26,7.22 6.81,8H4V10H6.09C6.04,10.33 6,10.66 6,11V12H4V14H6V15C6,15.34 6.04,15.67 6.09,16H4V18H6.81C7.85,19.79 9.78,21 12,21C14.22,21 16.15,19.79 17.19,18H20V16H17.91C17.96,15.67 18,15.34 18,15V14H20V12H18V11C18,10.66 17.96,10.33 17.91,10H20V8Z"/>
+        </svg>
+      );
+    case "git":
+      return (
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+          <path d="M23.546 10.93L13.067.452c-.604-.603-1.582-.603-2.188 0L8.708 2.627l2.76 2.76c.645-.215 1.379-.07 1.889.441.516.515.658 1.258.438 1.9l2.658 2.66c.645-.223 1.387-.078 1.9.435.721.72.721 1.884 0 2.604-.719.719-1.881.719-2.6 0-.539-.541-.674-1.337-.404-1.996L12.86 8.955v6.525c.176.086.342.203.488.348.713.721.713 1.883 0 2.6-.719.721-1.889.721-2.609 0-.719-.719-.719-1.879 0-2.598.182-.18.387-.316.605-.406V8.835c-.217-.091-.424-.222-.6-.401-.545-.545-.676-1.342-.396-2.009L7.636 3.7.45 10.881c-.6.605-.6 1.584 0 2.189l10.48 10.477c.604.604 1.582.604 2.186 0l10.43-10.43c.605-.603.605-1.582 0-2.187"/>
+        </svg>
+      );
+    case "remote":
+      return (
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/>
+          <path d="M13 6h3a2 2 0 0 1 2 2v7"/><path d="M6 9v12"/>
+        </svg>
+      );
+    default:
+      return null;
+  }
+}
+
 interface CollectionListProps {
-  onEdit: (name: string) => void;
+  onSelect: (name: string) => void;
   onAdd: () => void;
   onSyncComplete?: () => void;
   onCollectionsChanged?: () => void;
 }
 
-export default function CollectionList({ onEdit, onAdd, onSyncComplete, onCollectionsChanged }: CollectionListProps) {
+export default function CollectionList({ onSelect, onAdd, onSyncComplete, onCollectionsChanged }: CollectionListProps) {
   const [collections, setCollections] = useState<Collection[]>([]);
   const [statuses, setStatuses] = useState<Record<string, CollectionStatus>>({});
-  const [syncHistory, setSyncHistory] = useState<Record<string, SyncRun[]>>({});
-  const [deleting, setDeleting] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
-  const [expandedHistory, setExpandedHistory] = useState<string | null>(null);
 
   const load = () => {
     fetch("/api/collections")
@@ -31,7 +80,6 @@ export default function CollectionList({ onEdit, onAdd, onSyncComplete, onCollec
         setCollections(data);
         for (const col of data) {
           loadStatus(col.name);
-          loadHistory(col.name);
         }
       })
       .catch(console.error);
@@ -46,34 +94,7 @@ export default function CollectionList({ onEdit, onAdd, onSyncComplete, onCollec
       .catch(() => {});
   };
 
-  const loadHistory = (name: string) => {
-    fetch(`/api/collections/${encodeURIComponent(name)}/sync-runs`)
-      .then((r) => r.json())
-      .then((runs: SyncRun[]) => {
-        setSyncHistory((prev) => ({ ...prev, [name]: runs }));
-      })
-      .catch(() => {});
-  };
-
   useEffect(load, []);
-
-  const handleToggle = (name: string, enabled: boolean) => {
-    fetch(`/api/collections/${encodeURIComponent(name)}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ enabled }),
-    }).then(() => { load(); onCollectionsChanged?.(); });
-  };
-
-  const handleDelete = (name: string) => {
-    if (deleting === name) {
-      fetch(`/api/collections/${encodeURIComponent(name)}`, { method: "DELETE" })
-        .then(() => { load(); onCollectionsChanged?.(); })
-        .finally(() => setDeleting(null));
-    } else {
-      setDeleting(name);
-    }
-  };
 
   const syncAll = (full: boolean) => {
     setSyncing(true);
@@ -84,22 +105,13 @@ export default function CollectionList({ onEdit, onAdd, onSyncComplete, onCollec
     }).catch(console.error);
   };
 
-  const syncOne = (name: string, full: boolean) => {
-    setSyncing(true);
-    fetch(`/api/sync/${encodeURIComponent(name)}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ full }),
-    }).catch(console.error);
-  };
-
   const handleSyncComplete = () => {
     setSyncing(false);
     for (const col of collections) {
       loadStatus(col.name);
-      loadHistory(col.name);
     }
     onSyncComplete?.();
+    onCollectionsChanged?.();
   };
 
   return (
@@ -109,9 +121,6 @@ export default function CollectionList({ onEdit, onAdd, onSyncComplete, onCollec
         <div className="sync-actions">
           <button className="btn btn-sm" onClick={() => syncAll(false)} disabled={syncing}>
             Sync All
-          </button>
-          <button className="btn btn-sm btn-secondary" onClick={() => syncAll(true)} disabled={syncing}>
-            Full Sync All
           </button>
           <button className="btn btn-primary btn-sm" onClick={onAdd}>
             + Add Collection
@@ -124,26 +133,31 @@ export default function CollectionList({ onEdit, onAdd, onSyncComplete, onCollec
       <div className="collection-cards">
         {collections.map((col) => {
           const status = statuses[col.name];
-          const runs = syncHistory[col.name] ?? [];
-          const isExpanded = expandedHistory === col.name;
           return (
-            <div key={col.name} className="collection-card">
+            <div
+              key={col.name}
+              className="collection-card collection-card-clickable"
+              onClick={() => onSelect(col.name)}
+            >
               <div className="collection-card-header">
                 <span className="collection-card-type">
+                  <CrawlerIcon type={col.crawlerType} />
                   {CRAWLER_LABELS[col.crawlerType] ?? col.crawlerType}
                 </span>
-                <label className="toggle-label">
-                  <input
-                    type="checkbox"
-                    checked={col.enabled}
-                    onChange={(e) => handleToggle(col.name, e.target.checked)}
-                  />
-                  <span className="toggle-text">Enabled</span>
-                </label>
+                <div className="collection-card-badges">
+                  {col.publish && <span className="status-badge status-completed">Published</span>}
+                  {!col.enabled && <span className="status-badge status-failed">Disabled</span>}
+                </div>
               </div>
               <h3 className="collection-card-name">{col.title || col.name}</h3>
+              {col.description && (
+                <p className="collection-card-desc">{col.description}</p>
+              )}
               <div className="collection-card-stats">
-                <span>{status?.entityCount ?? "—"} entities</span>
+                <span>{status?.entityCount != null ? formatCount(status.entityCount) : "—"} entities</span>
+                {status?.diskSizeBytes != null && status.diskSizeBytes > 0 && (
+                  <span>{formatSize(status.diskSizeBytes)}</span>
+                )}
                 {status?.lastSyncRun && (
                   <span>
                     Last sync: {formatTimestamp(status.lastSyncRun.startedAt)}
@@ -154,65 +168,6 @@ export default function CollectionList({ onEdit, onAdd, onSyncComplete, onCollec
                   </span>
                 )}
               </div>
-              <div className="collection-card-actions">
-                <button className="btn btn-sm" onClick={() => syncOne(col.name, false)} disabled={syncing}>
-                  Sync
-                </button>
-                <button className="btn btn-sm btn-secondary" onClick={() => syncOne(col.name, true)} disabled={syncing}>
-                  Full Sync
-                </button>
-                <button className="btn btn-sm" onClick={() => onEdit(col.name)}>
-                  Edit
-                </button>
-                {runs.length > 0 && (
-                  <button
-                    className={`btn btn-sm${isExpanded ? " active" : ""}`}
-                    onClick={() => setExpandedHistory(isExpanded ? null : col.name)}
-                  >
-                    History
-                  </button>
-                )}
-                <button
-                  className={`btn btn-sm btn-danger${deleting === col.name ? " confirm" : ""}`}
-                  onClick={() => handleDelete(col.name)}
-                >
-                  {deleting === col.name ? "Confirm Delete" : "Delete"}
-                </button>
-              </div>
-              {isExpanded && runs.length > 0 && (
-                <div className="collection-card-history">
-                  <table className="sync-history-table">
-                    <thead>
-                      <tr>
-                        <th>Status</th>
-                        <th>Type</th>
-                        <th>Created</th>
-                        <th>Updated</th>
-                        <th>Deleted</th>
-                        <th>Started</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {runs.slice(0, 10).map((run) => (
-                        <tr key={run.id}>
-                          <td>
-                            <span className={`status-badge status-${run.status}`}>{run.status}</span>
-                          </td>
-                          <td>
-                            <span className={`sync-type-badge sync-type-${run.syncType || "incremental"}`}>
-                              {run.syncType === "full" ? "full" : "incr"}
-                            </span>
-                          </td>
-                          <td>{run.entitiesCreated}</td>
-                          <td>{run.entitiesUpdated}</td>
-                          <td>{run.entitiesDeleted}</td>
-                          <td>{formatTimestamp(run.startedAt)}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              )}
             </div>
           );
         })}

--- a/packages/ui/src/components/manage/ManageNav.tsx
+++ b/packages/ui/src/components/manage/ManageNav.tsx
@@ -1,30 +1,11 @@
-export type ManageSection = "collections" | "publish" | "mcp" | "export" | "settings";
+export type ManageSection = "collections";
 
 interface ManageNavProps {
   active: ManageSection;
   onSelect: (section: ManageSection) => void;
 }
 
-const sections: { id: ManageSection; label: string }[] = [
-  { id: "collections", label: "Collections" },
-  { id: "publish", label: "Publish" },
-  { id: "mcp", label: "MCP" },
-  { id: "export", label: "Export" },
-  { id: "settings", label: "Settings" },
-];
-
 export default function ManageNav({ active, onSelect }: ManageNavProps) {
-  return (
-    <nav className="manage-nav">
-      {sections.map((s) => (
-        <button
-          key={s.id}
-          className={`manage-nav-item${active === s.id ? " active" : ""}`}
-          onClick={() => onSelect(s.id)}
-        >
-          {s.label}
-        </button>
-      ))}
-    </nav>
-  );
+  // Single section — no nav needed
+  return null;
 }

--- a/packages/ui/src/components/manage/PublishPanel.tsx
+++ b/packages/ui/src/components/manage/PublishPanel.tsx
@@ -1,6 +1,14 @@
 import { useState, useEffect, useRef } from "react";
 import { formatTimestamp, type Collection, type PublishProgress } from "../../types";
 
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}m ${sec}s`;
+}
+
 export default function PublishPanel() {
   const [collections, setCollections] = useState<Collection[]>([]);
 
@@ -18,6 +26,12 @@ export default function PublishPanel() {
   const [progress, setProgress] = useState<PublishProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
   const pollRef = useRef<number | null>(null);
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    if (!publishing) return;
+    const tick = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(tick);
+  }, [publishing]);
 
   useEffect(() => {
     fetch("/api/collections").then((r) => r.json()).then(setCollections).catch(() => {});
@@ -135,6 +149,9 @@ export default function PublishPanel() {
             <span className={`status-badge status-${progress.active ? "running" : progress.error ? "failed" : "completed"}`}>
               {progress.active ? "Publishing" : progress.error ? "Failed" : "Done"}
             </span>
+            {progress.startedAt != null && (
+              <span className="sync-progress-elapsed">{formatElapsed(now - progress.startedAt)}</span>
+            )}
           </div>
           <div className="sync-progress-status">{progress.detail || progress.step}</div>
           {progress.error && <div className="form-error">{progress.error}</div>}

--- a/packages/ui/src/components/manage/SettingsPanel.tsx
+++ b/packages/ui/src/components/manage/SettingsPanel.tsx
@@ -22,7 +22,7 @@ export default function SettingsPanel() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sync: config.sync,
-        logging: config.logging,
+        ui: config.ui,
       }),
     });
     setSaving(false);
@@ -49,41 +49,19 @@ export default function SettingsPanel() {
           }
           className="form-input"
         />
-        <label>Concurrency</label>
-        <input
-          type="number"
-          value={config.sync.concurrency}
-          onChange={(e) =>
-            setConfig({ ...config, sync: { ...config.sync, concurrency: Number(e.target.value) } })
-          }
-          className="form-input"
-        />
-        <label>Retries</label>
-        <input
-          type="number"
-          value={config.sync.retries}
-          onChange={(e) =>
-            setConfig({ ...config, sync: { ...config.sync, retries: Number(e.target.value) } })
-          }
-          className="form-input"
-        />
       </div>
 
       <div className="form-group">
-        <h3>Logging</h3>
-        <label>Level</label>
-        <select
-          value={config.logging.level}
+        <h3>UI</h3>
+        <label>Port</label>
+        <input
+          type="number"
+          value={config.ui.port}
           onChange={(e) =>
-            setConfig({ ...config, logging: { ...config.logging, level: e.target.value } })
+            setConfig({ ...config, ui: { ...config.ui, port: Number(e.target.value) } })
           }
           className="form-input"
-        >
-          <option value="debug">Debug</option>
-          <option value="info">Info</option>
-          <option value="warn">Warn</option>
-          <option value="error">Error</option>
-        </select>
+        />
       </div>
 
       <div className="form-actions">

--- a/packages/ui/src/components/manage/SyncProgress.tsx
+++ b/packages/ui/src/components/manage/SyncProgress.tsx
@@ -1,8 +1,15 @@
 import { useState, useEffect, useRef } from "react";
 import type { SyncProgress as SyncProgressType } from "../../types";
 
+export interface SyncResult {
+  created: number;
+  updated: number;
+  deleted: number;
+  error: string | null;
+}
+
 interface SyncProgressProps {
-  onComplete: () => void;
+  onComplete: (result: SyncResult) => void;
 }
 
 export default function SyncProgress({ onComplete }: SyncProgressProps) {
@@ -17,7 +24,12 @@ export default function SyncProgress({ onComplete }: SyncProgressProps) {
           setProgress(data);
           if (!data.active) {
             if (intervalRef.current) clearInterval(intervalRef.current);
-            onComplete();
+            onComplete({
+              created: data.created,
+              updated: data.updated,
+              deleted: data.deleted,
+              error: data.error,
+            });
           }
         })
         .catch(() => {});

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -75,6 +75,7 @@ export interface AppInfo {
 
 export interface CollectionStatus {
   entityCount: number;
+  diskSizeBytes: number;
   lastSyncRun: SyncRun | null;
 }
 
@@ -133,8 +134,8 @@ export interface CollectionConfig {
 }
 
 export interface FrozenInkConfig {
-  sync: { interval: number; concurrency: number; retries: number };
-  logging: { level: string };
+  sync: { interval: number };
+  ui: { port: number };
   [key: string]: unknown;
 }
 

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -120,6 +120,7 @@ export interface PublishProgress {
   step: string;
   detail: string;
   error: string | null;
+  startedAt: number | null;
 }
 
 export type UIMode = "browse" | "manage";

--- a/packages/website/src/docs/cli-reference.ts
+++ b/packages/website/src/docs/cli-reference.ts
@@ -29,7 +29,6 @@ export const cliReferencePage = renderDocsPage({
     { id: "cmd-publish", title: "publish", indent: true },
     { id: "cmd-unpublish", title: "unpublish", indent: true },
     { id: "cmd-clone", title: "clone", indent: true },
-    { id: "cmd-pull", title: "pull", indent: true },
     { id: "mcp-commands", title: "MCP" },
     { id: "cmd-mcp", title: "mcp", indent: true },
     { id: "other", title: "Other" },
@@ -158,16 +157,20 @@ fink update my-issues <span class="flag">--token</span> ghp_newToken</code></pre
   <h2 id="syncing">Syncing &amp; Indexing</h2>
 
   <h3 id="cmd-sync"><code>fink sync &lt;collection&gt;</code></h3>
-  <p>Synchronize one or more collections with their data sources. Sync is incremental by default.</p>
+  <p>Synchronize one or more collections with their data sources. Works for both local collections (GitHub, Obsidian, Git, MantisHub) and cloned/remote collections. Sync is incremental by default.</p>
   <pre><code><span class="cmt"># Sync a single collection</span>
 fink sync my-vault
 
-<span class="cmt"># Sync all enabled collections</span>
-fink sync "*"</code></pre>
+<span class="cmt"># Sync all enabled collections (including cloned ones)</span>
+fink sync "*"
+
+<span class="cmt"># Preview changes for a cloned collection</span>
+fink sync team-kb <span class="flag">--dry-run</span></code></pre>
   <table>
     <thead><tr><th>Option</th><th>Description</th></tr></thead>
     <tbody>
       <tr><td><code>--full</code></td><td>Force a full sync (ignore cursor, re-fetch everything)</td></tr>
+      <tr><td><code>--dry-run</code></td><td>Show sync plan without making changes (cloned collections only)</td></tr>
       <tr><td><code>--max &lt;count&gt;</code></td><td>Maximum entities to sync in this run</td></tr>
     </tbody>
   </table>
@@ -212,7 +215,7 @@ fink tui    <span class="cmt"># explicit</span></code></pre>
   <pre><code>fink unpublish my-vault</code></pre>
 
   <h3 id="cmd-clone"><code>fink clone &lt;url&gt;</code></h3>
-  <p>Clone a published collection to your local machine. See <a href="/docs/clone-pull">Clone &amp; Pull</a> for details.</p>
+  <p>Clone a published collection to your local machine. After cloning, use <code>fink sync</code> to keep it up to date. See <a href="/docs/clone-pull">Cloning</a> for details.</p>
   <pre><code>fink clone https://my-vault.example.workers.dev <span class="flag">--password</span> secret123</code></pre>
   <table>
     <thead><tr><th>Option</th><th>Description</th></tr></thead>
@@ -220,16 +223,6 @@ fink tui    <span class="cmt"># explicit</span></code></pre>
       <tr><td><code>--name &lt;name&gt;</code></td><td>Local collection name (defaults to remote name)</td></tr>
       <tr><td><code>--password &lt;password&gt;</code></td><td>Password for the published site</td></tr>
       <tr><td><code>--dry-run</code></td><td>Preview without downloading</td></tr>
-    </tbody>
-  </table>
-
-  <h3 id="cmd-pull"><code>fink pull &lt;collection&gt;</code></h3>
-  <p>Pull updates from a remote published site into a cloned collection.</p>
-  <pre><code>fink pull my-vault</code></pre>
-  <table>
-    <thead><tr><th>Option</th><th>Description</th></tr></thead>
-    <tbody>
-      <tr><td><code>--dry-run</code></td><td>Show what would change without applying</td></tr>
     </tbody>
   </table>
 

--- a/packages/website/src/docs/clone-pull.ts
+++ b/packages/website/src/docs/clone-pull.ts
@@ -1,9 +1,9 @@
 import { renderDocsPage } from "./layout";
 
 export const clonePullPage = renderDocsPage({
-  title: "Clone & Pull",
+  title: "Cloning",
   description:
-    "Clone a published Frozen Ink collection to your machine and keep it up to date with fink pull.",
+    "Clone a published Frozen Ink collection to your machine and keep it up to date with fink sync.",
   activePath: "/docs/clone-pull",
   canonicalPath: "/docs/clone-pull",
   section: "Features",
@@ -11,8 +11,8 @@ export const clonePullPage = renderDocsPage({
     { id: "overview", title: "Overview" },
     { id: "cloning", title: "Cloning a collection" },
     { id: "clone-options", title: "Clone options", indent: true },
-    { id: "pulling", title: "Pulling updates" },
-    { id: "pull-options", title: "Pull options", indent: true },
+    { id: "syncing", title: "Syncing updates" },
+    { id: "sync-options", title: "Sync options", indent: true },
     { id: "how-it-works", title: "How it works" },
     { id: "example-workflow", title: "Example workflow" },
     { id: "differences", title: "Cloned vs. local collections" },
@@ -23,11 +23,11 @@ export const clonePullPage = renderDocsPage({
     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
     <span>Features</span>
     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
-    <span>Clone &amp; Pull</span>
+    <span>Cloning</span>
   </div>
 
-  <h1 class="page-title">Clone &amp; Pull</h1>
-  <p class="page-lead">Published Frozen Ink collections can be cloned to another machine for local, offline access. Once cloned, use <code>fink pull</code> to fetch updates — no API tokens or source credentials needed.</p>
+  <h1 class="page-title">Cloning</h1>
+  <p class="page-lead">Published Frozen Ink collections can be cloned to another machine for local, offline access. Once cloned, use <code>fink sync</code> to fetch updates — no API tokens or source credentials needed.</p>
 
   <h2 id="overview">Overview</h2>
   <p>When you <a href="/docs/publishing">publish a collection</a> to Cloudflare, anyone with the URL and password can browse it in a browser. <strong>Cloning</strong> takes this a step further: it downloads the entire published collection to your local <code>~/.frozenink/</code> directory, creating a fully functional local copy you can search, browse, and query via MCP — just like a locally created collection.</p>
@@ -41,7 +41,7 @@ export const clonePullPage = renderDocsPage({
     <div class="feature-card">
       <div class="feature-card-icon">🔄</div>
       <h4>Incremental Updates</h4>
-      <p><code>fink pull</code> fetches only what's changed — added, updated, or deleted entities — keeping your local copy in sync efficiently.</p>
+      <p><code>fink sync</code> fetches only what's changed — added, updated, or deleted entities — keeping your local copy in sync efficiently.</p>
     </div>
   </div>
 
@@ -77,21 +77,23 @@ export const clonePullPage = renderDocsPage({
     </tbody>
   </table>
 
-  <h2 id="pulling">Pulling updates</h2>
-  <p>After cloning, use <code>fink pull</code> to fetch any changes that have been published since your last clone or pull:</p>
+  <h2 id="syncing">Syncing updates</h2>
+  <p>After cloning, use <code>fink sync</code> to fetch any changes that have been published since your last clone or sync:</p>
 
-  <pre><code>fink pull my-vault</code></pre>
+  <pre><code>fink sync my-vault</code></pre>
 
-  <p>The pull command compares your local data with the remote and applies only the differences:</p>
+  <p>The sync command compares your local data with the remote and applies only the differences:</p>
   <ul>
     <li><strong>Added entities</strong> — downloaded and inserted into the local database</li>
     <li><strong>Updated entities</strong> — local copies replaced with the newer version</li>
     <li><strong>Deleted entities</strong> — removed from the local database and filesystem</li>
   </ul>
 
-  <p>If there are no changes, <code>fink pull</code> reports "Already up to date" and exits.</p>
+  <p>If there are no changes, <code>fink sync</code> reports "Already up to date" and exits.</p>
 
-  <h3 id="pull-options">Pull options</h3>
+  <p>Cloned collections work seamlessly with <code>fink sync "*"</code>, which syncs all collections — both local and cloned — in a single command.</p>
+
+  <h3 id="sync-options">Sync options</h3>
   <table>
     <thead>
       <tr><th>Option</th><th>Description</th></tr>
@@ -112,14 +114,14 @@ fink publish my-github-issues <span class="flag">--password</span> secret123
 fink clone https://my-github-issues.example.workers.dev \
   <span class="flag">--password</span> secret123
 
-<span class="cmt"># Later — pull updates after the work machine re-syncs and re-publishes</span>
-fink pull my-github-issues</code></pre>
+<span class="cmt"># Later — sync updates after the work machine re-syncs and re-publishes</span>
+fink sync my-github-issues</code></pre>
 
   <div class="callout callout-info">
     <div class="callout-icon">ℹ️</div>
     <div class="callout-body">
       <strong>Re-publish to share updates</strong>
-      <p>Cloned collections pull from the <em>published</em> version, not directly from the original source. To make new data available for pulling, sync locally and re-publish on the source machine: <code>fink sync my-collection && fink publish my-collection</code>.</p>
+      <p>Cloned collections sync from the <em>published</em> version, not directly from the original source. To make new data available, sync locally and re-publish on the source machine: <code>fink sync my-collection && fink publish my-collection</code>.</p>
     </div>
   </div>
 
@@ -133,7 +135,7 @@ fink pull my-github-issues</code></pre>
     <tbody>
       <tr><td>Created with</td><td><code>fink add</code></td><td><code>fink clone</code></td></tr>
       <tr><td>Data source</td><td>Direct (GitHub API, local vault, etc.)</td><td>Published Frozen Ink site</td></tr>
-      <tr><td>Update command</td><td><code>fink sync</code></td><td><code>fink pull</code></td></tr>
+      <tr><td>Update command</td><td><code>fink sync</code></td><td><code>fink sync</code></td></tr>
       <tr><td>Requires source credentials</td><td>Yes</td><td>No (only site password)</td></tr>
       <tr><td>Can be published</td><td>Yes</td><td>Yes</td></tr>
       <tr><td>MCP access</td><td>Yes</td><td>Yes</td></tr>

--- a/packages/website/src/docs/getting-started.ts
+++ b/packages/website/src/docs/getting-started.ts
@@ -86,7 +86,7 @@ fink sync "*"</code></pre>
     <div class="callout-icon">ℹ️</div>
     <div class="callout-body">
       <strong>Alternative: clone a published collection</strong>
-      <p>If someone has already published a Frozen Ink collection, you can skip <code>fink add</code> and <code>fink sync</code> entirely. Just clone it directly: <code>fink clone https://their-site.workers.dev --password secret</code>. See <a href="/docs/clone-pull">Clone &amp; Pull</a> for details.</p>
+      <p>If someone has already published a Frozen Ink collection, you can skip <code>fink add</code> and <code>fink sync</code> entirely. Just clone it directly: <code>fink clone https://their-site.workers.dev --password secret</code>. See <a href="/docs/clone-pull">Cloning</a> for details.</p>
     </div>
   </div>
 

--- a/packages/website/src/docs/key-scenarios.ts
+++ b/packages/website/src/docs/key-scenarios.ts
@@ -134,12 +134,12 @@ fink publish my-vault <span class="flag">--password</span> secure-secret</code><
       <div class="step-body">
         <h4>Users can keep their clones in sync</h4>
         <p>When you re-sync and re-publish, everyone pulls the latest changes incrementally:</p>
-        <pre><code>fink pull my-vault</code></pre>
+        <pre><code>fink sync my-vault</code></pre>
       </div>
     </div>
   </div>
 
-  <p>Cloned collections are fully functional — searchable, browsable, and available to MCP clients. No source credentials needed. See <a href="/docs/clone-pull">Clone &amp; Pull</a> for the full guide.</p>
+  <p>Cloned collections are fully functional — searchable, browsable, and available to MCP clients. No source credentials needed. See <a href="/docs/clone-pull">Cloning</a> for the full guide.</p>
 
   <h2 id="local-ai">Local AI assistant context</h2>
   <p><strong>Situation:</strong> You use an MCP-enabled coding assistant (for example Claude Code or Codex CLI). When working on a feature, you want instant access to your project's GitHub issues, git history, and design notes — without manually pasting content into every conversation.</p>

--- a/packages/website/src/docs/layout.ts
+++ b/packages/website/src/docs/layout.ts
@@ -29,7 +29,7 @@ const NAV_SECTIONS = [
     title: "Features",
     items: [
       { label: "Managing Collections", href: "/docs/collections" },
-      { label: "Clone & Pull", href: "/docs/clone-pull" },
+      { label: "Cloning", href: "/docs/clone-pull" },
       { label: "Publishing", href: "/docs/publishing" },
     ],
   },

--- a/packages/website/src/docs/layout.ts
+++ b/packages/website/src/docs/layout.ts
@@ -781,7 +781,7 @@ export function renderDocsPage(opts: DocsPageOptions): string {
       <li><a href="/#connectors">Connectors</a></li>
       <li><a href="/docs/what-is-frozen-ink" class="active">Docs</a></li>
       <li class="nav-social">
-        <a href="https://github.com/vboctor/frozenink" target="_blank" rel="noopener" aria-label="GitHub" class="nav-icon-link">
+        <a href="https://github.com/vboctor/frozen-ink" target="_blank" rel="noopener" aria-label="GitHub" class="nav-icon-link">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.341-3.369-1.341-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>
         </a>
         <a href="https://x.com/vboctor" target="_blank" rel="noopener" aria-label="X (Twitter)" class="nav-icon-link">

--- a/packages/website/src/site.html
+++ b/packages/website/src/site.html
@@ -584,7 +584,7 @@
       <li><a href="#connectors">Connectors</a></li>
       <li><a href="/docs/what-is-frozen-ink">Docs</a></li>
       <li class="nav-social">
-        <a href="https://github.com/vboctor/frozenink" target="_blank" rel="noopener" aria-label="GitHub" class="nav-icon-link">
+        <a href="https://github.com/vboctor/frozen-ink" target="_blank" rel="noopener" aria-label="GitHub" class="nav-icon-link">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.341-3.369-1.341-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>
         </a>
         <a href="https://x.com/vboctor" target="_blank" rel="noopener" aria-label="X (Twitter)" class="nav-icon-link">

--- a/packages/website/website.md
+++ b/packages/website/website.md
@@ -48,7 +48,7 @@ packages/website/src/
 The sidebar nav is defined in `NAV_SECTIONS` in `layout.ts`. The canonical page order is:
 
 1. **Overview**: What is Frozen Ink?, Key Scenarios, Getting Started
-2. **Features**: Managing Collections, Clone & Pull, Publishing
+2. **Features**: Managing Collections, Cloning, Publishing
 3. **Connectors**: GitHub, Obsidian, Git, MantisHub
 4. **AI Integrations**: Local MCP Setup, Cloud MCP Access, Claude Code, Claude Cowork, Claude Desktop, Codex CLI, ChatGPT Desktop
 5. **Reference**: CLI Reference, Configuration


### PR DESCRIPTION
## Summary

- **Unified `fink sync` / `fink pull`:** removed `fink pull` and made `fink sync` handle both local crawlers and cloned/remote collections. Desktop UI now syncs cloned collections (previously a no-op). Prepare step no longer auto-regenerates markdown — it warns and prints the exact `fink generate` command instead.
- **MantisHub incremental sync rewrite:** lightweight scan (`select=id,updated_at&page_size=100`) with early-stop once a page has no matches against `updatedSince`, then fetch full data only for updated issues. Reconcile no longer re-renders every entity (which was essentially running `generate`); entity markdown is written during the sync loop, and missing files are restored on demand via a cheap existence check in `upsertEntity`.
- **Granular progress reporting:** new `Crawler.setProgressCallback` wired through `SyncEngine` → management API → CLI, TUI, and a new browse-mode sync button in the desktop UI. Sync messages now describe what's happening (scanning, fetching specific issues, fetching users, orphan cleanup).
- **Desktop browse-mode sync button:** circular-arrow icon in the browse toolbar (hidden in published mode). Opens a modal with live progress and final results.
- **Persistent sync results:** `CollectionDetail` now shows the final `X created, Y updated, Z deleted — Last sync: …` below the sync buttons after completion, instead of hiding the progress panel.
- **Fix stale Cloudflare token on republish:** `getCredentials()` cached the OAuth token for the desktop app's lifetime; tokens expire after ~1 hour. All R2/D1 API calls now invalidate and re-read on 401 with a clearer error message.
- **Publish elapsed time in desktop UI:** `PublishProgress` carries a `startedAt` timestamp; desktop UI ticks a live elapsed clock next to the status badge, matching the TUI.
- **Diagnostics:** credential fingerprint (first 4 chars + length), credential source path, and MantisBT 401/403-specific hints in error messages.

## Test plan

- [ ] `bun run ci` passes (markdownlint, typecheck, 128 + 199 + 58 bun tests, 27 vitest tests, UI build, worker build)
- [ ] `fink sync <local-collection>` works
- [ ] `fink sync <cloned-collection>` works (was previously rejected)
- [ ] `fink sync "*"` syncs local and cloned collections in one run
- [ ] `fink pull` no longer exists
- [ ] Desktop UI `Sync` button works for cloned collections
- [ ] Desktop UI browse-mode sync icon triggers incremental sync, shows progress + results
- [ ] MantisHub incremental sync picks up new issues quickly and does not run the equivalent of `generate`
- [ ] Republish in desktop app after OAuth token expiry recovers without restart
- [ ] Desktop publish progress shows live elapsed time

🤖 Generated with [Claude Code](https://claude.com/claude-code)