### PR TITLE
Incremental D1 publish via remote manifest diff

### DIFF
--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -409,10 +409,22 @@ export function handleManagementRequest(req: Request): Response | null {
   if (unpublishColMatch && method === "POST") {
     const name = decodeURIComponent(unpublishColMatch[1]);
     return handleAsync(async () => {
-      const { unpublishCollection } = await import("./unpublish");
-      await unpublishCollection(name, (step, detail) => {
-        console.log(`  [unpublish:${step}] ${detail}`);
-      });
+      // Fire-and-forget so the UI can poll /api/publish/status (which is
+      // shared between publish and unpublish — only one runs at a time).
+      publishProgress = { active: true, step: "starting", detail: `Unpublishing "${name}"...`, error: null, startedAt: Date.now() };
+      void (async () => {
+        const startedAt = publishProgress.startedAt ?? Date.now();
+        try {
+          const { unpublishCollection } = await import("./unpublish");
+          await unpublishCollection(name, (step, detail) => {
+            console.log(`  [unpublish:${step}] ${detail}`);
+            publishProgress = { ...publishProgress, step, detail };
+          });
+          publishProgress = { active: false, step: "done", detail: `Unpublished "${name}"`, error: null, startedAt };
+        } catch (err) {
+          publishProgress = { active: false, step: "failed", detail: "", error: String(err), startedAt };
+        }
+      })();
       return jsonResponse({ ok: true });
     });
   }

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -464,15 +464,22 @@ export async function publishCollections(
       contentHash: entity.contentHash ?? null,
     }));
     const plan = computeSyncPlan(localForPlan, remoteManifest);
-    const changedExtIds = [
-      ...plan.entities.add.map((e) => e.externalId),
+    // Invert pull semantics into push semantics: computeSyncPlan returns
+    //   add    = remote-only (pull would download these)
+    //   update = both, hash differs
+    //   delete = local-only (pull would remove these locally)
+    // For publish we instead need:
+    //   push:   local-only + hash-differs   → INSERT OR REPLACE on remote
+    //   prune:  remote-only                 → DELETE on remote
+    const pushExtIds = [
+      ...plan.entities.delete,
       ...plan.entities.update.map((e) => e.externalId),
     ];
-    const deletedExtIds = plan.entities.delete;
+    const pruneExtIds = plan.entities.add.map((e) => e.externalId);
 
     onProgress(
       "d1-build",
-      `Incremental plan: +${plan.entities.add.length} ~${plan.entities.update.length} -${deletedExtIds.length}`,
+      `Incremental plan: +${plan.entities.delete.length} ~${plan.entities.update.length} -${pruneExtIds.length}`,
     );
 
     // Build delta SQL.
@@ -481,27 +488,30 @@ export async function publishCollections(
     // Chunk IN(...) lists so each DELETE statement stays under MAX_BATCH_BYTES.
     const DELETE_CHUNK = 200;
 
-    // Deletes: drop FTS rows first (no cascade), then entities rows.
-    for (let i = 0; i < deletedExtIds.length; i += DELETE_CHUNK) {
-      const chunk = deletedExtIds.slice(i, i + DELETE_CHUNK);
+    // Prune entries that exist remotely but not locally — drop FTS rows
+    // first (no cascade), then entities rows.
+    for (let i = 0; i < pruneExtIds.length; i += DELETE_CHUNK) {
+      const chunk = pruneExtIds.slice(i, i + DELETE_CHUNK);
       const inList = chunk.map((id) => `'${escapeSQL(id)}'`).join(",");
       deltaSql.push(`DELETE FROM entities_fts WHERE external_id IN (${inList});`);
       deltaSql.push(`DELETE FROM entities WHERE external_id IN (${inList});`);
     }
 
-    if (changedExtIds.length > 0) {
-      // Pre-delete FTS rows for changed entities. FTS5 has no UNIQUE constraint
-      // on external_id, so INSERT OR REPLACE wouldn't dedupe — explicit DELETE
-      // is required before the INSERT below.
-      for (let i = 0; i < changedExtIds.length; i += DELETE_CHUNK) {
-        const chunk = changedExtIds.slice(i, i + DELETE_CHUNK);
+    if (pushExtIds.length > 0) {
+      // Pre-delete FTS and entity rows for pushed entities. Neither table has
+      // a UNIQUE constraint on external_id (entities.id is the only PK), so
+      // INSERT OR REPLACE wouldn't dedupe — explicit DELETE is required
+      // before the INSERTs below to avoid leaving stale duplicates.
+      for (let i = 0; i < pushExtIds.length; i += DELETE_CHUNK) {
+        const chunk = pushExtIds.slice(i, i + DELETE_CHUNK);
         const inList = chunk.map((id) => `'${escapeSQL(id)}'`).join(",");
         deltaSql.push(`DELETE FROM entities_fts WHERE external_id IN (${inList});`);
+        deltaSql.push(`DELETE FROM entities WHERE external_id IN (${inList});`);
       }
 
-      const changedSet = new Set(changedExtIds);
+      const pushSet = new Set(pushExtIds);
       for (const { entity, colName, colCrawler } of localRows) {
-        if (!changedSet.has(entity.externalId)) continue;
+        if (!pushSet.has(entity.externalId)) continue;
 
         const data = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
         if (Buffer.byteLength(data, "utf8") > MAX_ENTITY_DATA_BYTES) {

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -437,8 +437,10 @@ export async function publishCollections(
     // Read all local entities once.
     const themeEngine = createGenerateThemeEngine();
     const MAX_FTS_CONTENT = 8000;
-    // D1's per-statement SQL length limit is ~100-128 KB. Skip entities whose
-    // serialized data alone exceeds this — their INSERT would fail SQLITE_TOOBIG.
+    // D1's per-statement SQL length limit is ~100-128 KB. Entities whose
+    // serialized data alone exceeds this can never be pushed — their INSERT
+    // would fail SQLITE_TOOBIG. Filter them out of the plan entirely so they
+    // don't keep showing up as "+1 to push" forever on every re-publish.
     const MAX_ENTITY_DATA_BYTES = 80 * 1024;
     let skippedTooLarge = 0;
 
@@ -452,8 +454,19 @@ export async function publishCollections(
       const colDef = getCollection(colName)!;
       const colDb = getCollectionDb(getCollectionDbPath(colName));
       for (const entity of colDb.select().from(entities).all()) {
+        const dataStr = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
+        if (Buffer.byteLength(dataStr, "utf8") > MAX_ENTITY_DATA_BYTES) {
+          skippedTooLarge++;
+          continue;
+        }
         localRows.push({ entity, colName, colCrawler: colDef.crawler });
       }
+    }
+    if (skippedTooLarge > 0) {
+      onProgress(
+        "d1-build",
+        `Skipped ${skippedTooLarge} oversized entit${skippedTooLarge === 1 ? "y" : "ies"} (data > ${MAX_ENTITY_DATA_BYTES / 1024} KB)`,
+      );
     }
 
     const localForPlan: LocalEntity[] = localRows.map(({ entity }) => ({
@@ -514,10 +527,6 @@ export async function publishCollections(
         if (!pushSet.has(entity.externalId)) continue;
 
         const data = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
-        if (Buffer.byteLength(data, "utf8") > MAX_ENTITY_DATA_BYTES) {
-          skippedTooLarge++;
-          continue;
-        }
         const folderVal = entity.folder != null ? `'${escapeSQL(entity.folder)}'` : "NULL";
         const slugVal = entity.slug != null ? `'${escapeSQL(entity.slug)}'` : "NULL";
 
@@ -547,10 +556,6 @@ export async function publishCollections(
 
         deltaSql.push(`INSERT INTO entities_fts (entity_id, external_id, entity_type, title, content, tags) VALUES (${ftsEntityIdFor(entity.externalId)}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(ftsContent)}', '${escapeSQL(entityTagNames)}');`);
       }
-    }
-
-    if (skippedTooLarge > 0) {
-      onProgress("d1-build", `Skipped ${skippedTooLarge} oversized entit${skippedTooLarge === 1 ? "y" : "ies"} (data > ${MAX_ENTITY_DATA_BYTES / 1024} KB)`);
     }
 
     if (deltaSql.length === 0) {

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { existsSync, readdirSync, statSync } from "fs";
 import { join, extname } from "path";
 import { createInterface } from "readline";
 import {
@@ -25,6 +25,8 @@ import type { EntityData } from "@frozenink/core";
 const __moduleDir = getModuleDir(import.meta.url);
 import { assertInitialPublishConfirmation } from "./publish-policy";
 import { createGenerateThemeEngine } from "./generate";
+import { RemoteClient } from "./remote-client";
+import { computeSyncPlan, type LocalEntity, type ManifestEntity } from "./sync-plan";
 
 function randomSuffix(): string {
   return Math.random().toString(36).slice(2, 8);
@@ -67,23 +69,16 @@ function getMimeType(filePath: string): string {
   return MIME_TYPES[extname(filePath).toLowerCase()] || "application/octet-stream";
 }
 
-async function hashDbFiles(dbPath: string): Promise<string> {
-  const files = [dbPath, `${dbPath}-wal`, `${dbPath}-shm`];
-  const chunks: Uint8Array[] = [];
-  for (const file of files) {
-    if (existsSync(file)) chunks.push(readFileSync(file));
+// FNV-1a 32-bit. The published FTS5 schema declares `entity_id UNINDEXED` as
+// the first column; it's only echoed back to clients (used as a React key in
+// the search UI) and not joined against `entities.id`. A deterministic hash
+// of external_id is enough — uniqueness within a result set is what matters.
+function ftsEntityIdFor(externalId: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < externalId.length; i++) {
+    h = Math.imul(h ^ externalId.charCodeAt(i), 16777619);
   }
-  const total = chunks.reduce((n, c) => n + c.length, 0);
-  const combined = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.length;
-  }
-  const hashBuf = await crypto.subtle.digest("SHA-256", combined);
-  return Array.from(new Uint8Array(hashBuf))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+  return h >>> 0;
 }
 
 async function runConcurrent<T>(
@@ -174,7 +169,6 @@ export async function publishCollections(
     createR2Bucket,
     putR2Object,
     putR2String,
-    getR2String,
     deleteR2Objects,
     listR2Objects,
     deployWorker,
@@ -368,7 +362,7 @@ export async function publishCollections(
     if (isUpdate) {
       const allKeys = new Set(fileSizes.keys());
       try {
-        const staleKeys = [...existingR2Objects.keys()].filter((key) => !allKeys.has(key) && !key.endsWith("/db-digest"));
+        const staleKeys = [...existingR2Objects.keys()].filter((key) => !allKeys.has(key));
         if (staleKeys.length > 0) {
           onProgress("r2-cleanup", `Removing ${staleKeys.length} stale file(s)...`);
           await deleteR2Objects(r2BucketName, staleKeys);
@@ -386,38 +380,16 @@ export async function publishCollections(
     onProgress("r2-upload", `${parts.join(", ")} out of ${totalFiles} total`);
   }
 
-  // --- Phase 3: D1 rebuild (destructive — done last to minimize downtime) ---
+  // --- Phase 3: D1 incremental update (manifest-driven delta) ---
 
-  let dbDigest = "";
   if (!workerOnly) {
-    const dbPath = getCollectionDbPath(collectionName);
+    onProgress("d1-build", "Computing incremental plan...");
 
-    // Run migration before hashing so the digest reflects the post-migration schema.
-    // If folder/slug columns were just added (backfilled from data.markdown_path),
-    // the DB content changes and won't match the pre-migration remote digest,
-    // forcing a full D1 rebuild with the correct schema.
-    const colDbForDigest = getCollectionDb(dbPath);
-    dbDigest = await hashDbFiles(dbPath);
-
-    let remoteDigest: string | null = null;
-    if (isUpdate) {
-      try {
-        remoteDigest = await getR2String(r2BucketName, `${collectionName}/db-digest`);
-      } catch { /* ignore — treat as no digest */ }
-    }
-    const skipD1 = isUpdate && remoteDigest === dbDigest;
-
-    if (skipD1) {
-      onProgress("d1-build", `Database unchanged (digest match) — skipping D1 rebuild`);
-    } else {
-      onProgress("d1-build", "Building D1 payload...");
-      const schemaSql: string[] = [];
-
-      schemaSql.push("DROP TABLE IF EXISTS entities_fts;");
-      schemaSql.push("DROP TABLE IF EXISTS entities;");
-      schemaSql.push("DROP TABLE IF EXISTS collections_meta;");
-      schemaSql.push("");
-      schemaSql.push(`CREATE TABLE entities (
+    // Ensure schema exists. Idempotent so first publish creates tables and
+    // re-publish is a no-op. No DROPs — the manifest-driven delta below
+    // brings D1 in sync without wiping it.
+    const schemaInit: string[] = [];
+    schemaInit.push(`CREATE TABLE IF NOT EXISTS entities (
   id INTEGER PRIMARY KEY,
   external_id TEXT NOT NULL, entity_type TEXT NOT NULL,
   title TEXT NOT NULL, data TEXT NOT NULL DEFAULT '{}',
@@ -427,82 +399,148 @@ export async function publishCollections(
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );`);
-      schemaSql.push("CREATE INDEX idx_entities_external ON entities(external_id);");
-      schemaSql.push("CREATE INDEX idx_entities_folder   ON entities(folder, slug);");
-      schemaSql.push("CREATE INDEX idx_entities_type     ON entities(entity_type);");
-      schemaSql.push("CREATE INDEX idx_entities_updated  ON entities(updated_at);");
-      schemaSql.push("CREATE VIRTUAL TABLE entities_fts USING fts5(entity_id UNINDEXED, external_id UNINDEXED, entity_type UNINDEXED, title, content, tags);");
-      schemaSql.push("");
+    schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_external ON entities(external_id);");
+    schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_folder   ON entities(folder, slug);");
+    schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_type     ON entities(entity_type);");
+    schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_updated  ON entities(updated_at);");
+    schemaInit.push("CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(entity_id UNINDEXED, external_id UNINDEXED, entity_type UNINDEXED, title, content, tags);");
+    await executeD1Query(d1DatabaseId, schemaInit.join("\n"));
 
-      const themeEngine = createGenerateThemeEngine();
-      const MAX_FTS_CONTENT = 8000;
+    // Fetch remote manifest (empty on first publish). Manifest endpoint is
+    // behind authMiddleware when PASSWORD_HASH is set; pass the plaintext
+    // password so the request authenticates against the worker we just deployed.
+    let remoteManifest: ManifestEntity[] = [];
+    if (isUpdate) {
+      try {
+        const client = new RemoteClient(workerUrl, plaintextPassword || undefined);
+        const { entries } = await client.getManifest();
+        remoteManifest = entries;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        onProgress("d1-build", `Could not fetch remote manifest (${msg}); treating as empty`);
+      }
+    }
 
-      let entityIdOffset = 0;
+    // Read all local entities once.
+    const themeEngine = createGenerateThemeEngine();
+    const MAX_FTS_CONTENT = 8000;
+    // D1's per-statement SQL length limit is ~100-128 KB. Skip entities whose
+    // serialized data alone exceeds this — their INSERT would fail SQLITE_TOOBIG.
+    const MAX_ENTITY_DATA_BYTES = 80 * 1024;
+    let skippedTooLarge = 0;
 
-      // D1's per-statement SQL length limit appears to be ~100-128 KB. Skip
-      // entities whose serialized data alone exceeds this, since their INSERT
-      // would fail SQLITE_TOOBIG even as a single-statement batch.
-      const MAX_ENTITY_DATA_BYTES = 80 * 1024;
-      let skippedTooLarge = 0;
+    type LocalRow = {
+      entity: typeof entities.$inferSelect;
+      colName: string;
+      colCrawler: string;
+    };
+    const localRows: LocalRow[] = [];
+    for (const colName of collectionNames) {
+      const colDef = getCollection(colName)!;
+      const colDb = getCollectionDb(getCollectionDbPath(colName));
+      for (const entity of colDb.select().from(entities).all()) {
+        localRows.push({ entity, colName, colCrawler: colDef.crawler });
+      }
+    }
 
-      for (const colName of collectionNames) {
-        const col = getCollection(colName)!;
-        const colDb = colName === collectionName ? colDbForDigest : getCollectionDb(getCollectionDbPath(colName));
+    const localForPlan: LocalEntity[] = localRows.map(({ entity }) => ({
+      externalId: entity.externalId,
+      entityType: entity.entityType,
+      title: entity.title,
+      data: entity.data as unknown as Record<string, unknown> | string,
+      contentHash: entity.contentHash ?? null,
+    }));
+    const plan = computeSyncPlan(localForPlan, remoteManifest);
+    const changedExtIds = [
+      ...plan.entities.add.map((e) => e.externalId),
+      ...plan.entities.update.map((e) => e.externalId),
+    ];
+    const deletedExtIds = plan.entities.delete;
 
-        const allEntities = colDb.select().from(entities).all();
+    onProgress(
+      "d1-build",
+      `Incremental plan: +${plan.entities.add.length} ~${plan.entities.update.length} -${deletedExtIds.length}`,
+    );
 
-        for (const entity of allEntities) {
-          const data = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
-          if (Buffer.byteLength(data, "utf8") > MAX_ENTITY_DATA_BYTES) {
-            skippedTooLarge++;
-            continue;
-          }
-          entityIdOffset++;
-          const folderVal = entity.folder != null ? `'${escapeSQL(entity.folder)}'` : "NULL";
-          const slugVal = entity.slug != null ? `'${escapeSQL(entity.slug)}'` : "NULL";
+    // Build delta SQL.
+    const deltaSql: string[] = [];
 
-          schemaSql.push(`INSERT INTO entities (id, external_id, entity_type, title, data, content_hash, folder, slug, created_at, updated_at) VALUES (${entityIdOffset}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(data)}', ${entity.contentHash ? `'${escapeSQL(entity.contentHash)}'` : "NULL"}, ${folderVal}, ${slugVal}, ${entity.createdAt ? `'${escapeSQL(entity.createdAt)}'` : "datetime('now')"}, ${entity.updatedAt ? `'${escapeSQL(entity.updatedAt)}'` : "datetime('now')"});`);
+    // Chunk IN(...) lists so each DELETE statement stays under MAX_BATCH_BYTES.
+    const DELETE_CHUNK = 200;
 
-          // FTS inline via theme engine
-          const entityDataParsed: EntityData = typeof entity.data === "object" ? entity.data as EntityData : JSON.parse(entity.data as string);
-          const entityTagNames = (entityDataParsed.tags ?? []).join(" ");
-          let ftsContent = "";
-          const hasMarkdown = entity.folder != null && entity.slug != null;
-          if (hasMarkdown && themeEngine.has(col.crawler)) {
-            try {
-              ftsContent = themeEngine.render({
-                entity: {
-                  externalId: entity.externalId,
-                  entityType: entity.entityType,
-                  title: entity.title,
-                  data: (entityDataParsed.source ?? {}) as Record<string, unknown>,
-                  url: entityDataParsed.url ?? undefined,
-                  tags: entityDataParsed.tags ?? [],
-                },
-                collectionName: colName,
-                crawlerType: col.crawler,
-              });
-            } catch { /* fall back to empty content */ }
-          }
-          if (ftsContent.length > MAX_FTS_CONTENT) ftsContent = ftsContent.slice(0, MAX_FTS_CONTENT);
+    // Deletes: drop FTS rows first (no cascade), then entities rows.
+    for (let i = 0; i < deletedExtIds.length; i += DELETE_CHUNK) {
+      const chunk = deletedExtIds.slice(i, i + DELETE_CHUNK);
+      const inList = chunk.map((id) => `'${escapeSQL(id)}'`).join(",");
+      deltaSql.push(`DELETE FROM entities_fts WHERE external_id IN (${inList});`);
+      deltaSql.push(`DELETE FROM entities WHERE external_id IN (${inList});`);
+    }
 
-          schemaSql.push(`INSERT INTO entities_fts (entity_id, external_id, entity_type, title, content, tags) VALUES (${entityIdOffset}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(ftsContent)}', '${escapeSQL(entityTagNames)}');`);
+    if (changedExtIds.length > 0) {
+      // Pre-delete FTS rows for changed entities. FTS5 has no UNIQUE constraint
+      // on external_id, so INSERT OR REPLACE wouldn't dedupe — explicit DELETE
+      // is required before the INSERT below.
+      for (let i = 0; i < changedExtIds.length; i += DELETE_CHUNK) {
+        const chunk = changedExtIds.slice(i, i + DELETE_CHUNK);
+        const inList = chunk.map((id) => `'${escapeSQL(id)}'`).join(",");
+        deltaSql.push(`DELETE FROM entities_fts WHERE external_id IN (${inList});`);
+      }
+
+      const changedSet = new Set(changedExtIds);
+      for (const { entity, colName, colCrawler } of localRows) {
+        if (!changedSet.has(entity.externalId)) continue;
+
+        const data = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
+        if (Buffer.byteLength(data, "utf8") > MAX_ENTITY_DATA_BYTES) {
+          skippedTooLarge++;
+          continue;
         }
+        const folderVal = entity.folder != null ? `'${escapeSQL(entity.folder)}'` : "NULL";
+        const slugVal = entity.slug != null ? `'${escapeSQL(entity.slug)}'` : "NULL";
 
-        onProgress("d1-build", `Built "${colName}": ${allEntities.length} entities`);
-      }
-      if (skippedTooLarge > 0) {
-        onProgress("d1-build", `Skipped ${skippedTooLarge} oversized entit${skippedTooLarge === 1 ? "y" : "ies"} (data > ${MAX_ENTITY_DATA_BYTES / 1024} KB)`);
-      }
+        deltaSql.push(`INSERT OR REPLACE INTO entities (external_id, entity_type, title, data, content_hash, folder, slug, created_at, updated_at) VALUES ('${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(data)}', ${entity.contentHash ? `'${escapeSQL(entity.contentHash)}'` : "NULL"}, ${folderVal}, ${slugVal}, ${entity.createdAt ? `'${escapeSQL(entity.createdAt)}'` : "datetime('now')"}, ${entity.updatedAt ? `'${escapeSQL(entity.updatedAt)}'` : "datetime('now')"});`);
 
-      // Upload in batches bounded by both size (large data blobs) and count (execution time).
+        const entityDataParsed: EntityData = typeof entity.data === "object" ? entity.data as EntityData : JSON.parse(entity.data as string);
+        const entityTagNames = (entityDataParsed.tags ?? []).join(" ");
+        let ftsContent = "";
+        const hasMarkdown = entity.folder != null && entity.slug != null;
+        if (hasMarkdown && themeEngine.has(colCrawler)) {
+          try {
+            ftsContent = themeEngine.render({
+              entity: {
+                externalId: entity.externalId,
+                entityType: entity.entityType,
+                title: entity.title,
+                data: (entityDataParsed.source ?? {}) as Record<string, unknown>,
+                url: entityDataParsed.url ?? undefined,
+                tags: entityDataParsed.tags ?? [],
+              },
+              collectionName: colName,
+              crawlerType: colCrawler,
+            });
+          } catch { /* fall back to empty content */ }
+        }
+        if (ftsContent.length > MAX_FTS_CONTENT) ftsContent = ftsContent.slice(0, MAX_FTS_CONTENT);
+
+        deltaSql.push(`INSERT INTO entities_fts (entity_id, external_id, entity_type, title, content, tags) VALUES (${ftsEntityIdFor(entity.externalId)}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(ftsContent)}', '${escapeSQL(entityTagNames)}');`);
+      }
+    }
+
+    if (skippedTooLarge > 0) {
+      onProgress("d1-build", `Skipped ${skippedTooLarge} oversized entit${skippedTooLarge === 1 ? "y" : "ies"} (data > ${MAX_ENTITY_DATA_BYTES / 1024} KB)`);
+    }
+
+    if (deltaSql.length === 0) {
+      onProgress("d1-upload", "No D1 changes to apply");
+    } else {
+      // Batch upload bounded by size (large data blobs) and count (execution time).
       // Use Buffer.byteLength for accurate UTF-8 byte count — stmt.length undercounts Unicode.
-      const MAX_BATCH_BYTES = 100 * 1024; // 100 KB — conservative against D1's SQL length limit
+      const MAX_BATCH_BYTES = 100 * 1024;
       const MAX_BATCH_COUNT = 500;
       const batches: string[][] = [];
       let current: string[] = [];
       let currentBytes = 0;
-      for (const stmt of schemaSql) {
+      for (const stmt of deltaSql) {
         const stmtBytes = Buffer.byteLength(stmt, "utf8");
         if (current.length > 0 && (currentBytes + stmtBytes > MAX_BATCH_BYTES || current.length >= MAX_BATCH_COUNT)) {
           batches.push(current);
@@ -515,7 +553,7 @@ export async function publishCollections(
       if (current.length > 0) batches.push(current);
 
       const totalBatches = batches.length;
-      onProgress("d1-upload", `Uploading to D1 (${totalBatches} batches)...`);
+      onProgress("d1-upload", `Uploading to D1 (${totalBatches} batch${totalBatches === 1 ? "" : "es"})...`);
       let batchCount = 0;
       for (const batch of batches) {
         await executeD1Query(d1DatabaseId, batch.join("\n"));
@@ -524,8 +562,7 @@ export async function publishCollections(
           onProgress("d1-upload", `Uploading to D1... ${batchCount}/${totalBatches} batches`);
         }
       }
-      await putR2String(r2BucketName, `${collectionName}/db-digest`, dbDigest);
-    } // else: D1 rebuild
+    }
 
     // Upload collection config YAML to R2 (needed by new worker architecture)
     onProgress("config", "Uploading collection config to R2...");
@@ -560,7 +597,6 @@ export async function publishCollections(
     mcpUrl,
     protected: passwordProtected,
     publishedAt: new Date().toISOString(),
-    ...(dbDigest ? { dbDigest } : {}),
   });
 
   onProgress("done", "Publish completed");

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -363,12 +363,19 @@ export async function publishCollections(
       uploadCount++;
     });
 
-    // Stale cleanup: remove R2 keys no longer in the local set
+    // Stale cleanup: remove R2 keys no longer in the local set.
+    // Skip `_config/` — those files are uploaded later in Phase 3 (not tracked
+    // in `fileSizes`), so without this guard they'd be deleted here and only
+    // re-created if Phase 3 reaches the config-upload step. A crash mid-publish
+    // would leave the worker with no _config/collections.yml, which makes
+    // /api/collections return [] and breaks remote clones.
     let deletedCount = 0;
     if (isUpdate) {
       const allKeys = new Set(fileSizes.keys());
       try {
-        const staleKeys = [...existingR2Objects.keys()].filter((key) => !allKeys.has(key));
+        const staleKeys = [...existingR2Objects.keys()].filter(
+          (key) => !allKeys.has(key) && !key.startsWith("_config/"),
+        );
         if (staleKeys.length > 0) {
           onProgress("r2-cleanup", `Removing ${staleKeys.length} stale file(s)...`);
           await deleteR2Objects(r2BucketName, staleKeys);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -288,6 +288,12 @@ export async function publishCollections(
   } finally {
     cleanupTempFile(tomlFile);
   }
+  // Wrangler doesn't always echo the URL on re-deploys — fall back to the
+  // previously-saved URL (or the default workers.dev hostname) so downstream
+  // requests like the manifest fetch in Phase 3 always have a real base URL.
+  if (!workerUrl) {
+    workerUrl = existingPublish?.url || `https://${workerName}.workers.dev`;
+  }
 
   // --- Phase 2: R2 uploads (before D1 rebuild so the site stays live on old data) ---
 
@@ -579,9 +585,6 @@ export async function publishCollections(
     }
   }
 
-  if (!workerUrl) {
-    workerUrl = `https://${workerName}.workers.dev`;
-  }
   const mcpUrl = `${workerUrl}/mcp`;
   const passwordProtected = passwordHash.length > 0;
 

--- a/packages/ui/src/components/manage/CollectionDetail.tsx
+++ b/packages/ui/src/components/manage/CollectionDetail.tsx
@@ -4,7 +4,6 @@ import {
   formatTimestamp,
   type Collection,
   type CollectionStatus,
-  type SyncRun,
   type PublishProgress,
   type McpLinkStatus,
 } from "../../types";
@@ -86,11 +85,9 @@ function formatCount(n: number): string {
 export default function CollectionDetail({ name, onBack, onEdit, onCollectionsChanged }: CollectionDetailProps) {
   const [collection, setCollection] = useState<Collection | null>(null);
   const [status, setStatus] = useState<CollectionStatus | null>(null);
-  const [syncHistory, setSyncHistory] = useState<SyncRun[]>([]);
   const [syncing, setSyncing] = useState(false);
   const [lastSyncResult, setLastSyncResult] = useState<SyncResult | null>(null);
   const [deleting, setDeleting] = useState(false);
-  const [showHistory, setShowHistory] = useState(false);
 
   // Publish state
   const [publishing, setPublishing] = useState(false);
@@ -128,13 +125,6 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
       .catch(() => {});
   }, [name]);
 
-  const loadHistory = useCallback(() => {
-    fetch(`/api/collections/${encodeURIComponent(name)}/sync-runs`)
-      .then((r) => r.json())
-      .then(setSyncHistory)
-      .catch(() => {});
-  }, [name]);
-
   const loadMcp = useCallback(async () => {
     try {
       const res = await fetch("/api/mcp/status");
@@ -145,9 +135,8 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
   useEffect(() => {
     loadCollection();
     loadStatus();
-    loadHistory();
     loadMcp();
-  }, [loadCollection, loadStatus, loadHistory, loadMcp]);
+  }, [loadCollection, loadStatus, loadMcp]);
 
   useEffect(() => {
     return () => {
@@ -170,9 +159,8 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
     setSyncing(false);
     setLastSyncResult(result);
     loadStatus();
-    loadHistory();
     onCollectionsChanged?.();
-  }, [loadStatus, loadHistory, onCollectionsChanged]);
+  }, [loadStatus, onCollectionsChanged]);
 
   // --- Enable/Disable ---
   const handleToggle = (enabled: boolean) => {
@@ -379,14 +367,6 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
               </button>
             </>
           )}
-          {syncHistory.length > 0 && (
-            <button
-              className={`btn btn-sm${showHistory ? " active" : ""}`}
-              onClick={() => setShowHistory(!showHistory)}
-            >
-              History
-            </button>
-          )}
         </div>
         {syncing && <SyncProgress onComplete={handleSyncComplete} />}
         {!syncing && lastSyncResult && (
@@ -399,38 +379,6 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
                 {status?.lastSyncRun && <span>Last sync: {formatTimestamp(status.lastSyncRun.startedAt)}</span>}
               </span>
             )}
-          </div>
-        )}
-        {showHistory && syncHistory.length > 0 && (
-          <div className="collection-card-history" style={{ marginTop: 8 }}>
-            <table className="sync-history-table">
-              <thead>
-                <tr>
-                  <th>Status</th>
-                  <th>Type</th>
-                  <th>Created</th>
-                  <th>Updated</th>
-                  <th>Deleted</th>
-                  <th>Started</th>
-                </tr>
-              </thead>
-              <tbody>
-                {syncHistory.slice(0, 10).map((run) => (
-                  <tr key={run.id}>
-                    <td><span className={`status-badge status-${run.status}`}>{run.status}</span></td>
-                    <td>
-                      <span className={`sync-type-badge sync-type-${run.syncType || "incremental"}`}>
-                        {run.syncType === "full" ? "full" : "incr"}
-                      </span>
-                    </td>
-                    <td>{run.entitiesCreated}</td>
-                    <td>{run.entitiesUpdated}</td>
-                    <td>{run.entitiesDeleted}</td>
-                    <td>{formatTimestamp(run.startedAt)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
           </div>
         )}
       </div>

--- a/packages/ui/src/components/manage/PublishPanel.tsx
+++ b/packages/ui/src/components/manage/PublishPanel.tsx
@@ -107,24 +107,31 @@ export default function PublishPanel() {
     doPublish(collectionName, {});
   };
 
-  const handleUnpublish = async (collectionName: string) => {
+  const handleUnpublish = (collectionName: string) => {
     const confirmed = window.confirm(
       `Unpublish "${collectionName}"? This will delete its Cloudflare worker, D1 database, and R2 bucket.`,
     );
     if (!confirmed) return;
 
+    setPublishing(true);
+    setProgress(null);
     setError(null);
-    try {
-      const res = await fetch(`/api/collections/${encodeURIComponent(collectionName)}/unpublish`, { method: "POST" });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({ error: "Unpublish failed" }));
-        setError(data.error || "Unpublish failed");
-      } else {
-        fetch("/api/collections").then((r) => r.json()).then(setCollections).catch(() => {});
-      }
-    } catch (err) {
-      setError(String(err));
-    }
+
+    fetch(`/api/collections/${encodeURIComponent(collectionName)}/unpublish`, { method: "POST" })
+      .catch(() => {});
+
+    pollRef.current = window.setInterval(async () => {
+      try {
+        const res = await fetch("/api/publish/status");
+        const data: PublishProgress = await res.json();
+        setProgress(data);
+        if (!data.active) {
+          if (pollRef.current) clearInterval(pollRef.current);
+          setPublishing(false);
+          fetch("/api/collections").then((r) => r.json()).then(setCollections).catch(() => {});
+        }
+      } catch {}
+    }, 1000);
   };
 
   return (
@@ -143,20 +150,25 @@ export default function PublishPanel() {
       {authError && <div className="form-error" style={{ whiteSpace: "pre-wrap" }}>{authError}</div>}
       {error && <div className="form-error">{error}</div>}
 
-      {progress && (publishing || progress.error) && (
-        <div className="sync-progress">
-          <div className="sync-progress-header">
-            <span className={`status-badge status-${progress.active ? "running" : progress.error ? "failed" : "completed"}`}>
-              {progress.active ? "Publishing" : progress.error ? "Failed" : "Done"}
-            </span>
-            {progress.startedAt != null && (
-              <span className="sync-progress-elapsed">{formatElapsed(now - progress.startedAt)}</span>
-            )}
+      {progress && (publishing || progress.error) && (() => {
+        const isUnpublish = /unpublish/i.test(progress.detail) || /delet/i.test(progress.detail);
+        const verb = isUnpublish ? "Unpublishing" : "Publishing";
+        const doneVerb = isUnpublish ? "Unpublished" : "Done";
+        return (
+          <div className="sync-progress">
+            <div className="sync-progress-header">
+              <span className={`status-badge status-${progress.active ? "running" : progress.error ? "failed" : "completed"}`}>
+                {progress.active ? verb : progress.error ? "Failed" : doneVerb}
+              </span>
+              {progress.startedAt != null && (
+                <span className="sync-progress-elapsed">{formatElapsed(now - progress.startedAt)}</span>
+              )}
+            </div>
+            <div className="sync-progress-status">{progress.detail || progress.step}</div>
+            {progress.error && <div className="form-error">{progress.error}</div>}
           </div>
-          <div className="sync-progress-status">{progress.detail || progress.step}</div>
-          {progress.error && <div className="form-error">{progress.error}</div>}
-        </div>
-      )}
+        );
+      })()}
 
       {publishedCollections.length > 0 && (
         <div className="preset-list">

--- a/packages/worker/src/db/client.ts
+++ b/packages/worker/src/db/client.ts
@@ -131,11 +131,24 @@ export async function getEntitiesByExternalIds(
 export async function getFullManifest(
   db: D1Database,
 ): Promise<Array<{ externalId: string; hash: string }>> {
-  const { results } = await db
-    .prepare("SELECT external_id, content_hash FROM entities")
-    .all<{ external_id: string; content_hash: string | null }>();
-  return (results ?? []).map((r) => ({
-    externalId: r.external_id,
-    hash: r.content_hash ?? "",
-  }));
+  // D1's worker binding silently returns no rows when .all() is called on a
+  // bare SELECT against a large table (observed: ~24K-row entities table
+  // returns []). Page explicitly with LIMIT/OFFSET to dodge that limit.
+  // ORDER BY id keeps pages stable across calls.
+  const PAGE_SIZE = 5000;
+  const out: Array<{ externalId: string; hash: string }> = [];
+  let offset = 0;
+  for (;;) {
+    const { results } = await db
+      .prepare("SELECT external_id, content_hash FROM entities ORDER BY id LIMIT ? OFFSET ?")
+      .bind(PAGE_SIZE, offset)
+      .all<{ external_id: string; content_hash: string | null }>();
+    const rows = results ?? [];
+    for (const r of rows) {
+      out.push({ externalId: r.external_id, hash: r.content_hash ?? "" });
+    }
+    if (rows.length < PAGE_SIZE) break;
+    offset += rows.length;
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary

Replaces the destructive D1 full-rebuild on every publish with a manifest-driven incremental delta. Re-publishes that touch nothing now upload nothing; re-publishes that touch a few entities upload only those.

Along the way fixes several latent bugs in the surrounding flow that this surfaced:

- **Worker `getFullManifest` returned 0 rows from `.all()` on the 24K-row entities table** (D1 binding silently caps a bare SELECT). Now paginated with `LIMIT/OFFSET 5000`.
- **`computeSyncPlan` is pull-oriented** (`add` = remote-only); the publish was using its outputs verbatim and pushing the wrong set. Inverted the mapping: `pushExtIds = local-only ∪ hash-differs`, `pruneExtIds = remote-only`.
- **`entities` has no `UNIQUE(external_id)`** so `INSERT OR REPLACE` would have left duplicates on every update. Explicit `DELETE` precedes each push.
- **Stale R2 cleanup was deleting `_config/*.yml`** between Phase 2 and the Phase 3 re-upload, breaking remote clones if anything failed in between. `_config/` is now skipped from cleanup.
- **`deployWorker` returns "" on no-op redeploys**, which made the manifest fetch hit a malformed URL and silently treat the remote as empty. Fall back to the saved publish-state URL immediately after deploy.
- **Oversized entities (data > 80 KB)** can't be pushed (D1 per-statement limit). They were appearing as `+1 to push` on every re-publish; now filtered out of the diff entirely with a single up-front "Skipped N oversized" log.

Plus a few UI cleanups: the redundant **Sync History** button + inline table on the Collection page is gone, and **Unpublish** now reports progress in the UI the same way Publish does (shared `publishProgress`, polled by `/api/publish/status`).

## Test plan

- [ ] First publish of a fresh collection: `Incremental plan: +N ~0 -0`, batches upload entities, manifest endpoint returns N rows
- [ ] Republish with no local changes: `Incremental plan: +0 ~0 -0`, `No D1 changes to apply`
- [ ] Republish after editing one entity: `Incremental plan: +0 ~1 -0`, single small batch
- [ ] Republish after deleting one local entity: `Incremental plan: +0 ~0 -1`, single small batch
- [ ] Oversized entities log once and don't reappear in subsequent plans
- [ ] Clone a published collection, modify source, sync clone — pulls deltas
- [ ] Unpublish from UI shows "Unpublishing..." progress and finishes with "Unpublished"
- [ ] `bun run ci` passes (lint + typecheck + tests + UI build + worker build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)