### PR TITLE
Add /docs/download page and Download button to nav

### DIFF
--- a/packages/website/src/docs/download.ts
+++ b/packages/website/src/docs/download.ts
@@ -1,0 +1,67 @@
+import { renderDocsPage } from "./layout";
+
+export const downloadPage = renderDocsPage({
+  title: "Download",
+  description:
+    "Download Frozen Ink as a CLI for developers or as a desktop app for everyday use.",
+  activePath: "/docs/download",
+  canonicalPath: "/docs/download",
+  section: "Overview",
+  tocLinks: [
+    { id: "cli", title: "CLI — for developers" },
+    { id: "desktop", title: "Desktop App" },
+    { id: "macos", title: "macOS", indent: true },
+    { id: "windows", title: "Windows", indent: true },
+    { id: "linux", title: "Linux", indent: true },
+  ],
+  content: `
+  <div class="docs-breadcrumb">
+    <a href="/docs">Docs</a>
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+    <span>Download</span>
+  </div>
+
+  <h1 class="page-title">Download Frozen Ink</h1>
+  <p class="page-lead">Frozen Ink is available as a command-line tool for developers and AI workflows, and as a native desktop app for everyday use.</p>
+
+  <h2 id="cli">CLI — for developers &amp; AI workflows</h2>
+  <p>The CLI is the primary way to manage collections, sync sources, and expose your knowledge base via MCP. It runs on macOS, Windows, and Linux wherever Node.js is available.</p>
+
+  <p><strong>Install globally with npm:</strong></p>
+  <pre><code>npm install -g @vboctor/fink</code></pre>
+
+  <p>Verify the install:</p>
+  <pre><code>fink --version</code></pre>
+
+  <div class="callout callout-tip">
+    <div class="callout-icon">&#128218;</div>
+    <div class="callout-body">
+      <strong>Next steps</strong>
+      <p>Head to the <a href="/docs">Getting Started guide</a> to add your first collection and start browsing your knowledge base.</p>
+    </div>
+  </div>
+
+  <h2 id="desktop">Desktop App — for everyday use</h2>
+  <p>The desktop app provides a native GUI for browsing and managing your knowledge base without using the terminal. Binaries are attached to each GitHub Release.</p>
+
+  <ul>
+    <li id="macos"><strong>macOS</strong> — Apple Silicon and Intel, as a <code>.dmg</code> installer</li>
+    <li id="windows"><strong>Windows</strong> — 64-bit, as a <code>.exe</code> installer</li>
+    <li id="linux"><strong>Linux</strong> — <code>.AppImage</code> (universal) and <code>.deb</code> (Debian/Ubuntu)</li>
+  </ul>
+
+  <p style="margin-top: 20px;">All binaries are listed under <em>Assets</em> on the GitHub Releases page.</p>
+  <a href="https://github.com/vboctor/frozen-ink/releases/latest" target="_blank" rel="noopener" class="btn btn-primary" style="margin-top:8px;">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+    Download Desktop App
+  </a>
+
+  <div class="callout callout-warning">
+    <div class="callout-icon">&#9888;&#65039;</div>
+    <div class="callout-body">
+      <strong>macOS Gatekeeper</strong>
+      <p>The app is currently unsigned. If macOS blocks it on first launch, right-click the app and choose <strong>Open</strong>, or run <code>xattr -cr /Applications/FrozenInk.app</code> in Terminal to clear the quarantine attribute.</p>
+    </div>
+  </div>
+`,
+});

--- a/packages/website/src/docs/layout.ts
+++ b/packages/website/src/docs/layout.ts
@@ -23,6 +23,7 @@ const NAV_SECTIONS = [
       { label: "What is Frozen Ink?", href: "/docs/what-is-frozen-ink" },
       { label: "Key Scenarios", href: "/docs/key-scenarios" },
       { label: "Getting Started", href: "/docs" },
+      { label: "Download", href: "/docs/download" },
     ],
   },
   {
@@ -149,7 +150,7 @@ export function renderDocsPage(opts: DocsPageOptions): string {
   <meta name="description" content="${description}" />
   <meta name="theme-color" content="#0969da" />
   ${seoMeta}
-  <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABjSURBVFhH7c0xDQAgDEXRHwcuwP5dMA0TYKAlYeAO9CX/TndnZmZmZmZmZmZm/6Kq1t0fvN3dT7MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzOzv/E6d2dmZmZmZn/WcQC9fg7gL4VGPAAAAABJRU5ErkJggg==" />
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg viewBox='0 0 28 28' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='3' y='16' width='22' height='5' rx='1.5' fill='%23e36209'/%3E%3Crect x='4' y='10' width='20' height='5' rx='1.5' fill='%231a9e8f'/%3E%3Crect x='3' y='4' width='22' height='5' rx='1.5' fill='%23cf222e'/%3E%3C/svg%3E" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -520,6 +521,28 @@ export function renderDocsPage(opts: DocsPageOptions): string {
     .docs-article pre .flag { color: #005cc5; }
     .docs-article pre .num { color: #e36209; }
 
+    /* ===== Buttons ===== */
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 22px;
+      border-radius: 10px;
+      font-size: 14px;
+      font-weight: 600;
+      transition: all 0.2s;
+      cursor: pointer;
+      border: none;
+      text-decoration: none;
+    }
+
+    .btn-primary {
+      background: var(--text);
+      color: #fff !important;
+    }
+
+    .btn-primary:hover { opacity: 0.85; color: #fff !important; }
+
     /* ===== Callouts ===== */
     .callout {
       display: flex;
@@ -780,6 +803,7 @@ export function renderDocsPage(opts: DocsPageOptions): string {
       <li><a href="/#how">Getting Started</a></li>
       <li><a href="/#connectors">Connectors</a></li>
       <li><a href="/docs/what-is-frozen-ink" class="active">Docs</a></li>
+      <li><a href="/docs/download" class="nav-cta">Download</a></li>
       <li class="nav-social">
         <a href="https://github.com/vboctor/frozen-ink" target="_blank" rel="noopener" aria-label="GitHub" class="nav-icon-link">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.341-3.369-1.341-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -26,6 +26,7 @@ import { connectorMantishubPage } from "./docs/connector-mantishub";
 import { clonePullPage } from "./docs/clone-pull";
 import { cliReferencePage } from "./docs/cli-reference";
 import { configurationPage } from "./docs/configuration";
+import { downloadPage } from "./docs/download";
 
 const DOC_PAGES: Record<string, string> = {
   "/docs": gettingStartedPage,
@@ -48,6 +49,7 @@ const DOC_PAGES: Record<string, string> = {
   "/docs/integrations/chatgpt-desktop": chatgptDesktopPage,
   "/docs/reference/cli": cliReferencePage,
   "/docs/reference/configuration": configurationPage,
+  "/docs/download": downloadPage,
 };
 
 export default {

--- a/packages/website/src/site.html
+++ b/packages/website/src/site.html
@@ -583,6 +583,7 @@
       <li><a href="#how">Getting Started</a></li>
       <li><a href="#connectors">Connectors</a></li>
       <li><a href="/docs/what-is-frozen-ink">Docs</a></li>
+      <li><a href="/docs/download" class="nav-cta">Download</a></li>
       <li class="nav-social">
         <a href="https://github.com/vboctor/frozen-ink" target="_blank" rel="noopener" aria-label="GitHub" class="nav-icon-link">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.341-3.369-1.341-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>
@@ -681,9 +682,9 @@
   </div>
 
   <div class="hero-actions">
-    <a href="#download" class="btn btn-primary">
+    <a href="/docs/download" class="btn btn-primary">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-      Download for macOS
+      Download
     </a>
     <a href="https://demo.frozenink.dev" class="btn btn-secondary" target="_blank">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>


### PR DESCRIPTION
## Summary

- New `/docs/download` page with CLI install instructions (`npm install -g @vboctor/fink`) and a Desktop App section listing macOS, Windows, and Linux formats with a single black "Download Desktop App" button pointing to GitHub Releases
- "Download" added to the docs sidebar (Overview section) and as a `nav-cta` pill button in the top nav on both the homepage and all docs pages
- Homepage hero CTA fixed: `href="#download"` (dead link) → `/docs/download`, label updated from "Download for macOS" → "Download"
- Docs favicon updated to match the homepage (inline SVG instead of low-res PNG base64)
- `.btn` / `.btn-primary` styles added to the docs layout CSS so the download button renders correctly on doc pages
- macOS Gatekeeper callout references `FrozenInk.app` (no space)

## Test plan

- [ ] Visit `/docs/download` — page renders with CLI section, platform list, black download button, and Gatekeeper callout
- [ ] Click homepage hero "Download" button — navigates to `/docs/download`
- [ ] Click "Download" pill in top nav (homepage and any `/docs/*` page) — navigates to `/docs/download`
- [ ] Check docs sidebar shows "Download" under Overview, highlighted when on `/docs/download`
- [ ] Verify favicon matches on both homepage and docs pages
- [ ] `bun run ci` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)