### PR TITLE
Add clone upgrade prompt, collection info endpoint, and sync fast-path

### DIFF
--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -110,9 +110,17 @@ Examples:
     const collectionDir = join(home, "collections", localName);
     const storage = new LocalStorageBackend(collectionDir);
 
-    // Persist the original crawler type so serve/prepare can use the right theme
+    // Persist the original crawler type so serve/prepare can use the right theme,
+    // and — when the remote exposes /info — the manifest hash so the next sync's
+    // fast-path can detect "no changes" without a manifest download.
     const meta = new MetadataStore(dbPath);
     meta.setCrawlerType(manifest.collection?.crawlerType ?? null);
+    try {
+      const info = await client.getInfo();
+      if (info.manifestHash) meta.setRemoteManifestHash(info.manifestHash);
+    } catch {
+      // Older workers won't have /info — the first sync will populate the hash.
+    }
     meta.close();
 
     // Batch-fetch all entity data

--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -86,6 +86,17 @@ Examples:
       process.exit(1);
     }
 
+    // Fail early if the manifest's crawler type is unknown to this installation —
+    // a newer Frozen Ink likely published this collection with a crawler we don't have.
+    const manifestCrawlerType = manifest.collection?.crawlerType ?? "";
+    const themeEngine = createGenerateThemeEngine();
+    if (manifestCrawlerType && !themeEngine.has(manifestCrawlerType)) {
+      console.error(
+        `Unknown crawler type "${manifestCrawlerType}". This collection requires a newer version of Frozen Ink — please upgrade to clone it.`,
+      );
+      process.exit(1);
+    }
+
     // Register the collection
     addCollection(localName, {
       crawler: "remote",
@@ -132,8 +143,7 @@ Examples:
 
     // Generate markdown locally using the theme engine (same as generateCollection) so that
     // the on-disk files match what prepare/serve render — no re-generation needed on first serve.
-    const crawlerType = manifest.collection?.crawlerType ?? "";
-    const themeEngine = createGenerateThemeEngine();
+    const crawlerType = manifestCrawlerType;
     const indexer = new SearchIndexer(dbPath);
 
     if (themeEngine.has(crawlerType)) {

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -1,0 +1,47 @@
+import { Command } from "commander";
+import { RemoteClient } from "./remote-client";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+export const infoCommand = new Command("info")
+  .description("Show metadata about a published collection (name, title, entity count, size, crawler type, etc.)")
+  .argument("<url>", "URL of the published site (e.g. https://my-fink.workers.dev)")
+  .option("--password <password>", "Password for protected sites")
+  .option("--json", "Output raw JSON instead of formatted text")
+  .addHelpText("after", `
+Examples:
+  fink info https://my-fink.workers.dev --password secret123
+  fink info https://my-fink.workers.dev --json
+`)
+  .action(async (url: string, opts: { password?: string; json?: boolean }) => {
+    const client = new RemoteClient(url, opts.password);
+    const info = await client.getInfo();
+
+    if (opts.json) {
+      console.log(JSON.stringify(info, null, 2));
+      return;
+    }
+
+    console.log(`Collection: ${info.title} (${info.name})`);
+    if (info.description) console.log(`Description: ${info.description}`);
+    console.log(`Crawler:    ${info.crawlerType}`);
+    console.log(`Entities:   ${info.entityCount}`);
+    const typeEntries = Object.entries(info.entityTypes);
+    if (typeEntries.length > 0) {
+      const byType = typeEntries
+        .sort((a, b) => b[1] - a[1])
+        .map(([t, n]) => `${t}=${n}`)
+        .join(", ");
+      console.log(`  by type:  ${byType}`);
+    }
+    console.log(`Size:       ${formatBytes(info.totalDataBytes)} (entity data)`);
+    if (info.lastUpdatedAt) console.log(`Updated:    ${info.lastUpdatedAt}`);
+    console.log(`Manifest:   v${info.manifestVersion} (hash ${info.manifestHash.slice(0, 12)})`);
+    console.log(`Worker:     build ${info.workerBuildId}`);
+    console.log(`Generated:  ${info.generatedAt}`);
+  });

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -594,9 +594,22 @@ export async function publishCollections(
       }
     }
 
-    // Invalidate cached manifests so the next client request rebuilds from
-    // the fresh D1 state. Worker writes the cache on the next GET /manifest.
-    const cacheKeys = collectionNames.map((n) => `_cache/manifest-${n}.json`);
+    // Invalidate cached manifests and info blobs so the next client request
+    // rebuilds from the fresh D1 state. Info cache keys include the worker
+    // build ID, so we list and filter rather than guessing.
+    const cacheKeys: string[] = collectionNames.map((n) => `_cache/manifest-${n}.json`);
+    try {
+      const cached = await listR2Objects(r2BucketName, "_cache/");
+      for (const obj of cached) {
+        for (const n of collectionNames) {
+          if (obj.key.startsWith("_cache/info-") && obj.key.endsWith(`-${n}.json`)) {
+            cacheKeys.push(obj.key);
+          }
+        }
+      }
+    } catch {
+      // Listing is best-effort; manifest cache invalidation still proceeds below.
+    }
     try {
       await deleteR2Objects(r2BucketName, cacheKeys);
     } catch {

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -88,15 +88,38 @@ export async function pullCollection(collectionName: string, opts: PullCollectio
   const collectionDir = join(home, "collections", collectionName);
   const storage = new LocalStorageBackend(collectionDir);
 
+  // Fast-path: ask /info for the remote manifest hash and compare to the hash
+  // stored from the last successful sync. If they match, nothing has changed
+  // and we can skip the full manifest download + sync-plan computation.
+  // Falls back to the manifest flow if /info is unavailable (older worker) or
+  // no hash is stored locally yet.
+  const meta = new MetadataStore(dbPath);
+  const localManifestHash = meta.getRemoteManifestHash();
+  let remoteManifestHash: string | null = null;
+  try {
+    const info = await client.getInfo();
+    remoteManifestHash = info.manifestHash ?? null;
+    if (info.crawlerType) meta.setCrawlerType(info.crawlerType);
+    if (localManifestHash && remoteManifestHash && localManifestHash === remoteManifestHash) {
+      meta.close();
+      log("Already up to date.");
+      return { created: 0, updated: 0, deleted: 0 };
+    }
+  } catch (err) {
+    // Older workers won't have /info — fall back to the manifest path below.
+    if (!(err instanceof Error) || !err.message.startsWith("HTTP 404 ")) {
+      meta.close();
+      throw err;
+    }
+  }
+
   // Fetch remote manifest
   log("Fetching manifest...");
   const { manifest, entries } = await client.getManifest();
 
   // Keep crawler.type in sync — repairs clones created before this field existed
   if (manifest.collection?.crawlerType) {
-    const meta = new MetadataStore(dbPath);
     meta.setCrawlerType(manifest.collection.crawlerType);
-    meta.close();
   }
 
   // Build local entity list
@@ -114,6 +137,10 @@ export async function pullCollection(collectionName: string, opts: PullCollectio
   const plan = computeSyncPlan(localEntities, entries);
 
   if (isSyncPlanEmpty(plan)) {
+    // Persist the hash so the next /info fast-path short-circuits even if the
+    // local DB predated the manifestHash feature.
+    if (remoteManifestHash) meta.setRemoteManifestHash(remoteManifestHash);
+    meta.close();
     log("Already up to date.");
     return { created: 0, updated: 0, deleted: 0 };
   }
@@ -121,6 +148,7 @@ export async function pullCollection(collectionName: string, opts: PullCollectio
   printSyncPlan(plan);
 
   if (opts.dryRun) {
+    meta.close();
     return { created: plan.entities.add.length, updated: plan.entities.update.length, deleted: plan.entities.delete.length };
   }
 
@@ -275,6 +303,9 @@ export async function pullCollection(collectionName: string, opts: PullCollectio
     indexer.removeIndex(entityId);
   }
   indexer.close();
+
+  if (remoteManifestHash) meta.setRemoteManifestHash(remoteManifestHash);
+  meta.close();
 
   const result: PullCollectionResult = {
     created: plan.entities.add.length,

--- a/packages/cli/src/commands/remote-client.ts
+++ b/packages/cli/src/commands/remote-client.ts
@@ -11,6 +11,23 @@ export interface ManifestResponse {
   entities: string;
 }
 
+export interface CollectionInfo {
+  version: number;
+  name: string;
+  title: string;
+  description: string | null;
+  crawlerType: string;
+  entityCount: number;
+  entityTypes: Record<string, number>;
+  totalDataBytes: number;
+  lastUpdatedAt: string | null;
+  manifestVersion: number;
+  manifestHash: string;
+  capabilities: string[];
+  workerBuildId: string;
+  generatedAt: string;
+}
+
 export class RemoteClient {
   private baseUrl: string;
   private password: string | undefined;
@@ -96,6 +113,26 @@ export class RemoteClient {
     }
 
     return { manifest, entries: parseManifestEntities(manifest.entities) };
+  }
+
+  async getInfo(): Promise<CollectionInfo> {
+    // Resolve the collection name the same way getManifest does, so callers
+    // can call getInfo() standalone without a prior manifest fetch.
+    if (!this.collectionName) {
+      try {
+        const info = await this.fetchJson<CollectionInfo>("/api/collections/_default/info");
+        if (info.name) this.collectionName = info.name;
+        return info;
+      } catch (err) {
+        if (!(err instanceof Error) || !err.message.startsWith("HTTP 404 ")) throw err;
+      }
+      const collections = await this.fetchJson<Array<{ name: string }>>("/api/collections");
+      if (collections.length === 0) throw new Error("No collections found on remote site.");
+      this.collectionName = collections[0].name;
+    }
+    return this.fetchJson<CollectionInfo>(
+      `/api/collections/${encodeURIComponent(this.collectionName)}/info`,
+    );
   }
 
   async getEntitiesBulk(externalIds: string[]): Promise<RemoteEntityData[]> {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,7 @@ import { mcpCommand } from "./commands/mcp";
 import { tableplusCommand } from "./commands/tableplus";
 import { vscodeCommand } from "./commands/vscode";
 import { cloneCommand } from "./commands/clone";
+import { infoCommand } from "./commands/info";
 
 import { compactCommand } from "./commands/compact";
 import { startTui } from "./tui/index";
@@ -52,6 +53,7 @@ program.addCommand(mcpCommand);
 program.addCommand(tableplusCommand);
 program.addCommand(vscodeCommand);
 program.addCommand(cloneCommand);
+program.addCommand(infoCommand);
 
 program.addCommand(compactCommand);
 

--- a/packages/core/src/db/metadata.ts
+++ b/packages/core/src/db/metadata.ts
@@ -42,6 +42,7 @@ const K = {
   description: "description",
   version: "version",
   crawlerType: "crawler.type",
+  remoteManifestHash: "remote.manifest_hash",
 } as const;
 
 export class MetadataStore {
@@ -181,6 +182,20 @@ export class MetadataStore {
 
   getCrawlerType(): string | null {
     return this.getOptional(K.crawlerType);
+  }
+
+  /**
+   * Manifest hash from the last successful sync of a remote-cloned collection.
+   * Compared against the remote /info endpoint's manifestHash so sync can skip
+   * the full /manifest download when nothing has changed.
+   */
+  setRemoteManifestHash(hash: string | null | undefined): void {
+    if (hash == null || hash === "") this.delete(K.remoteManifestHash);
+    else this.set(K.remoteManifestHash, hash);
+  }
+
+  getRemoteManifestHash(): string | null {
+    return this.getOptional(K.remoteManifestHash);
   }
 
   close(): void {

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -46,6 +46,8 @@ export function buildRenderContext(
   };
 }
 
+declare const __BUILD_ID__: string;
+
 const api = new Hono<{ Bindings: Env }>();
 
 // GET /api/app-info
@@ -242,6 +244,80 @@ api.get("/api/collections/:name/entities", async (c) => {
   return c.json({
     entities: result,
     pagination: { limit, offset, count: result.length },
+  });
+});
+
+// GET /api/collections/:name/info
+// Returns summary metadata about a collection — intended for discovery and to
+// let clients decide whether a full manifest pull is worthwhile.
+// Cached in R2 at `_cache/info-{buildId}-{name}.json`; the buildId prefix means
+// worker redeploys automatically bypass old caches. Publish invalidates the
+// current-buildId key alongside the manifest cache.
+api.get("/api/collections/:name/info", async (c) => {
+  const name = c.req.param("name");
+  const col = await getCollectionConfig(c.env.BUCKET, name);
+  if (!col) return c.json({ error: "Collection not found" }, 404);
+
+  const cacheKey = `_cache/info-${__BUILD_ID__}-${name}.json`;
+  const cached = await c.env.BUCKET.get(cacheKey);
+  if (cached) {
+    return new Response(cached.body, {
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  const manifest = await getFullManifest(c.env.DB);
+  const entityCount = manifest.length;
+
+  // Aggregate per-type counts, total data size (bytes of stored JSON), and the
+  // most recent updated_at so clients can tell at a glance how big a sync is
+  // and whether anything changed since their last pull.
+  const typeRows = await c.env.DB.prepare(
+    "SELECT entity_type, COUNT(*) as count FROM entities GROUP BY entity_type",
+  ).all<{ entity_type: string; count: number }>();
+  const entityTypes: Record<string, number> = {};
+  for (const row of typeRows.results ?? []) {
+    entityTypes[row.entity_type] = row.count;
+  }
+
+  const sizeRow = await c.env.DB.prepare(
+    "SELECT COALESCE(SUM(LENGTH(data)), 0) as bytes, MAX(updated_at) as last FROM entities",
+  ).first<{ bytes: number; last: string | null }>();
+
+  // manifestHash: a stable fingerprint of every (externalId, hash) pair so
+  // clients can cheaply detect "nothing changed" without downloading the full
+  // entity list. Same input as the manifest body → same hash.
+  const fingerprint = manifest.map((e) => `${e.externalId}\t${e.hash}`).join("\n");
+  const fpBytes = new TextEncoder().encode(fingerprint);
+  const digest = await crypto.subtle.digest("SHA-256", fpBytes);
+  const manifestHash = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  const body = {
+    version: 1,
+    name: col.name,
+    title: col.title || col.name,
+    description: col.description ?? null,
+    crawlerType: col.crawler,
+    entityCount,
+    entityTypes,
+    totalDataBytes: sizeRow?.bytes ?? 0,
+    lastUpdatedAt: sizeRow?.last ?? null,
+    manifestVersion: 1,
+    manifestHash,
+    capabilities: ["bulk-entities", "html-render"],
+    workerBuildId: __BUILD_ID__,
+    generatedAt: new Date().toISOString(),
+  };
+  const bodyJson = JSON.stringify(body);
+
+  await c.env.BUCKET.put(cacheKey, bodyJson, {
+    httpMetadata: { contentType: "application/json" },
+  });
+
+  return new Response(bodyJson, {
+    headers: { "content-type": "application/json" },
   });
 });
 


### PR DESCRIPTION
## Summary

- **Clone now fails fast with an upgrade message** when the remote manifest declares a crawler type that isn't registered locally, instead of silently skipping markdown generation.
- **New `GET /api/collections/:name/info` worker endpoint** returning name, title, description, crawler type, entity count with per-type breakdown, total data bytes, last-updated timestamp, manifest version, a SHA-256 `manifestHash` over `(externalId, hash)` pairs, capabilities, and the worker build ID. Cached in R2 under a key that includes the build ID so worker redeploys bypass old caches; publish invalidates the current build's info cache alongside the manifest cache.
- **New `fink info <url>` CLI** that pretty-prints the response (with `--json`).
- **Sync fast-path**: `pull` calls `/info` first and, if the remote `manifestHash` matches the one saved on the last successful sync, short-circuits without downloading the full manifest. Falls back to the manifest flow when `/info` is unavailable (older worker) or no hash is stored locally. Clone also persists the hash so the first post-clone sync benefits.

## Test plan

- [ ] `bun run ci` passes locally
- [ ] Clone a collection whose crawler type is unknown → see upgrade error, exit 1
- [ ] Clone a normal collection → succeeds, `remote.manifest_hash` persisted
- [ ] `fink info <url>` shows collection metadata; `--json` emits raw JSON
- [ ] `fink sync` against an unchanged remote → short-circuits as "Already up to date." without fetching `/manifest`
- [ ] `fink sync` after remote republish → hash differs, falls through to full sync
- [ ] `fink sync` against an older worker (no `/info` route) → falls back to manifest flow, still syncs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)