### PR TITLE
Add update-notify for CLI and desktop clients

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,7 @@ jobs:
             packages/desktop/release/*.exe
             packages/desktop/release/*.AppImage
             packages/desktop/release/*.deb
+            packages/desktop/release/*.yml
 
   publish:
     name: Publish npm + GitHub Release
@@ -170,6 +171,10 @@ jobs:
           find artifacts/desktop-windows-latest -name '*.exe' -exec cp {} release-assets/ \;
           find artifacts/desktop-ubuntu-latest -name '*.AppImage' -exec cp {} release-assets/ \;
           find artifacts/desktop-ubuntu-latest -name '*.deb' -exec cp {} release-assets/ \;
+          # electron-updater auto-update manifests (one per platform)
+          find artifacts/desktop-macos-14 -name 'latest-mac.yml' -exec cp {} release-assets/ \;
+          find artifacts/desktop-windows-latest -name 'latest.yml' -exec cp {} release-assets/ \;
+          find artifacts/desktop-ubuntu-latest -name 'latest-linux.yml' -exec cp {} release-assets/ \;
           echo "Release assets:"
           ls -lh release-assets/
 

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ On tag push, the `.github/workflows/release.yml` workflow runs:
 
 - **`build-cli`**: builds the CLI npm bundle and platform-native Bun binaries on Ubuntu, macOS arm64, macOS x64, and Windows runners.
 - **`build-desktop`**: builds the Electron app (DMG, NSIS installer, AppImage, deb) on native runners.
-- **`publish`**: publishes `@vboctor/fink` to npm and creates a GitHub Release with all binaries attached.
+- **`publish`**: publishes `@vboctor/fink` to npm and creates a GitHub Release with all binaries attached. The desktop job also emits `latest-mac.yml`, `latest.yml`, and `latest-linux.yml` update manifests so packaged Frozen Ink installs can detect new releases via `electron-updater`; the CLI reads `registry.npmjs.org` to notify users of available upgrades.
 
 **One-time setup required:** configure **npm trusted publishing (OIDC)** for `@vboctor/fink` on [npmjs.com](https://docs.npmjs.com/trusted-publishers) — point it at this repo and the `.github/workflows/release.yml` workflow. No long-lived `NPM_TOKEN` secret is needed; npm verifies the workflow identity per-release via GitHub OIDC, and the package is published with provenance attestations.
 

--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
       "version": "0.1.0",
       "dependencies": {
         "better-sqlite3": "^11.0.0",
+        "electron-updater": "^6.3.9",
       },
       "devDependencies": {
         "@electron/rebuild": "^3.0.0",
@@ -781,6 +782,8 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.331", "", {}, "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q=="],
 
+    "electron-updater": ["electron-updater@6.8.3", "", { "dependencies": { "builder-util-runtime": "9.5.1", "fs-extra": "^10.1.0", "js-yaml": "^4.1.0", "lazy-val": "^1.0.5", "lodash.escaperegexp": "^4.1.2", "lodash.isequal": "^4.5.0", "semver": "~7.7.3", "tiny-typed-emitter": "^2.1.0" } }, "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
@@ -1079,7 +1082,11 @@
 
     "lodash.difference": ["lodash.difference@4.5.0", "", {}, "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="],
 
+    "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
+
     "lodash.flatten": ["lodash.flatten@4.4.0", "", {}, "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="],
+
+    "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
 
     "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
 
@@ -1545,6 +1552,8 @@
 
     "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
+    "tiny-typed-emitter": ["tiny-typed-emitter@2.1.0", "", {}, "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
@@ -1780,6 +1789,8 @@
     "electron-builder/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "electron-publish/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "electron-updater/builder-util-runtime": ["builder-util-runtime@9.5.1", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ=="],
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -1,0 +1,51 @@
+import { Command } from "commander";
+import { spawnProcess } from "@frozenink/core";
+import pkg from "../../package.json";
+import {
+  NPM_PACKAGE_NAME,
+  GITHUB_RELEASES_URL,
+  checkForUpdate,
+  isStandaloneBinary,
+} from "../update-notifier";
+
+export const upgradeCommand = new Command("upgrade")
+  .description("Upgrade fink to the latest release")
+  .option("--check", "Print current and latest versions without upgrading")
+  .action(async (opts: { check?: boolean }) => {
+    const current: string = pkg.version;
+    const { latest, hasUpdate } = await checkForUpdate(current);
+
+    if (!latest) {
+      console.error("Could not determine the latest version (registry unreachable).");
+      process.exit(1);
+    }
+
+    if (opts.check) {
+      console.log(`current ${current}, latest ${latest}`);
+      process.exit(hasUpdate ? 1 : 0);
+    }
+
+    if (!hasUpdate) {
+      console.log(`fink is up to date (${current}).`);
+      return;
+    }
+
+    if (isStandaloneBinary()) {
+      console.log(`A newer version (${latest}) is available.`);
+      console.log(`Download the matching binary from: ${GITHUB_RELEASES_URL}`);
+      return;
+    }
+
+    console.log(`Upgrading fink ${current} → ${latest}...`);
+    const result = await spawnProcess(
+      ["npm", "install", "-g", `${NPM_PACKAGE_NAME}@latest`],
+      { env: process.env as Record<string, string | undefined> },
+    );
+    if (result.stdout) process.stdout.write(result.stdout);
+    if (result.stderr) process.stderr.write(result.stderr);
+    if (result.exitCode !== 0) {
+      console.error(`npm install exited with code ${result.exitCode}.`);
+      process.exit(result.exitCode);
+    }
+    console.log("Upgrade complete.");
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,9 +24,13 @@ import { vscodeCommand } from "./commands/vscode";
 import { cloneCommand } from "./commands/clone";
 
 import { compactCommand } from "./commands/compact";
+import { upgradeCommand } from "./commands/upgrade";
 import { startTui } from "./tui/index";
+import { notifyIfUpdateAvailable } from "./update-notifier";
 
 const program = new Command();
+
+notifyIfUpdateAvailable(version);
 
 program
   .name("fink")
@@ -54,6 +58,7 @@ program.addCommand(vscodeCommand);
 program.addCommand(cloneCommand);
 
 program.addCommand(compactCommand);
+program.addCommand(upgradeCommand);
 
 // If no arguments passed (just "fink"), launch TUI by default
 const args = process.argv.slice(2);

--- a/packages/cli/src/update-notifier.ts
+++ b/packages/cli/src/update-notifier.ts
@@ -1,0 +1,133 @@
+/**
+ * Lightweight update notifier for the fink CLI.
+ *
+ * Mirrors the behavior of the `update-notifier` npm package but is inlined so
+ * it works inside both the esbuild-bundled npm payload and the `bun build --compile`
+ * standalone binaries. Neither ships the child-process `check.js` file that the
+ * upstream package forks to.
+ *
+ * - Once per 24h, fetches the latest version from the npm registry.
+ * - Caches the result under `~/.frozenink/update-cache.json`.
+ * - Prints a boxed banner when a newer version is available, with channel-aware
+ *   upgrade instructions (npm vs. standalone binary).
+ */
+import { join } from "path";
+import { homedir } from "os";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+
+export const NPM_PACKAGE_NAME = "@vboctor/fink";
+export const GITHUB_RELEASES_URL = "https://github.com/vboctor/frozen-ink/releases/latest";
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+interface CacheFile {
+  lastCheck: number;
+  latestVersion: string | null;
+}
+
+function cachePath(): string {
+  const dir = process.env.FROZENINK_HOME || join(homedir(), ".frozenink");
+  return join(dir, "update-cache.json");
+}
+
+function readCache(): CacheFile {
+  try {
+    return JSON.parse(readFileSync(cachePath(), "utf-8")) as CacheFile;
+  } catch {
+    return { lastCheck: 0, latestVersion: null };
+  }
+}
+
+function writeCache(cache: CacheFile): void {
+  try {
+    const p = cachePath();
+    mkdirSync(join(p, ".."), { recursive: true });
+    writeFileSync(p, JSON.stringify(cache));
+  } catch {
+    // Best-effort — do not fail the command because of cache write errors.
+  }
+}
+
+/** Detects if the running CLI is a standalone Bun-compiled binary. */
+export function isStandaloneBinary(): boolean {
+  const exec = process.execPath || "";
+  return /fink-(darwin|linux|windows)/.test(exec);
+}
+
+/** Compare semver-ish strings. Returns 1 if a > b, -1 if a < b, 0 if equal. */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string) => v.replace(/^v/, "").split("-")[0].split(".").map((n) => parseInt(n, 10) || 0);
+  const av = parse(a);
+  const bv = parse(b);
+  const len = Math.max(av.length, bv.length);
+  for (let i = 0; i < len; i++) {
+    const ai = av[i] ?? 0;
+    const bi = bv[i] ?? 0;
+    if (ai > bi) return 1;
+    if (ai < bi) return -1;
+  }
+  return 0;
+}
+
+async function fetchLatestVersion(): Promise<string | null> {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE_NAME}/latest`, {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version?: string };
+    return data.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Explicit check — used by `fink upgrade --check`. */
+export async function checkForUpdate(currentVersion: string): Promise<{ current: string; latest: string | null; hasUpdate: boolean }> {
+  const latest = await fetchLatestVersion();
+  if (latest) writeCache({ lastCheck: Date.now(), latestVersion: latest });
+  return {
+    current: currentVersion,
+    latest,
+    hasUpdate: latest !== null && compareVersions(latest, currentVersion) > 0,
+  };
+}
+
+function banner(currentVersion: string, latestVersion: string): string {
+  const upgradeCmd = isStandaloneBinary()
+    ? `Download: ${GITHUB_RELEASES_URL}`
+    : `Run: npm i -g ${NPM_PACKAGE_NAME}@latest`;
+  const lines = [
+    `Update available ${currentVersion} → ${latestVersion}`,
+    upgradeCmd,
+  ];
+  const width = Math.max(...lines.map((l) => l.length)) + 2;
+  const top = `╭${"─".repeat(width)}╮`;
+  const bot = `╰${"─".repeat(width)}╯`;
+  const body = lines.map((l) => `│ ${l}${" ".repeat(width - l.length - 1)}│`).join("\n");
+  return `\n${top}\n${body}\n${bot}\n`;
+}
+
+/**
+ * Print an upgrade banner to stderr if a cached check says an update is available,
+ * and asynchronously refresh the cache in the background if it's stale. Safe to call
+ * on every invocation; never blocks the current command.
+ */
+export function notifyIfUpdateAvailable(currentVersion: string): void {
+  // Honor opt-out used by both `update-notifier` and Node tooling in general.
+  if (process.env.NO_UPDATE_NOTIFIER === "1" || process.env.CI) return;
+
+  const cache = readCache();
+
+  if (cache.latestVersion && compareVersions(cache.latestVersion, currentVersion) > 0) {
+    process.stderr.write(banner(currentVersion, cache.latestVersion));
+  }
+
+  if (Date.now() - cache.lastCheck > CHECK_INTERVAL_MS) {
+    // Fire and forget — do not await.
+    fetchLatestVersion()
+      .then((latest) => {
+        writeCache({ lastCheck: Date.now(), latestVersion: latest });
+      })
+      .catch(() => {});
+  }
+}

--- a/packages/desktop/build.mjs
+++ b/packages/desktop/build.mjs
@@ -22,6 +22,7 @@ const require = createRequire(import.meta.url);`,
   },
   external: [
     "electron",
+    "electron-updater",
     "better-sqlite3",
     // Bun-specific modules — only reached at runtime when isBun===true (never in Electron)
     "bun:sqlite",

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -2,6 +2,14 @@ appId: com.frozenink.desktop
 productName: Frozen Ink
 copyright: Copyright © 2026
 
+# Tells electron-builder where to emit `latest-*.yml` update manifests during
+# dist:* runs, and where electron-updater should look at runtime. Uploading
+# the installers themselves to the release is handled by our GH workflow.
+publish:
+  provider: github
+  owner: vboctor
+  repo: frozen-ink
+
 directories:
   output: release
   buildResources: build

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -14,7 +14,8 @@
     "dist:linux": "bun build.mjs && electron-builder --linux"
   },
   "dependencies": {
-    "better-sqlite3": "^11.0.0"
+    "better-sqlite3": "^11.0.0",
+    "electron-updater": "^6.3.9"
   },
   "devDependencies": {
     "electron": "^33.0.0",

--- a/packages/desktop/src/main/auto-updater.ts
+++ b/packages/desktop/src/main/auto-updater.ts
@@ -1,0 +1,45 @@
+/**
+ * Notify-only auto-updater.
+ *
+ * Because the desktop builds are unsigned on macOS and Windows, silent
+ * self-replacement via electron-updater is unsafe (Gatekeeper / SmartScreen
+ * will block an uninstalled update). Instead, we check GitHub Releases on
+ * launch + every 4h, and when a newer version is published we notify the
+ * renderer which shows a banner linking to the release page. The user
+ * downloads and installs the new build manually.
+ */
+import type { BrowserWindow } from "electron";
+import { app } from "electron";
+import { autoUpdater } from "electron-updater";
+
+const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+const RELEASES_PAGE = "https://github.com/vboctor/frozen-ink/releases/latest";
+
+export function initAutoUpdater(window: BrowserWindow): void {
+  // In dev (unpackaged) the auto-update config files are missing and the
+  // check would just produce noise.
+  if (!app.isPackaged) return;
+
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = false;
+  // electron-updater ships its own logger slot; stderr console is fine for now.
+  autoUpdater.logger = console;
+
+  autoUpdater.on("update-available", (info) => {
+    if (window.isDestroyed()) return;
+    window.webContents.send("update:available", {
+      version: info.version,
+      releaseNotes: typeof info.releaseNotes === "string" ? info.releaseNotes : null,
+      releaseUrl: RELEASES_PAGE,
+    });
+  });
+
+  autoUpdater.on("error", (err) => {
+    console.warn("[auto-updater]", err?.message ?? err);
+  });
+
+  autoUpdater.checkForUpdates().catch(() => {});
+  setInterval(() => {
+    autoUpdater.checkForUpdates().catch(() => {});
+  }, CHECK_INTERVAL_MS);
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -9,6 +9,7 @@ const __desktopDirname = dirname(__desktopFilename);
 import { getLastWorkspace, openWorkspace, createWorkspace, listRecentWorkspaces } from "./workspace-manager";
 import { registerIpcHandlers } from "./ipc-handlers";
 import { createTray, updateTrayMenu, destroyTray } from "./tray";
+import { initAutoUpdater } from "./auto-updater";
 import { setAppMode } from "../../../cli/src/commands/management-api";
 import { createApiServer } from "../../../cli/src/commands/serve";
 
@@ -127,6 +128,8 @@ app.whenReady().then(async () => {
   }
 
   mainWindow = createMainWindow();
+
+  initAutoUpdater(mainWindow);
 
   // Register IPC handlers
   registerIpcHandlers(() => mainWindow);

--- a/packages/desktop/src/main/ipc-handlers.ts
+++ b/packages/desktop/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, BrowserWindow } from "electron";
+import { ipcMain, dialog, shell, BrowserWindow } from "electron";
 import {
   loadWorkspaces,
   createWorkspace,
@@ -39,5 +39,18 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null): 
 
   ipcMain.handle("get-platform", () => {
     return process.platform;
+  });
+
+  // Open a release page in the user's default browser. URL is validated to
+  // avoid the IPC channel being repurposed to open arbitrary links.
+  ipcMain.handle("update:open-release-page", async (_event, url: string) => {
+    try {
+      const parsed = new URL(url);
+      if (parsed.host !== "github.com") return { ok: false };
+      await shell.openExternal(parsed.toString());
+      return { ok: true };
+    } catch {
+      return { ok: false };
+    }
   });
 }

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,5 +1,11 @@
 import { contextBridge, ipcRenderer } from "electron";
 
+export interface UpdateInfo {
+  version: string;
+  releaseNotes: string | null;
+  releaseUrl: string;
+}
+
 contextBridge.exposeInMainWorld("frozenink", {
   openDirectoryPicker: () => ipcRenderer.invoke("open-directory-picker"),
   getWorkspaces: () => ipcRenderer.invoke("get-workspaces"),
@@ -9,4 +15,10 @@ contextBridge.exposeInMainWorld("frozenink", {
   switchWorkspace: (path: string) => ipcRenderer.invoke("switch-workspace", path),
   getAppVersion: () => ipcRenderer.invoke("get-app-version"),
   platform: process.platform,
+  onUpdateAvailable: (cb: (info: UpdateInfo) => void) => {
+    const handler = (_: unknown, info: UpdateInfo) => cb(info);
+    ipcRenderer.on("update:available", handler);
+    return () => ipcRenderer.removeListener("update:available", handler);
+  },
+  openReleasePage: (url: string) => ipcRenderer.invoke("update:open-release-page", url),
 });

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -371,6 +371,52 @@ body {
   color: var(--text);
 }
 
+.update-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px;
+  background: var(--accent-bg);
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
+  font-size: 0.85rem;
+  font-family: var(--font-sans);
+  flex-shrink: 0;
+}
+
+.update-banner-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.update-banner-btn {
+  padding: 4px 10px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.update-banner-btn:hover {
+  opacity: 0.9;
+}
+
+.update-banner-close {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.update-banner-close:hover {
+  color: var(--text);
+}
+
 /* ===== Layout ===== */
 .layout {
   display: flex;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,6 +12,7 @@ import BrowseSyncButton from "./components/BrowseSyncButton";
 import TabBar, { type Tab } from "./components/TabBar";
 import LinksPanel, { type Backlink, type LinkItem } from "./components/LinksPanel";
 import ModeSwitcher from "./components/ModeSwitcher";
+import UpdateBanner from "./components/UpdateBanner";
 import ManageNav, { type ManageSection } from "./components/manage/ManageNav";
 import CollectionList from "./components/manage/CollectionList";
 import CollectionForm from "./components/manage/CollectionForm";
@@ -1263,6 +1264,7 @@ export default function App() {
 
   return (
     <>
+      {appMode === "desktop" && <UpdateBanner />}
       {appMode !== "desktop" && (
         <FrozenInkBanner
           collectionTitle={collections.find((c) => c.name === selectedCollection)?.title ?? selectedCollection}

--- a/packages/ui/src/components/UpdateBanner.tsx
+++ b/packages/ui/src/components/UpdateBanner.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+
+interface UpdateInfo {
+  version: string;
+  releaseNotes: string | null;
+  releaseUrl: string;
+}
+
+interface FrozenInkApi {
+  onUpdateAvailable?: (cb: (info: UpdateInfo) => void) => () => void;
+  openReleasePage?: (url: string) => Promise<{ ok: boolean }>;
+}
+
+const DISMISS_KEY = "frozenink-update-dismissed";
+
+export default function UpdateBanner() {
+  const [info, setInfo] = useState<UpdateInfo | null>(null);
+
+  useEffect(() => {
+    const api = (window as unknown as { frozenink?: FrozenInkApi }).frozenink;
+    if (!api?.onUpdateAvailable) return;
+    return api.onUpdateAvailable((next) => {
+      try {
+        if (localStorage.getItem(DISMISS_KEY) === next.version) return;
+      } catch {}
+      setInfo(next);
+    });
+  }, []);
+
+  if (!info) return null;
+
+  const dismiss = () => {
+    try { localStorage.setItem(DISMISS_KEY, info.version); } catch {}
+    setInfo(null);
+  };
+
+  const download = () => {
+    const api = (window as unknown as { frozenink?: FrozenInkApi }).frozenink;
+    api?.openReleasePage?.(info.releaseUrl).catch(() => {});
+  };
+
+  return (
+    <div className="update-banner" role="status">
+      <span className="update-banner-text">
+        Frozen Ink {info.version} is available.
+      </span>
+      <button className="update-banner-btn" onClick={download}>Download</button>
+      <button className="update-banner-close" onClick={dismiss} aria-label="Dismiss update notice">×</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- CLI: daily npm registry check with a channel-aware banner (npm vs. standalone Bun binary) plus a new `fink upgrade [--check]` command. The notifier is inlined instead of using the `update-notifier` package because that package forks a `check.js` file that does not survive esbuild bundling or `bun build --compile`.
- Desktop: runs `electron-updater` in notify-only mode (builds are unsigned, so silent self-replace is unsafe). When a newer release is detected, the main process emits an IPC event; a dismissible `UpdateBanner` renders in the UI and opens the GitHub releases page via `shell.openExternal` (host allowlisted to `github.com`).
- Release pipeline: uploads `latest-mac.yml` / `latest.yml` / `latest-linux.yml` alongside installers so `electron-updater` can find manifests at runtime. `electron-builder.yml` gains a `publish: { provider: github }` block.

## Test plan

- [x] `bun run ci` (markdown lint, typecheck, all test suites, UI + worker build)
- [x] `cd packages/cli && bun run build` produces `dist/fink.mjs` cleanly
- [ ] Tag a test release and confirm `latest-*.yml` manifests appear and packaged desktop picks them up
- [ ] Smoke test `fink upgrade --check` against the real npm registry
- [ ] Verify standalone binary path prints the GitHub releases URL instead of `npm i -g`

🤖 Generated with [Claude Code](https://claude.com/claude-code)