### PR TITLE
Restructure RSS tree, speed up republish, and fix desktop updater

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -30,18 +30,37 @@ async function writeFolderConfigFiles(
   basePath: string,
 ): Promise<void> {
   const configs = themeEngine.getFolderConfigs(crawlerType);
-  if (Object.keys(configs).length === 0) return;
 
-  // Use listDirs so empty directories (e.g. assets/ with no files yet) are also covered
   const allDirs = await storage.listDirs!(basePath);
+
+  // Collect dirs that contain at least one markdown file (directly or via subdirs).
+  const allFiles = await storage.list(basePath);
+  const dirsWithMarkdown = new Set<string>();
+  for (const filePath of allFiles) {
+    if (!filePath.endsWith(".md")) continue;
+    const parts = filePath.split("/");
+    for (let i = 1; i < parts.length; i++) {
+      dirsWithMarkdown.add(parts.slice(0, i).join("/"));
+    }
+  }
 
   for (const dirPath of allDirs) {
     const folderName = dirPath.split("/").pop()!;
-    if (!(folderName in configs)) continue;
+    // Remove stale yml files from dirs that no longer contain any markdown files.
+    if (!dirsWithMarkdown.has(dirPath)) {
+      try {
+        await storage.delete(`${dirPath}/${folderName}.yml`);
+      } catch {
+        // yml may not exist — fine
+      }
+      continue;
+    }
+    if (Object.keys(configs).length === 0 || !(folderName in configs)) continue;
     const config = configs[folderName];
     const lines: string[] = [];
     if (config.visible === false) lines.push("visible: false");
     if (config.sort === "DESC") lines.push("sort: DESC");
+    if (lines.length === 0) continue;
     await storage.write(`${dirPath}/${folderName}.yml`, lines.join("\n") + "\n");
   }
 }

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -812,6 +812,7 @@ async function triggerPublish(opts: Record<string, unknown>): Promise<void> {
       { collectionName, toolDescription, password, removePassword, forcePublic },
       (step, detail) => {
         publishProgress = { ...publishProgress, step, detail };
+        console.log(`[publish:${collectionName}] ${step}: ${detail}`);
       },
     );
 

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,7 +1,8 @@
 import { Command } from "commander";
-import { existsSync, readdirSync, statSync } from "fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { join, extname } from "path";
 import { createInterface } from "readline";
+import { createHash } from "crypto";
 import {
   getFrozenInkHome,
   getCollectionDb,
@@ -18,6 +19,7 @@ import {
   getNamedCredentials,
   saveNamedCredentials,
   removeNamedCredentials,
+  MetadataStore,
 } from "@frozenink/core";
 import { getPublishCredentialKey } from "./publish-credentials";
 import type { EntityData } from "@frozenink/core";
@@ -96,6 +98,85 @@ async function runConcurrent<T>(
   await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
 }
 
+const META_WORKER_CONFIG_HASH = "publish.last_worker_config_hash";
+const META_LOCAL_MANIFEST_HASH = "publish.last_local_manifest_hash";
+
+function sha256Hex(input: string | Buffer): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+/**
+ * Fingerprint of the inputs that decide what the deployed worker does.
+ * Includes the bundle bytes plus all fields baked into wrangler.toml.
+ * Excludes the salted passwordHash (which changes every publish) — we use the
+ * plaintext password presence/value instead so stable inputs hash stably.
+ */
+function computeWorkerConfigHash(inputs: {
+  workerBundlePath: string;
+  workerName: string;
+  d1DatabaseName: string;
+  d1DatabaseId: string;
+  r2BucketName: string;
+  plaintextPassword: string;
+  passwordProtected: boolean;
+  toolDescription?: string;
+}): string {
+  const bundleBytes = readFileSync(inputs.workerBundlePath);
+  const bundleHash = sha256Hex(bundleBytes);
+  const configJson = JSON.stringify({
+    bundleHash,
+    workerName: inputs.workerName,
+    d1DatabaseName: inputs.d1DatabaseName,
+    d1DatabaseId: inputs.d1DatabaseId,
+    r2BucketName: inputs.r2BucketName,
+    plaintextPassword: inputs.plaintextPassword,
+    passwordProtected: inputs.passwordProtected,
+    toolDescription: inputs.toolDescription ?? "",
+  });
+  return sha256Hex(configJson);
+}
+
+/**
+ * Pack rows into one or more `<prefix> (..), (..), (..);` statements, flushing
+ * when the pending buffer would exceed maxBytes. Empty rows list is a no-op.
+ */
+function pushMultiRowInserts(
+  out: string[],
+  prefix: string,
+  rows: string[],
+  maxBytes: number,
+): void {
+  if (rows.length === 0) return;
+  const prefixBytes = Buffer.byteLength(prefix, "utf8");
+  let buf: string[] = [];
+  let bufBytes = prefixBytes;
+  for (const row of rows) {
+    const rowBytes = Buffer.byteLength(row, "utf8") + 2; // ", " separator
+    if (buf.length > 0 && bufBytes + rowBytes > maxBytes) {
+      out.push(`${prefix}${buf.join(", ")};`);
+      buf = [];
+      bufBytes = prefixBytes;
+    }
+    buf.push(row);
+    bufBytes += rowBytes;
+  }
+  if (buf.length > 0) out.push(`${prefix}${buf.join(", ")};`);
+}
+
+/**
+ * Stable fingerprint of the local entity set. Includes folder/slug so that
+ * theme-driven path changes (e.g. slug format update) trigger a D1 push even
+ * when contentHash is unchanged.
+ */
+function computeLocalManifestHash(
+  rows: Array<{ externalId: string; contentHash: string | null; folder: string | null; slug: string | null }>,
+): string {
+  const sorted = rows
+    .map((r) => `${r.externalId}\t${r.contentHash ?? ""}\t${r.folder ?? ""}\t${r.slug ?? ""}`)
+    .sort();
+  return sha256Hex(sorted.join("\n"));
+}
+
 // --- Reusable publish function ---
 
 export interface PublishOptions {
@@ -105,6 +186,13 @@ export interface PublishOptions {
   removePassword?: boolean;
   forcePublic?: boolean;
   workerOnly?: boolean;
+  /**
+   * Force a full D1 rebuild: bypass the manifest-hash short-circuit and treat
+   * every local entity as "push". Needed after theme path changes (folder/slug
+   * moves) because those don't alter contentHash and the incremental plan
+   * wouldn't pick them up.
+   */
+  full?: boolean;
 }
 
 export interface PublishResult {
@@ -179,7 +267,7 @@ export async function publishCollections(
 
   await checkWranglerAuth();
 
-  const { collectionName, removePassword = false, forcePublic = false } = options;
+  const { collectionName, removePassword = false, forcePublic = false, full = false } = options;
   let { workerOnly = false } = options;
   const workerName = collectionName;
   const password = options.password?.trim();
@@ -258,6 +346,11 @@ export async function publishCollections(
     throw new Error("Worker bundle not found. If developing locally, run 'cd packages/worker && bun run build'.");
   }
 
+  // Open the collection metadata store — used for cross-publish caching
+  // (worker-config hash to skip redeploy, local-manifest hash to skip D1 push).
+  const collectionDbPath = getCollectionDbPath(collectionName);
+  const meta = existsSync(collectionDbPath) ? new MetadataStore(collectionDbPath) : null;
+
   // --- Phase 1: Create infrastructure + deploy worker ---
 
   if (!workerOnly) {
@@ -270,29 +363,46 @@ export async function publishCollections(
   onProgress("r2", "Setting up R2 bucket...");
   await createR2Bucket(r2BucketName);
 
-  onProgress("deploy", "Deploying worker...");
-
-  const tomlContent = generateWranglerToml({
+  const workerConfigHash = computeWorkerConfigHash({
+    workerBundlePath,
     workerName,
-    mainScript: workerBundlePath,
     d1DatabaseName,
     d1DatabaseId,
     r2BucketName,
-    passwordHash,
+    plaintextPassword,
+    passwordProtected: passwordHash.length > 0,
     toolDescription,
   });
-  const tomlFile = writeTempFile(tomlContent, ".toml");
+  const storedWorkerConfigHash = isUpdate ? meta?.getOptional(META_WORKER_CONFIG_HASH) : null;
+  const canSkipDeploy = isUpdate && storedWorkerConfigHash === workerConfigHash && !!existingPublish?.url;
+
   let workerUrl = "";
-  try {
-    workerUrl = await deployWorker(tomlFile);
-  } finally {
-    cleanupTempFile(tomlFile);
-  }
-  // Wrangler doesn't always echo the URL on re-deploys — fall back to the
-  // previously-saved URL (or the default workers.dev hostname) so downstream
-  // requests like the manifest fetch in Phase 3 always have a real base URL.
-  if (!workerUrl) {
-    workerUrl = existingPublish?.url || `https://${workerName}.workers.dev`;
+  if (canSkipDeploy) {
+    workerUrl = existingPublish!.url;
+    onProgress("deploy", "Worker bundle + config unchanged — skipping redeploy");
+  } else {
+    onProgress("deploy", "Deploying worker...");
+    const tomlContent = generateWranglerToml({
+      workerName,
+      mainScript: workerBundlePath,
+      d1DatabaseName,
+      d1DatabaseId,
+      r2BucketName,
+      passwordHash,
+      toolDescription,
+    });
+    const tomlFile = writeTempFile(tomlContent, ".toml");
+    try {
+      workerUrl = await deployWorker(tomlFile);
+    } finally {
+      cleanupTempFile(tomlFile);
+    }
+    // Wrangler doesn't always echo the URL on re-deploys — fall back to the
+    // previously-saved URL (or the default workers.dev hostname) so downstream
+    // requests like the manifest fetch in Phase 3 always have a real base URL.
+    if (!workerUrl) {
+      workerUrl = existingPublish?.url || `https://${workerName}.workers.dev`;
+    }
   }
 
   // --- Phase 2: R2 uploads (before D1 rebuild so the site stays live on old data) ---
@@ -397,44 +507,10 @@ export async function publishCollections(
 
   // --- Phase 3: D1 incremental update (manifest-driven delta) ---
 
+  let newLocalManifestHash: string | null = null;
+
   if (!workerOnly) {
     onProgress("d1-build", "Computing incremental plan...");
-
-    // Ensure schema exists. Idempotent so first publish creates tables and
-    // re-publish is a no-op. No DROPs — the manifest-driven delta below
-    // brings D1 in sync without wiping it.
-    const schemaInit: string[] = [];
-    schemaInit.push(`CREATE TABLE IF NOT EXISTS entities (
-  id INTEGER PRIMARY KEY,
-  external_id TEXT NOT NULL, entity_type TEXT NOT NULL,
-  title TEXT NOT NULL, data TEXT NOT NULL DEFAULT '{}',
-  content_hash TEXT,
-  folder TEXT,
-  slug TEXT,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);`);
-    schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_external ON entities(external_id);");
-    schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_folder   ON entities(folder, slug);");
-    schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_type     ON entities(entity_type);");
-    schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_updated  ON entities(updated_at);");
-    schemaInit.push("CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(entity_id UNINDEXED, external_id UNINDEXED, entity_type UNINDEXED, title, content, tags);");
-    await executeD1Query(d1DatabaseId, schemaInit.join("\n"));
-
-    // Fetch remote manifest (empty on first publish). Manifest endpoint is
-    // behind authMiddleware when PASSWORD_HASH is set; pass the plaintext
-    // password so the request authenticates against the worker we just deployed.
-    let remoteManifest: ManifestEntity[] = [];
-    if (isUpdate) {
-      try {
-        const client = new RemoteClient(workerUrl, plaintextPassword || undefined);
-        const { entries } = await client.getManifest();
-        remoteManifest = entries;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        onProgress("d1-build", `Could not fetch remote manifest (${msg}); treating as empty`);
-      }
-    }
 
     // Read all local entities once.
     const themeEngine = createGenerateThemeEngine();
@@ -471,126 +547,200 @@ export async function publishCollections(
       );
     }
 
-    const localForPlan: LocalEntity[] = localRows.map(({ entity }) => ({
-      externalId: entity.externalId,
-      entityType: entity.entityType,
-      title: entity.title,
-      data: entity.data as unknown as Record<string, unknown> | string,
-      contentHash: entity.contentHash ?? null,
-    }));
-    const plan = computeSyncPlan(localForPlan, remoteManifest);
-    // Invert pull semantics into push semantics: computeSyncPlan returns
-    //   add    = remote-only (pull would download these)
-    //   update = both, hash differs
-    //   delete = local-only (pull would remove these locally)
-    // For publish we instead need:
-    //   push:   local-only + hash-differs   → INSERT OR REPLACE on remote
-    //   prune:  remote-only                 → DELETE on remote
-    const pushExtIds = [
-      ...plan.entities.delete,
-      ...plan.entities.update.map((e) => e.externalId),
-    ];
-    const pruneExtIds = plan.entities.add.map((e) => e.externalId);
-
-    onProgress(
-      "d1-build",
-      `Incremental plan: +${plan.entities.delete.length} ~${plan.entities.update.length} -${pruneExtIds.length}`,
+    // Fast-path: if the local entity set is identical to what we last pushed,
+    // skip the entire D1 phase (schema init + manifest fetch + plan + upload +
+    // cache invalidation). The stored hash is only set after a successful push,
+    // so this is safe to trust without round-tripping /info.
+    newLocalManifestHash = computeLocalManifestHash(
+      localRows.map(({ entity }) => ({
+        externalId: entity.externalId,
+        contentHash: entity.contentHash ?? null,
+        folder: entity.folder ?? null,
+        slug: entity.slug ?? null,
+      })),
     );
-
-    // Build delta SQL.
-    const deltaSql: string[] = [];
-
-    // Chunk IN(...) lists so each DELETE statement stays under MAX_BATCH_BYTES.
-    const DELETE_CHUNK = 200;
-
-    // Prune entries that exist remotely but not locally — drop FTS rows
-    // first (no cascade), then entities rows.
-    for (let i = 0; i < pruneExtIds.length; i += DELETE_CHUNK) {
-      const chunk = pruneExtIds.slice(i, i + DELETE_CHUNK);
-      const inList = chunk.map((id) => `'${escapeSQL(id)}'`).join(",");
-      deltaSql.push(`DELETE FROM entities_fts WHERE external_id IN (${inList});`);
-      deltaSql.push(`DELETE FROM entities WHERE external_id IN (${inList});`);
-    }
-
-    if (pushExtIds.length > 0) {
-      // Pre-delete FTS and entity rows for pushed entities. Neither table has
-      // a UNIQUE constraint on external_id (entities.id is the only PK), so
-      // INSERT OR REPLACE wouldn't dedupe — explicit DELETE is required
-      // before the INSERTs below to avoid leaving stale duplicates.
-      for (let i = 0; i < pushExtIds.length; i += DELETE_CHUNK) {
-        const chunk = pushExtIds.slice(i, i + DELETE_CHUNK);
-        const inList = chunk.map((id) => `'${escapeSQL(id)}'`).join(",");
-        deltaSql.push(`DELETE FROM entities_fts WHERE external_id IN (${inList});`);
-        deltaSql.push(`DELETE FROM entities WHERE external_id IN (${inList});`);
-      }
-
-      const pushSet = new Set(pushExtIds);
-      for (const { entity, colName, colCrawler } of localRows) {
-        if (!pushSet.has(entity.externalId)) continue;
-
-        const data = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
-        const folderVal = entity.folder != null ? `'${escapeSQL(entity.folder)}'` : "NULL";
-        const slugVal = entity.slug != null ? `'${escapeSQL(entity.slug)}'` : "NULL";
-
-        deltaSql.push(`INSERT OR REPLACE INTO entities (external_id, entity_type, title, data, content_hash, folder, slug, created_at, updated_at) VALUES ('${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(data)}', ${entity.contentHash ? `'${escapeSQL(entity.contentHash)}'` : "NULL"}, ${folderVal}, ${slugVal}, ${entity.createdAt ? `'${escapeSQL(entity.createdAt)}'` : "datetime('now')"}, ${entity.updatedAt ? `'${escapeSQL(entity.updatedAt)}'` : "datetime('now')"});`);
-
-        const entityDataParsed: EntityData = typeof entity.data === "object" ? entity.data as EntityData : JSON.parse(entity.data as string);
-        const entityTagNames = (entityDataParsed.tags ?? []).join(" ");
-        let ftsContent = "";
-        const hasMarkdown = entity.folder != null && entity.slug != null;
-        if (hasMarkdown && themeEngine.has(colCrawler)) {
-          try {
-            ftsContent = themeEngine.render({
-              entity: {
-                externalId: entity.externalId,
-                entityType: entity.entityType,
-                title: entity.title,
-                data: (entityDataParsed.source ?? {}) as Record<string, unknown>,
-                url: entityDataParsed.url ?? undefined,
-                tags: entityDataParsed.tags ?? [],
-              },
-              collectionName: colName,
-              crawlerType: colCrawler,
-            });
-          } catch { /* fall back to empty content */ }
-        }
-        if (ftsContent.length > MAX_FTS_CONTENT) ftsContent = ftsContent.slice(0, MAX_FTS_CONTENT);
-
-        deltaSql.push(`INSERT INTO entities_fts (entity_id, external_id, entity_type, title, content, tags) VALUES (${ftsEntityIdFor(entity.externalId)}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(ftsContent)}', '${escapeSQL(entityTagNames)}');`);
-      }
-    }
-
-    if (deltaSql.length === 0) {
-      onProgress("d1-upload", "No D1 changes to apply");
+    const storedLocalManifestHash = isUpdate ? meta?.getOptional(META_LOCAL_MANIFEST_HASH) : null;
+    if (!full && storedLocalManifestHash && storedLocalManifestHash === newLocalManifestHash) {
+      onProgress("d1-build", "Local manifest unchanged since last publish — skipping D1 rebuild");
     } else {
-      // Batch upload bounded by size (large data blobs) and count (execution time).
-      // Use Buffer.byteLength for accurate UTF-8 byte count — stmt.length undercounts Unicode.
+      // Ensure schema exists. Idempotent so first publish creates tables and
+      // re-publish is a no-op. No DROPs — the manifest-driven delta below
+      // brings D1 in sync without wiping it.
+      const schemaInit: string[] = [];
+      schemaInit.push(`CREATE TABLE IF NOT EXISTS entities (
+  id INTEGER PRIMARY KEY,
+  external_id TEXT NOT NULL, entity_type TEXT NOT NULL,
+  title TEXT NOT NULL, data TEXT NOT NULL DEFAULT '{}',
+  content_hash TEXT,
+  folder TEXT,
+  slug TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);`);
+      schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_external ON entities(external_id);");
+      schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_folder   ON entities(folder, slug);");
+      schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_type     ON entities(entity_type);");
+      schemaInit.push("CREATE INDEX IF NOT EXISTS idx_entities_updated  ON entities(updated_at);");
+      schemaInit.push("CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(entity_id UNINDEXED, external_id UNINDEXED, entity_type UNINDEXED, title, content, tags);");
+      await executeD1Query(d1DatabaseId, schemaInit.join("\n"));
+
+      // Fetch remote manifest (empty on first publish). Manifest endpoint is
+      // behind authMiddleware when PASSWORD_HASH is set; pass the plaintext
+      // password so the request authenticates against the worker we just deployed.
+      let remoteManifest: ManifestEntity[] = [];
+      if (isUpdate) {
+        try {
+          const client = new RemoteClient(workerUrl, plaintextPassword || undefined);
+          const { entries } = await client.getManifest();
+          remoteManifest = entries;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          onProgress("d1-build", `Could not fetch remote manifest (${msg}); treating as empty`);
+        }
+      }
+
+      const localForPlan: LocalEntity[] = localRows.map(({ entity }) => ({
+        externalId: entity.externalId,
+        entityType: entity.entityType,
+        title: entity.title,
+        data: entity.data as unknown as Record<string, unknown> | string,
+        contentHash: entity.contentHash ?? null,
+      }));
+      const plan = computeSyncPlan(localForPlan, remoteManifest);
+      // Invert pull semantics into push semantics: computeSyncPlan returns
+      //   add    = remote-only (pull would download these)
+      //   update = both, hash differs
+      //   delete = local-only (pull would remove these locally)
+      // For publish we instead need:
+      //   push:   local-only + hash-differs   → INSERT OR REPLACE on remote
+      //   prune:  remote-only                 → DELETE on remote
+      // --full forces every local entity into the push set so folder/slug
+      // (and other non-content-hash) changes propagate to D1.
+      const pushExtIds = full
+        ? localRows.map((r) => r.entity.externalId)
+        : [
+            ...plan.entities.delete,
+            ...plan.entities.update.map((e) => e.externalId),
+          ];
+      const pruneExtIds = plan.entities.add.map((e) => e.externalId);
+
+      onProgress(
+        "d1-build",
+        full
+          ? `Full rebuild: ${pushExtIds.length} pushed, ${pruneExtIds.length} pruned`
+          : `Incremental plan: +${plan.entities.delete.length} ~${plan.entities.update.length} -${pruneExtIds.length}`,
+      );
+
+      // Two-phase SQL: all DELETEs before any INSERTs, so batches can run in
+      // parallel without risking an INSERT racing its own pre-delete.
+      const deleteSql: string[] = [];
+      const insertSql: string[] = [];
+
+      // Chunk IN(...) lists so each DELETE statement stays under MAX_BATCH_BYTES.
+      const DELETE_CHUNK = 200;
+
+      // Prune entries that exist remotely but not locally — drop FTS rows
+      // first (no cascade), then entities rows.
+      const allDeleteIds = [...pruneExtIds, ...pushExtIds];
+      for (let i = 0; i < allDeleteIds.length; i += DELETE_CHUNK) {
+        const chunk = allDeleteIds.slice(i, i + DELETE_CHUNK);
+        const inList = chunk.map((id) => `'${escapeSQL(id)}'`).join(",");
+        deleteSql.push(`DELETE FROM entities_fts WHERE external_id IN (${inList});`);
+        deleteSql.push(`DELETE FROM entities WHERE external_id IN (${inList});`);
+      }
+
+      if (pushExtIds.length > 0) {
+        const pushSet = new Set(pushExtIds);
+        const entityValueRows: string[] = [];
+        const ftsValueRows: string[] = [];
+
+        for (const { entity, colName, colCrawler } of localRows) {
+          if (!pushSet.has(entity.externalId)) continue;
+
+          const data = typeof entity.data === "string" ? entity.data : JSON.stringify(entity.data);
+          const folderVal = entity.folder != null ? `'${escapeSQL(entity.folder)}'` : "NULL";
+          const slugVal = entity.slug != null ? `'${escapeSQL(entity.slug)}'` : "NULL";
+
+          entityValueRows.push(
+            `('${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(data)}', ${entity.contentHash ? `'${escapeSQL(entity.contentHash)}'` : "NULL"}, ${folderVal}, ${slugVal}, ${entity.createdAt ? `'${escapeSQL(entity.createdAt)}'` : "datetime('now')"}, ${entity.updatedAt ? `'${escapeSQL(entity.updatedAt)}'` : "datetime('now')"})`,
+          );
+
+          const entityDataParsed: EntityData = typeof entity.data === "object" ? entity.data as EntityData : JSON.parse(entity.data as string);
+          const entityTagNames = (entityDataParsed.tags ?? []).join(" ");
+          let ftsContent = "";
+          const hasMarkdown = entity.folder != null && entity.slug != null;
+          if (hasMarkdown && themeEngine.has(colCrawler)) {
+            try {
+              ftsContent = themeEngine.render({
+                entity: {
+                  externalId: entity.externalId,
+                  entityType: entity.entityType,
+                  title: entity.title,
+                  data: (entityDataParsed.source ?? {}) as Record<string, unknown>,
+                  url: entityDataParsed.url ?? undefined,
+                  tags: entityDataParsed.tags ?? [],
+                },
+                collectionName: colName,
+                crawlerType: colCrawler,
+              });
+            } catch { /* fall back to empty content */ }
+          }
+          if (ftsContent.length > MAX_FTS_CONTENT) ftsContent = ftsContent.slice(0, MAX_FTS_CONTENT);
+
+          ftsValueRows.push(
+            `(${ftsEntityIdFor(entity.externalId)}, '${escapeSQL(entity.externalId)}', '${escapeSQL(entity.entityType)}', '${escapeSQL(entity.title)}', '${escapeSQL(ftsContent)}', '${escapeSQL(entityTagNames)}')`,
+          );
+        }
+
+        // Group rows into multi-row INSERTs to cut per-statement overhead.
+        // Bounded by byte size per INSERT to stay under D1's statement limit.
+        const MAX_INSERT_BYTES = 80 * 1024;
+        const entityPrefix = "INSERT OR REPLACE INTO entities (external_id, entity_type, title, data, content_hash, folder, slug, created_at, updated_at) VALUES ";
+        const ftsPrefix = "INSERT INTO entities_fts (entity_id, external_id, entity_type, title, content, tags) VALUES ";
+        pushMultiRowInserts(insertSql, entityPrefix, entityValueRows, MAX_INSERT_BYTES);
+        pushMultiRowInserts(insertSql, ftsPrefix, ftsValueRows, MAX_INSERT_BYTES);
+      }
+
+      // Pack each phase into size-bounded batches, then execute each phase
+      // with bounded concurrency. Deletes always finish before any inserts.
       const MAX_BATCH_BYTES = 100 * 1024;
       const MAX_BATCH_COUNT = 500;
-      const batches: string[][] = [];
-      let current: string[] = [];
-      let currentBytes = 0;
-      for (const stmt of deltaSql) {
-        const stmtBytes = Buffer.byteLength(stmt, "utf8");
-        if (current.length > 0 && (currentBytes + stmtBytes > MAX_BATCH_BYTES || current.length >= MAX_BATCH_COUNT)) {
-          batches.push(current);
-          current = [];
-          currentBytes = 0;
-        }
-        current.push(stmt);
-        currentBytes += stmtBytes;
-      }
-      if (current.length > 0) batches.push(current);
+      const D1_CONCURRENCY = 4;
 
-      const totalBatches = batches.length;
-      onProgress("d1-upload", `Uploading to D1 (${totalBatches} batch${totalBatches === 1 ? "" : "es"})...`);
-      let batchCount = 0;
-      for (const batch of batches) {
-        await executeD1Query(d1DatabaseId, batch.join("\n"));
-        batchCount++;
-        if (batchCount % 5 === 0 || batchCount === totalBatches) {
-          onProgress("d1-upload", `Uploading to D1... ${batchCount}/${totalBatches} batches`);
+      async function runPhase(phaseSql: string[], label: string) {
+        if (phaseSql.length === 0) return;
+        const batches: string[][] = [];
+        let current: string[] = [];
+        let currentBytes = 0;
+        for (const stmt of phaseSql) {
+          const stmtBytes = Buffer.byteLength(stmt, "utf8");
+          if (current.length > 0 && (currentBytes + stmtBytes > MAX_BATCH_BYTES || current.length >= MAX_BATCH_COUNT)) {
+            batches.push(current);
+            current = [];
+            currentBytes = 0;
+          }
+          current.push(stmt);
+          currentBytes += stmtBytes;
         }
+        if (current.length > 0) batches.push(current);
+
+        const total = batches.length;
+        onProgress("d1-upload", `${label}: ${total} batch${total === 1 ? "" : "es"} (concurrency ${Math.min(D1_CONCURRENCY, total)})...`);
+        let done = 0;
+        await runConcurrent(batches, D1_CONCURRENCY, async (batch) => {
+          await executeD1Query(d1DatabaseId, batch.join("\n"));
+          done++;
+          if (done % 5 === 0 || done === total) {
+            onProgress("d1-upload", `${label}... ${done}/${total} batches`);
+          }
+        });
+      }
+
+      if (deleteSql.length === 0 && insertSql.length === 0) {
+        onProgress("d1-upload", "No D1 changes to apply");
+      } else {
+        await runPhase(deleteSql, "D1 deletes");
+        await runPhase(insertSql, "D1 inserts");
       }
     }
 
@@ -650,6 +800,13 @@ export async function publishCollections(
     publishedAt: new Date().toISOString(),
   });
 
+  // Persist hashes for the next publish's fast-paths.
+  if (meta) {
+    meta.set(META_WORKER_CONFIG_HASH, workerConfigHash);
+    if (newLocalManifestHash) meta.set(META_LOCAL_MANIFEST_HASH, newLocalManifestHash);
+    meta.close();
+  }
+
   onProgress("done", "Publish completed");
 
   return {
@@ -673,6 +830,7 @@ export const publishCommand = new Command("publish")
   .option("--public", "Explicitly allow public access on initial publish (skip confirmation prompt)")
   .option("--tool-description <description>", "Tool description advertised to MCP clients")
   .option("--worker-only", "Deploy worker code only (skip D1/R2 data upload)")
+  .option("--full", "Force full D1 rebuild (push every entity, bypass manifest/incremental-hash short-circuit). Use after theme path changes.")
   .addHelpText("after", `
 Examples:
   # Publish with password protection
@@ -696,6 +854,7 @@ Examples:
     public?: boolean;
     toolDescription?: string;
     workerOnly?: boolean;
+    full?: boolean;
   }) => {
     try {
       ensureInitialized();
@@ -743,6 +902,7 @@ Examples:
           removePassword: opts.removePassword,
           forcePublic,
           workerOnly,
+          full: !!opts.full,
         },
         (step, detail) => console.log(`  [${step}] ${detail}`),
       );

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -235,13 +235,23 @@ function buildFileTree(
   dirPath: string,
   titleByPath: Map<string, string>,
   basePath: string = "",
+  themeConfigs: Record<string, FolderConfig> = {},
+  themeRootConfig: FolderConfig = {},
 ): object[] {
   if (!existsSync(dirPath)) return [];
 
-  // Read this directory's own config (including root: content/content.yml)
-  const ownConfig = readFolderConfig(dirPath);
-  const sortOrder = ownConfig.sort ?? "ASC";
-  const folderHide = ownConfig.hide ?? [];
+  // Resolve which theme config applies to this directory.
+  const folderLeaf = basePath
+    ? (basePath.includes("/") ? basePath.split("/").pop()! : basePath)
+    : "";
+  const themeConfig = folderLeaf ? (themeConfigs[folderLeaf] ?? {}) : themeRootConfig;
+
+  // Merge: yml overrides theme for fields it specifies; theme provides defaults.
+  const ymlConfig = readFolderConfig(dirPath);
+  const merged: FolderConfig = { ...themeConfig, ...ymlConfig };
+
+  const sortOrder = merged.sort ?? "ASC";
+  const folderHide = merged.hide ?? [];
 
   const entries = readdirSync(dirPath, { withFileTypes: true });
   const dirs: object[] = [];
@@ -251,10 +261,11 @@ function buildFileTree(
     const relativePath = basePath ? `${basePath}/${entry.name}` : entry.name;
     if (entry.isDirectory()) {
       const childDirPath = join(dirPath, entry.name);
-      // Check child dir's visibility before including it
-      const childConfig = readFolderConfig(childDirPath);
-      if (childConfig.visible === false) continue;
-      const children = buildFileTree(childDirPath, titleByPath, relativePath);
+      const childThemeCfg = themeConfigs[entry.name] ?? {};
+      const childYmlCfg = readFolderConfig(childDirPath);
+      const childMerged: FolderConfig = { ...childThemeCfg, ...childYmlCfg };
+      if (childMerged.visible === false) continue;
+      const children = buildFileTree(childDirPath, titleByPath, relativePath, themeConfigs, themeRootConfig);
       // Hide directories with no (visible) files in their subtree so stale
       // empty folders on disk don't leak into the tree.
       if (countFiles(children) === 0) continue;
@@ -264,8 +275,11 @@ function buildFileTree(
         type: "directory",
         children,
       };
-      if (childConfig.showCount === true) {
+      if (childMerged.showCount === true) {
         dirNode.count = countFiles(children);
+      }
+      if (childMerged.expanded === false) {
+        dirNode.expanded = false;
       }
       dirs.push(dirNode);
     } else if (entry.name.endsWith(".md")) {
@@ -276,8 +290,14 @@ function buildFileTree(
         path: relativePath,
         type: "file",
       };
-      const title = titleByPath.get(relativePath);
-      if (title) node.title = title;
+      if (merged.created_at_prefix) {
+        const datePrefix = entry.name.slice(0, 8);
+        const stored = titleByPath.get(relativePath);
+        node.title = stored ? `${datePrefix} ${stored}` : entry.name.replace(/\.md$/, "");
+      } else {
+        const title = titleByPath.get(relativePath);
+        if (title) node.title = title;
+      }
       files.push(node);
     }
   }
@@ -285,6 +305,15 @@ function buildFileTree(
   // Apply directory/file ordering by this folder's sort config.
   const sortedDirs = sortOrder === "DESC" ? dirs.slice().reverse() : dirs;
   const sortedFiles = sortOrder === "DESC" ? files.slice().reverse() : files;
+
+  // Mark the first N expanded, rest explicitly collapsed. The UI defaults to
+  // "expanded" when the flag is absent, so both states must be set.
+  if (merged.expandFirstN && merged.expandFirstN > 0) {
+    for (let i = 0; i < sortedDirs.length; i++) {
+      (sortedDirs[i] as Record<string, unknown>).expanded = i < merged.expandFirstN;
+    }
+  }
+
   return [...sortedDirs, ...sortedFiles];
 }
 
@@ -395,7 +424,10 @@ export function createApiServer(
           }
         }
 
-        const tree = buildFileTree(contentDir, titleByPath);
+        const crawlerType = effectiveCrawlerType(col, dbPath);
+        const themeConfigs = themeEngine.getFolderConfigs(crawlerType);
+        const themeRootConfig = themeEngine.getRootConfig(crawlerType);
+        const tree = buildFileTree(contentDir, titleByPath, "", themeConfigs, themeRootConfig);
         return jsonResponse(tree);
       }
 

--- a/packages/core/src/theme/interface.ts
+++ b/packages/core/src/theme/interface.ts
@@ -1,7 +1,7 @@
 export interface FolderConfig {
   /** Whether this folder is visible in the file tree (default: true). */
   visible?: boolean;
-  /** Sort order for files in this folder (default: ASC). */
+  /** Sort order for both files and subdirectories in this folder (default: ASC). */
   sort?: "ASC" | "DESC";
   /**
    * Glob patterns matching filenames to hide within this folder.
@@ -16,6 +16,21 @@ export interface FolderConfig {
    * children are a fixed set of entity-type subfolders plus the project entity).
    */
   showCount?: boolean;
+  /**
+   * Expand the first N visible child directories by default (default: 0).
+   * After sorting, the first N directories in this folder are marked expanded.
+   */
+  expandFirstN?: number;
+  /**
+   * Whether this folder starts expanded in the tree (default: true).
+   * Set to false to render this folder collapsed by default.
+   */
+  expanded?: boolean;
+  /**
+   * Prefix each file's display title with its creation date as `YYYYMMDD `.
+   * The date is extracted from the leading 8-character date stamp in the filename.
+   */
+  created_at_prefix?: boolean;
 }
 
 export interface ThemeRenderContext {

--- a/packages/crawlers/src/rss/__tests__/crawler.test.ts
+++ b/packages/crawlers/src/rss/__tests__/crawler.test.ts
@@ -1,11 +1,31 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import { RssCrawler } from "../crawler";
+import type { CrawlerEntityData, SyncCursor, SyncResult } from "@frozenink/core";
 
 function textResponse(body: string, status = 200, contentType = "application/xml"): Response {
   return new Response(body, {
     status,
     headers: { "Content-Type": contentType },
   });
+}
+
+/**
+ * Drive the crawler the same way the sync engine does: loop sync() until
+ * hasMore is false. The crawler yields one entity per call so progress is
+ * reported live; tests want the aggregate.
+ */
+async function drainSync(crawler: RssCrawler, cursor: SyncCursor | null): Promise<{ entities: CrawlerEntityData[]; nextCursor: SyncResult["nextCursor"] }> {
+  const entities: CrawlerEntityData[] = [];
+  let cur = cursor;
+  let last: SyncResult | null = null;
+  for (let i = 0; i < 100; i++) {
+    const r = await crawler.sync(cur);
+    last = r;
+    entities.push(...r.entities);
+    cur = r.nextCursor ?? cur;
+    if (!r.hasMore) break;
+  }
+  return { entities, nextCursor: last!.nextCursor };
 }
 
 describe("RssCrawler", () => {
@@ -41,7 +61,7 @@ describe("RssCrawler", () => {
       return textResponse("", 404);
     });
 
-    const result = await crawler.sync(null);
+    const result = await drainSync(crawler, null);
     expect(result.entities).toHaveLength(1);
     expect(result.entities[0].externalId).toBe("post-1");
     expect(result.entities[0].entityType).toBe("post");
@@ -73,7 +93,7 @@ describe("RssCrawler", () => {
       return textResponse("", 404);
     });
 
-    const result = await crawler.sync({
+    const result = await drainSync(crawler, {
       watermark: "2025-01-15T00:00:00.000Z",
       seenIds: ["old"],
       backfillComplete: true,
@@ -114,7 +134,7 @@ describe("RssCrawler", () => {
       return textResponse("", 404);
     });
 
-    const result = await crawler.sync(null);
+    const result = await drainSync(crawler, null);
     expect(result.entities.map((e) => e.externalId).sort()).toEqual([
       "https://example.com/posts/older-one",
       "https://example.com/posts/older-two",
@@ -152,7 +172,7 @@ describe("RssCrawler", () => {
       return textResponse("", 404);
     });
 
-    const result = await crawler.sync({ backfillComplete: true });
+    const result = await drainSync(crawler, { backfillComplete: true });
     expect(result.entities).toHaveLength(1);
     const attachments = result.entities[0].attachments ?? [];
     expect(attachments).toHaveLength(1);

--- a/packages/crawlers/src/rss/__tests__/theme.test.ts
+++ b/packages/crawlers/src/rss/__tests__/theme.test.ts
@@ -47,7 +47,7 @@ describe("RssTheme", () => {
 
   it("builds deterministic dated file paths", () => {
     const path = theme.getFilePath(makeContext());
-    expect(path).toBe("posts/2025/20250114 My Post.md");
+    expect(path).toBe("2025/20250114-my-post.md");
   });
 
   it("preserves paragraph breaks from HTML content", () => {

--- a/packages/crawlers/src/rss/crawler.ts
+++ b/packages/crawlers/src/rss/crawler.ts
@@ -23,6 +23,138 @@ function arr<T>(value: T | T[] | undefined | null): T[] {
   return Array.isArray(value) ? value : [value];
 }
 
+function escapeHtmlAttr(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeHtmlText(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Drop the Jina reader preamble ("Title: ...\nURL Source: ...\nMarkdown Content:\n")
+ * so we're left with just the article body.
+ */
+function stripReaderPreamble(markdown: string): string {
+  const idx = markdown.indexOf("Markdown Content:");
+  if (idx >= 0) {
+    const after = markdown.slice(idx + "Markdown Content:".length);
+    return after.replace(/^\s+/, "");
+  }
+  return markdown;
+}
+
+/**
+ * Minimal markdown → HTML converter. Handles headings, paragraphs, unordered
+ * lists, blockquotes, fenced code, images, links, bold, italic, inline code.
+ * Used to wrap reader-proxy markdown so the rest of the pipeline (image
+ * extraction, theme renderHtml) keeps working.
+ */
+function markdownToSimpleHtml(md: string): string {
+  const lines = md.replace(/\r\n?/g, "\n").split("\n");
+  const out: string[] = [];
+  let i = 0;
+  let inList = false;
+  const closeList = () => { if (inList) { out.push("</ul>"); inList = false; } };
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Fenced code block
+    if (/^```/.test(line)) {
+      closeList();
+      const code: string[] = [];
+      i++;
+      while (i < lines.length && !/^```/.test(lines[i])) { code.push(lines[i]); i++; }
+      if (i < lines.length) i++;
+      out.push(`<pre><code>${escapeHtmlText(code.join("\n"))}</code></pre>`);
+      continue;
+    }
+
+    // Heading
+    const h = line.match(/^(#{1,6})\s+(.+)$/);
+    if (h) {
+      closeList();
+      const level = h[1].length;
+      out.push(`<h${level}>${renderInline(h[2].trim())}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    // Blockquote
+    if (/^>\s?/.test(line)) {
+      closeList();
+      const quote: string[] = [];
+      while (i < lines.length && /^>\s?/.test(lines[i])) {
+        quote.push(lines[i].replace(/^>\s?/, ""));
+        i++;
+      }
+      out.push(`<blockquote>${renderInline(quote.join(" "))}</blockquote>`);
+      continue;
+    }
+
+    // Unordered list item
+    const li = line.match(/^[-*]\s+(.+)$/);
+    if (li) {
+      if (!inList) { out.push("<ul>"); inList = true; }
+      out.push(`<li>${renderInline(li[1])}</li>`);
+      i++;
+      continue;
+    }
+
+    // Blank line — paragraph break
+    if (/^\s*$/.test(line)) {
+      closeList();
+      i++;
+      continue;
+    }
+
+    // Standalone image line — render as bare <img> so extractMediaUrls picks it up
+    const imgOnly = line.trim().match(/^!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)$/);
+    if (imgOnly) {
+      closeList();
+      out.push(`<p><img alt="${escapeHtmlAttr(imgOnly[1])}" src="${escapeHtmlAttr(imgOnly[2])}"></p>`);
+      i++;
+      continue;
+    }
+
+    // Paragraph: accumulate until blank line or block element
+    closeList();
+    const para: string[] = [line];
+    i++;
+    while (i < lines.length && !/^\s*$/.test(lines[i]) && !/^(#{1,6}\s|>\s?|[-*]\s+|```)/.test(lines[i])) {
+      para.push(lines[i]);
+      i++;
+    }
+    out.push(`<p>${renderInline(para.join(" "))}</p>`);
+  }
+  closeList();
+  return out.join("\n");
+}
+
+function renderInline(text: string): string {
+  // Order matters: protect code spans first so their contents aren't re-parsed.
+  const codeSpans: string[] = [];
+  let s = text.replace(/`([^`]+)`/g, (_m, c: string) => {
+    codeSpans.push(`<code>${escapeHtmlText(c)}</code>`);
+    return `\u0000${codeSpans.length - 1}\u0000`;
+  });
+  // Escape raw HTML unsafe chars in remaining text.
+  s = s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  // Images: ![alt](url)
+  s = s.replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g, (_m, alt: string, url: string) =>
+    `<img alt="${escapeHtmlAttr(alt)}" src="${escapeHtmlAttr(url)}">`);
+  // Links: [text](url)
+  s = s.replace(/\[([^\]]+)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g, (_m, label: string, url: string) =>
+    `<a href="${escapeHtmlAttr(url)}">${label}</a>`);
+  // Bold and italics
+  s = s.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  s = s.replace(/(^|[^*])\*([^*]+)\*/g, "$1<em>$2</em>");
+  // Restore code spans
+  s = s.replace(/\u0000(\d+)\u0000/g, (_m, n: string) => codeSpans[Number(n)]);
+  return s;
+}
+
 function text(value: unknown): string | undefined {
   if (typeof value === "string") return value.trim() || undefined;
   if (typeof value === "number") return String(value);
@@ -121,6 +253,19 @@ export class RssCrawler implements Crawler {
     trimValues: true,
   });
 
+  // State across sync() calls in one run. The sync engine drives one entity
+  // at a time so per-entity progress (counts, file writes) happens live
+  // instead of after the whole feed has been fetched + converted.
+  private runState: {
+    pending: ParsedFeedPost[];
+    total: number;
+    processed: number;
+    newestIso: string | undefined;
+    seenIds: Set<string>;
+    sawBackfill: boolean;
+    backfillTriggered: boolean;
+  } | null = null;
+
   async initialize(config: Record<string, unknown>): Promise<void> {
     this.config = {
       feedUrl: String(config.feedUrl ?? "").trim(),
@@ -148,58 +293,85 @@ export class RssCrawler implements Crawler {
   }
 
   async dispose(): Promise<void> {
-    // No-op
+    this.runState = null;
   }
 
   async sync(cursor: SyncCursor | null): Promise<SyncResult> {
     const c = (cursor as RssSyncCursor) ?? {};
-    const entities: CrawlerEntityData[] = [];
-    const seenIds = new Set(c.seenIds ?? []);
 
-    this.report(`Fetching feed: ${this.config.feedUrl}`);
-    const feedPosts = await this.fetchFeedPosts();
+    // On first call of a run, fetch the feed + sitemap once and build the
+    // queue of posts to process. Subsequent calls pop one post from the
+    // queue so the sync engine writes markdown + bumps counts live.
+    if (!this.runState) {
+      this.report(`Fetching feed: ${this.config.feedUrl}`);
+      const feedPosts = await this.fetchFeedPosts();
 
-    // Feed is always authoritative for latest watermark and incremental detection.
-    let newestIso = c.watermark;
-    let feedProcessed = 0;
-    for (const post of feedPosts) {
-      const postTime = post.updatedAt ?? post.publishedAt;
-      newestIso = maxIso(newestIso, postTime);
-      if (!this.shouldInclude(post, c.watermark, seenIds)) continue;
-      feedProcessed += 1;
-      this.report(`Processing feed post ${feedProcessed}/${feedPosts.length}: ${post.title}`);
-      entities.push(await this.postToEntity(post));
-      seenIds.add(post.id);
-      if (this.config.maxItems && entities.length >= this.config.maxItems) break;
+      let newestIso = c.watermark;
+      const seenIds = new Set(c.seenIds ?? []);
+      const toProcess: ParsedFeedPost[] = [];
+      for (const post of feedPosts) {
+        newestIso = maxIso(newestIso, post.updatedAt ?? post.publishedAt);
+        if (!this.shouldInclude(post, c.watermark, seenIds)) continue;
+        toProcess.push(post);
+        if (this.config.maxItems && toProcess.length >= this.config.maxItems) break;
+      }
+
+      let backfillPosts: ParsedFeedPost[] = [];
+      const wantBackfill = this.shouldRunBackfill(c)
+        && (!this.config.maxItems || toProcess.length < this.config.maxItems);
+      if (wantBackfill) {
+        const sitemapCandidates = await this.discoverSitemaps();
+        if (sitemapCandidates.length > 0) {
+          this.report(`Backfilling from ${sitemapCandidates.length} sitemap candidate(s)`);
+        }
+        backfillPosts = await this.fetchBackfillPosts(
+          sitemapCandidates,
+          seenIds,
+          this.config.maxItems ? this.config.maxItems - toProcess.length : undefined,
+        );
+        for (const post of backfillPosts) {
+          newestIso = maxIso(newestIso, post.updatedAt ?? post.publishedAt);
+        }
+      }
+
+      const pending = [...toProcess, ...backfillPosts];
+      this.runState = {
+        pending,
+        total: pending.length,
+        processed: 0,
+        newestIso,
+        seenIds,
+        sawBackfill: backfillPosts.length > 0 || wantBackfill,
+        backfillTriggered: wantBackfill,
+      };
     }
 
-    if (this.shouldRunBackfill(c) && (!this.config.maxItems || entities.length < this.config.maxItems)) {
-      const sitemapCandidates = await this.discoverSitemaps();
-      if (sitemapCandidates.length > 0) {
-        this.report(`Backfilling from ${sitemapCandidates.length} sitemap candidate(s)`);
-      }
-      const backfillPosts = await this.fetchBackfillPosts(sitemapCandidates, seenIds, this.config.maxItems ? this.config.maxItems - entities.length : undefined);
-      let backfillProcessed = 0;
-      for (const post of backfillPosts) {
-        const postTime = post.updatedAt ?? post.publishedAt;
-        newestIso = maxIso(newestIso, postTime);
-        backfillProcessed += 1;
-        this.report(`Processing sitemap post ${backfillProcessed}/${backfillPosts.length}: ${post.title}`);
-        entities.push(await this.postToEntity(post));
-        seenIds.add(post.id);
-      }
+    const state = this.runState;
+    const post = state.pending.shift();
+    if (!post) {
+      // Queue drained — final call. Return empty result with the finalized
+      // cursor and clear run state so the next sync run refetches the feed.
+      const nextCursor = {
+        watermark: state.newestIso,
+        seenIds: Array.from(state.seenIds).slice(-DEFAULT_SEEN_WINDOW),
+        backfillComplete: state.backfillTriggered ? true : c.backfillComplete,
+      } satisfies RssSyncCursor;
+      this.runState = null;
+      return { entities: [], nextCursor, hasMore: false, deletedExternalIds: [] };
     }
 
-    return {
-      entities,
-      nextCursor: {
-        watermark: newestIso,
-        seenIds: Array.from(seenIds).slice(-DEFAULT_SEEN_WINDOW),
-        backfillComplete: this.shouldRunBackfill(c) ? true : c.backfillComplete,
-      } satisfies RssSyncCursor,
-      hasMore: false,
-      deletedExternalIds: [],
-    };
+    state.processed += 1;
+    this.report(`Processing post ${state.processed}/${state.total}: ${post.title}`);
+    const entity = await this.postToEntity(post);
+    state.seenIds.add(post.id);
+
+    const hasMore = state.pending.length > 0;
+    const nextCursor = {
+      watermark: state.newestIso,
+      seenIds: Array.from(state.seenIds).slice(-DEFAULT_SEEN_WINDOW),
+      backfillComplete: hasMore ? c.backfillComplete : (state.backfillTriggered ? true : c.backfillComplete),
+    } satisfies RssSyncCursor;
+    return { entities: [entity], nextCursor, hasMore, deletedExternalIds: [] };
   }
 
   private report(message: string): void {
@@ -281,9 +453,16 @@ export class RssCrawler implements Crawler {
     const title = text(item.title) ?? link;
     const guid = text(item.guid);
 
-    const contentHtml =
-      text(item["content:encoded"]) ??
-      text(item.description);
+    // Prefer `content:encoded` (full body). Fall back to `description` only
+    // when it looks like real content (contains block-level HTML), since many
+    // feeds (e.g. openai.com) use <description> for a plain-text summary and
+    // the full post is only reachable via the item URL. Leaving contentHtml
+    // empty in that case lets resolvePostContent fetch the article HTML.
+    const fullContent = text(item["content:encoded"]);
+    const descriptionHtml = text(item.description);
+    const descriptionLooksLikeBody =
+      !!descriptionHtml && /<(p|img|div|ul|ol|h[1-6]|blockquote|pre|table)\b/i.test(descriptionHtml);
+    const contentHtml = fullContent ?? (descriptionLooksLikeBody ? descriptionHtml : undefined);
 
     const tags = arr(item.category).map((c) => text(c)).filter((v): v is string => !!v);
     const author = text(item["dc:creator"]) ?? text(item.author);
@@ -531,11 +710,53 @@ export class RssCrawler implements Crawler {
   }
 
   private async fetchArticleHtml(url: string): Promise<string | undefined> {
-    const html = await this.fetchText(url);
-    const article = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i)?.[0]
-      ?? html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)?.[0]
-      ?? html.match(/<body[^>]*>([\s\S]*?)<\/body>/i)?.[0];
-    return article;
+    // Try a direct fetch first. Many sites (e.g. openai.com) sit behind a
+    // Cloudflare challenge that returns a small "Just a moment..." page to
+    // non-browser agents; detect that and fall through to the reader proxy.
+    try {
+      const html = await this.fetchText(url);
+      if (html && !this.looksLikeBotChallenge(html)) {
+        const article = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i)?.[0]
+          ?? html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)?.[0]
+          ?? html.match(/<body[^>]*>([\s\S]*?)<\/body>/i)?.[0];
+        if (article && article.length > 800) return article;
+      }
+    } catch {
+      // Fall through to reader proxy.
+    }
+    return this.fetchArticleViaReader(url);
+  }
+
+  /** Heuristic: detect Cloudflare / generic bot-challenge interstitials. */
+  private looksLikeBotChallenge(html: string): boolean {
+    const sample = html.slice(0, 4000).toLowerCase();
+    return (
+      sample.includes("just a moment") ||
+      sample.includes("cf-challenge") ||
+      sample.includes("cf_chl_opt") ||
+      sample.includes("__cf_chl_") ||
+      sample.includes("attention required") ||
+      (sample.includes("cloudflare") && sample.includes("checking your browser"))
+    );
+  }
+
+  /**
+   * Pull article content through Jina's reader proxy (https://r.jina.ai/<url>),
+   * which returns cleaned markdown and bypasses most anti-bot interstitials.
+   * We convert its markdown into basic HTML so the rest of the pipeline (image
+   * extraction, theme rendering) keeps working unchanged.
+   */
+  private async fetchArticleViaReader(url: string): Promise<string | undefined> {
+    try {
+      this.report(`Fetching via reader proxy: ${url}`);
+      const res = await this.fetchFn(`https://r.jina.ai/${url}`);
+      if (!res.ok) return undefined;
+      const markdown = await res.text();
+      if (!markdown || markdown.length < 200) return undefined;
+      return markdownToSimpleHtml(stripReaderPreamble(markdown));
+    } catch {
+      return undefined;
+    }
   }
 
   private async downloadImageAttachments(post: ParsedFeedPost, imageUrls: string[]): Promise<CrawlerEntityData["attachments"]> {

--- a/packages/crawlers/src/rss/crawler.ts
+++ b/packages/crawlers/src/rss/crawler.ts
@@ -214,7 +214,10 @@ export class RssCrawler implements Crawler {
     if (!watermark) return true;
     const t = post.updatedAt ?? post.publishedAt;
     if (!t) return !seenIds.has(post.id);
-    return new Date(t).getTime() >= new Date(watermark).getTime() || !seenIds.has(post.id);
+    // Strict `>` so a post whose timestamp equals the stored watermark (i.e.
+    // the last sync's newest post) doesn't get reprocessed every run — that
+    // was re-downloading its image attachments on every sync.
+    return new Date(t).getTime() > new Date(watermark).getTime() || !seenIds.has(post.id);
   }
 
   private async fetchFeedPosts(): Promise<ParsedFeedPost[]> {

--- a/packages/crawlers/src/rss/theme.ts
+++ b/packages/crawlers/src/rss/theme.ts
@@ -1,4 +1,4 @@
-import type { Theme, ThemeRenderContext } from "@frozenink/core/theme";
+import type { FolderConfig, Theme, ThemeRenderContext } from "@frozenink/core/theme";
 import { frontmatter } from "@frozenink/core/theme";
 
 interface AssetRef {
@@ -12,13 +12,6 @@ function slugify(value: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "")
     .slice(0, 80);
-}
-
-function safeFilenameTitle(value: string): string {
-  return value
-    .replace(/[\\/:*?"<>|]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
 }
 
 function dateParts(value: string | undefined): { year: string; stamp: string } {
@@ -48,6 +41,32 @@ function decodeEntities(text: string): string {
     .replace(/&#39;/g, "'");
 }
 
+function imgTagToMarkdown(tag: string): string {
+  const src = tag.match(/src="([^"]*)"/i)?.[1] ?? "";
+  const alt = tag.match(/alt="([^"]*)"/i)?.[1] ?? "";
+  return src ? `\n\n![${alt}](${src})\n\n` : "";
+}
+
+/** Replace CDN image src URLs in HTML with local attachment paths where available. */
+function substituteLocalAssets(html: string, assets: AssetRef[]): string {
+  if (assets.length === 0) return html;
+  const byFilename = new Map<string, string>();
+  for (const asset of assets) {
+    const name = (asset.filename ?? "").toLowerCase();
+    byFilename.set(name, toMarkdownAttachmentRef(asset.storagePath));
+    // Also index without common size prefixes (medium_, large_, thumb_, xlarge_)
+    byFilename.set(name.replace(/^(medium|large|thumb|xlarge|orig)_/, ""), toMarkdownAttachmentRef(asset.storagePath));
+  }
+  return html.replace(/<img([^>]*)>/gi, (match, attrs: string) => {
+    const srcMatch = attrs.match(/src="([^"]*)"/i);
+    if (!srcMatch) return match;
+    const urlFilename = srcMatch[1].split("/").pop()?.split("?")[0]?.toLowerCase() ?? "";
+    const localPath = byFilename.get(urlFilename)
+      ?? byFilename.get(urlFilename.replace(/^(medium|large|thumb|xlarge|orig)_/, ""));
+    return localPath ? match.replace(srcMatch[0], `src="${localPath}"`) : match;
+  });
+}
+
 function htmlToReadableMarkdown(html: string): string {
   const sanitized = stripUnsafeHtml(html);
   const withStructure = sanitized
@@ -58,15 +77,11 @@ function htmlToReadableMarkdown(html: string): string {
     .replace(/<li[^>]*>/gi, "\n- ")
     .replace(/<\/li>/gi, "")
     .replace(/<\/h[1-6]>/gi, "\n\n")
-    .replace(/<h[1-6][^>]*>/gi, "\n\n## ");
+    .replace(/<h[1-6][^>]*>/gi, "\n\n## ")
+    .replace(/<img[^>]*\/?>/gi, imgTagToMarkdown);
   return decodeEntities(withStructure.replace(/<[^>]+>/g, ""))
     .replace(/\n{3,}/g, "\n\n")
     .trim();
-}
-
-function toAttachmentApiUrl(collectionName: string, storagePath: string): string {
-  const filePath = storagePath.replace(/^attachments\//, "");
-  return `/api/attachments/${encodeURIComponent(collectionName)}/${filePath}`;
 }
 
 function toMarkdownAttachmentRef(storagePath: string): string {
@@ -99,24 +114,25 @@ export class RssTheme implements Theme {
 
     const meta = joinIf([
       typeof d.publishedAt === "string" ? `Published: ${d.publishedAt}` : undefined,
-      typeof d.updatedAt === "string" ? `Updated: ${d.updatedAt}` : undefined,
       typeof d.author === "string" ? `Author: ${d.author}` : undefined,
     ]);
     if (meta) sections.push(meta);
 
-    const body = typeof d.contentHtml === "string" && d.contentHtml.trim()
-      ? htmlToReadableMarkdown(d.contentHtml)
-      : (typeof d.contentText === "string" ? d.contentText.trim() : "");
-    if (body) sections.push(body);
-
     const assets = ((d.assets as AssetRef[] | undefined) ?? []).filter(
       (a) => typeof a.storagePath === "string" && a.storagePath.startsWith("attachments/"),
     );
-    if (assets.length > 0) {
-      sections.push("## Images");
-      for (const asset of assets) {
-        const alt = (asset.filename || "image").replace(/\.[^.]+$/, "");
-        sections.push(`![${alt}](${toMarkdownAttachmentRef(asset.storagePath)})`);
+    const rawHtml = typeof d.contentHtml === "string" ? d.contentHtml.trim() : "";
+    const body = rawHtml
+      ? htmlToReadableMarkdown(substituteLocalAssets(rawHtml, assets))
+      : (typeof d.contentText === "string" ? d.contentText.trim() : "");
+    if (body) sections.push(body);
+
+    // Append any assets not already present inline in the body
+    for (const asset of assets) {
+      const localRef = toMarkdownAttachmentRef(asset.storagePath);
+      if (!body.includes(localRef)) {
+        const alt = (asset.filename ?? "image").replace(/\.[^.]+$/, "");
+        sections.push(`![${alt}](${localRef})`);
       }
     }
 
@@ -129,27 +145,17 @@ export class RssTheme implements Theme {
       ? stripUnsafeHtml(d.contentHtml)
       : `<p>${(typeof d.contentText === "string" ? d.contentText : "").replace(/</g, "&lt;")}</p>`;
 
-    const assets = ((d.assets as AssetRef[] | undefined) ?? []).filter(
-      (a) => typeof a.storagePath === "string" && a.storagePath.startsWith("attachments/"),
-    );
-    const gallery = assets.length === 0
-      ? ""
-      : `
-        <div class="rss-medium-gallery">
-          ${assets
-            .map((a) => {
-              const alt = (a.filename || "image").replace(/\.[^.]+$/, "");
-              const src = toAttachmentApiUrl(context.collectionName, a.storagePath);
-              return `<figure><img src="${src}" alt="${alt}" /><figcaption>${alt}</figcaption></figure>`;
-            })
-            .join("")}
-        </div>
-      `;
-
+    const publishedDate = typeof d.publishedAt === "string" ? d.publishedAt : null;
+    const sourceUrl = context.entity.url;
+    const linkIcon = sourceUrl
+      ? ` <a href="${sourceUrl}" target="_blank" rel="noopener noreferrer" class="rss-source-link" title="Open source article">` +
+        `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>` +
+        `</a>`
+      : "";
     const subline = joinIf([
-      typeof d.publishedAt === "string" ? `Published ${d.publishedAt}` : undefined,
+      publishedDate ? `Published <time class="rss-date" data-iso="${publishedDate}">${publishedDate}</time>` : undefined,
       typeof d.author === "string" ? `By ${d.author}` : undefined,
-    ]);
+    ]) + linkIcon;
 
     return `
       <style>
@@ -170,6 +176,18 @@ export class RssTheme implements Theme {
           color: var(--text-secondary);
           margin: 0 0 26px;
           font-size: 0.95rem;
+          display: flex;
+          align-items: center;
+          gap: 6px;
+        }
+        .rss-medium .rss-source-link {
+          color: var(--text-secondary);
+          opacity: 0.6;
+          display: inline-flex;
+          align-items: center;
+        }
+        .rss-medium .rss-source-link:hover {
+          opacity: 1;
         }
         .rss-medium .body {
           font-family: Georgia, "Times New Roman", serif;
@@ -188,23 +206,11 @@ export class RssTheme implements Theme {
           margin: 1.2em auto;
           border-radius: 6px;
         }
-        .rss-medium-gallery {
-          margin-top: 2.5rem;
-          display: grid;
-          gap: 1.4rem;
-        }
-        .rss-medium-gallery figure { margin: 0; }
-        .rss-medium-gallery figcaption {
-          margin-top: 0.45rem;
-          color: var(--text-secondary);
-          font-size: 0.9rem;
-        }
       </style>
       <article class="rss-medium">
         <h1>${context.entity.title}</h1>
         ${subline ? `<div class="subline">${subline}</div>` : ""}
         <div class="body">${bodyHtml}</div>
-        ${gallery}
       </article>
     `;
   }
@@ -212,19 +218,24 @@ export class RssTheme implements Theme {
   getFilePath(context: ThemeRenderContext): string {
     const d = context.entity.data;
     const dt = dateParts((d.publishedAt as string | undefined) ?? (d.updatedAt as string | undefined));
-    const title = safeFilenameTitle(context.entity.title) || slugify(context.entity.externalId) || "post";
-    return `posts/${dt.year}/${dt.stamp} ${title}.md`;
+    // Slugified filename keeps URLs clean (no spaces / unsafe chars). The
+    // display title lives on the entity row, not in the path.
+    const slug = slugify(context.entity.title) || slugify(context.entity.externalId) || "post";
+    return `${dt.year}/${dt.stamp}-${slug}.md`;
   }
 
-  folderConfigs() {
-    const configs: Record<string, { sort?: "ASC" | "DESC"; visible?: boolean }> = {
-      posts: { sort: "DESC" },
+  folderConfigs(): Record<string, FolderConfig> {
+    const configs: Record<string, FolderConfig> = {
       assets: { visible: false },
     };
     for (let year = 1970; year <= 2100; year++) {
-      configs[String(year)] = { sort: "DESC" };
+      configs[String(year)] = { sort: "DESC", expanded: false, created_at_prefix: true };
     }
     return configs;
+  }
+
+  rootConfig(): FolderConfig {
+    return { sort: "DESC", expandFirstN: 3 };
   }
 
   agentsMarkdown(options: { title: string; description?: string }): string {
@@ -236,8 +247,9 @@ export class RssTheme implements Theme {
       "",
       "## Entity Types",
       "",
-      "### Posts (`posts/YYYY/`)",
+      "### Posts (`YYYY/`)",
       "Each file uses `YYYYMMDD <title>.md` naming for chronological scanning.",
+      "Years are sorted newest to oldest; the most recent year is expanded by default.",
       "",
       "### Images (`attachments/rss/YYYY/`)",
       "Downloaded image assets referenced by feed posts.",

--- a/packages/desktop/src/main/auto-updater.ts
+++ b/packages/desktop/src/main/auto-updater.ts
@@ -10,7 +10,8 @@
  */
 import type { BrowserWindow } from "electron";
 import { app } from "electron";
-import { autoUpdater } from "electron-updater";
+import pkg from "electron-updater";
+const { autoUpdater } = pkg;
 
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
 const RELEASES_PAGE = "https://github.com/vboctor/frozen-ink/releases/latest";

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -112,6 +112,10 @@ function fileToUrlPath(file: string): string {
   return `/${file.replace(/\.md$/, "")}`;
 }
 
+function encodeFilePath(file: string): string {
+  return file.split("/").map(encodeURIComponent).join("/");
+}
+
 interface NavEntry {
   collection: string;
   file: string;
@@ -518,7 +522,7 @@ export default function App() {
     setLoading(true);
     setFileNotFound(false);
     fetch(
-      `/api/collections/${encodeURIComponent(selectedCollection)}/markdown/${selectedFile}`,
+      `/api/collections/${encodeURIComponent(selectedCollection)}/markdown/${encodeFilePath(selectedFile)}`,
     )
       .then((r) => {
         if (!r.ok) throw new Error("not-found");
@@ -542,7 +546,7 @@ export default function App() {
       return;
     }
     fetch(
-      `/api/collections/${encodeURIComponent(selectedCollection)}/backlinks/${selectedFile}`,
+      `/api/collections/${encodeURIComponent(selectedCollection)}/backlinks/${encodeFilePath(selectedFile)}`,
     )
       .then((r) => (r.ok ? r.json() : []))
       .then(setBacklinks)
@@ -556,7 +560,7 @@ export default function App() {
       return;
     }
     fetch(
-      `/api/collections/${encodeURIComponent(selectedCollection)}/outgoing-links/${selectedFile}`,
+      `/api/collections/${encodeURIComponent(selectedCollection)}/outgoing-links/${encodeFilePath(selectedFile)}`,
     )
       .then((r) => (r.ok ? r.json() : []))
       .then(setOutgoingLinks)
@@ -592,7 +596,7 @@ export default function App() {
     setHtmlContent(null);
     setHtmlLoading(true);
     fetch(
-      `/api/collections/${encodeURIComponent(selectedCollection)}/html/${selectedFile}`,
+      `/api/collections/${encodeURIComponent(selectedCollection)}/html/${encodeFilePath(selectedFile)}`,
     )
       .then((r) => {
         if (!r.ok) throw new Error("HTML not available");
@@ -1039,7 +1043,7 @@ export default function App() {
               <button
                 className="nav-btn icon-btn"
                 onClick={() => {
-                  const url = `/api/collections/${encodeURIComponent(selectedCollection)}/textpack/${selectedFile}`;
+                  const url = `/api/collections/${encodeURIComponent(selectedCollection)}/textpack/${encodeFilePath(selectedFile)}`;
                   const a = document.createElement("a");
                   a.href = url;
                   a.download = "";

--- a/packages/ui/src/components/FileTree.tsx
+++ b/packages/ui/src/components/FileTree.tsx
@@ -33,7 +33,7 @@ function containsPath(node: TreeNode, selectedFile: string | null): boolean {
 }
 
 const TreeItem = memo(function TreeItem({ node, selectedFile, onSelect, depth, defaultExpanded = false }: TreeItemProps) {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(node.expanded !== false);
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   // When a file outside the currently-paginated slice is selected (e.g. via

--- a/packages/ui/src/components/HtmlView.tsx
+++ b/packages/ui/src/components/HtmlView.tsx
@@ -15,6 +15,17 @@ export default function HtmlView({ html, onWikilinkClick }: HtmlViewProps) {
     if (!containerRef.current) return;
     containerRef.current.scrollTop = 0;
 
+    // Format ISO dates using the user's local timezone and locale
+    for (const el of containerRef.current.querySelectorAll<HTMLElement>(".rss-date[data-iso]")) {
+      const d = new Date(el.dataset.iso!);
+      if (!isNaN(d.getTime())) {
+        el.textContent = d.toLocaleString(undefined, {
+          year: "numeric", month: "long", day: "numeric",
+          hour: "numeric", minute: "2-digit",
+        });
+      }
+    }
+
     // Apply syntax highlighting to all code blocks
     const codeBlocks = containerRef.current.querySelectorAll("pre code");
     for (const block of codeBlocks) {

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -52,6 +52,8 @@ export interface TreeNode {
   title?: string;
   /** Total number of entity files (recursive) in this directory; only present on directory nodes. */
   count?: number;
+  /** Whether this directory starts expanded (undefined = true). */
+  expanded?: boolean;
   children?: TreeNode[];
 }
 

--- a/packages/website/src/catalog.json
+++ b/packages/website/src/catalog.json
@@ -5,6 +5,12 @@
       "url": "https://mantisbt.vboctor.workers.dev",
       "description": "A replica of the public Mantis Bug Tracker issue tracker synced from MantisHub. Useful for AI agents that need grounding in MantisBT core issues.",
       "crawler": "mantishub"
+    },
+    {
+      "title": "Sam Altman Blog",
+      "url": "https://sam-altman.vboctor.workers.dev",
+      "description": "Posts from Sam Altman's personal blog, synced from its Atom feed. Useful grounding for agents reasoning about OpenAI history, startup advice, and AI policy.",
+      "crawler": "rss"
     }
   ]
 }

--- a/packages/website/src/catalog.ts
+++ b/packages/website/src/catalog.ts
@@ -12,6 +12,7 @@ const CRAWLER_COLORS: Record<string, string> = {
   obsidian: "#7c3aed",
   git: "#e36209",
   mantishub: "#cf222e",
+  rss: "#ee802f",
 };
 
 const CONTRIBUTE_URL =

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -18,13 +18,14 @@ import { searchEntities } from "../db/search";
 import { getR2Object, getMimeType } from "../storage/r2";
 import { ThemeEngine } from "@frozenink/core/theme";
 import type { ThemeRenderContext, FolderConfig } from "@frozenink/core/theme";
-import { GitHubTheme, ObsidianTheme, GitTheme, MantisHubTheme } from "@frozenink/crawlers/themes";
+import { GitHubTheme, ObsidianTheme, GitTheme, MantisHubTheme, RssTheme } from "@frozenink/crawlers/themes";
 
 const themeEngine = new ThemeEngine();
 themeEngine.register(new GitHubTheme());
 themeEngine.register(new ObsidianTheme());
 themeEngine.register(new GitTheme());
 themeEngine.register(new MantisHubTheme());
+themeEngine.register(new RssTheme());
 
 export function buildRenderContext(
   collectionName: string,
@@ -128,12 +129,14 @@ api.get("/api/collections/:name/tree", async (c) => {
     .filter((p) => p.endsWith(".md"));
 
   // Derive folder configs from the theme instead of R2-stored yml files
-  const folderConfigs = new Map<string, { visible?: boolean; sort?: "ASC" | "DESC"; hide?: string[]; showCount?: boolean }>();
-  const rootConfig: { hide?: string[] } = {};
+  const folderConfigs = new Map<string, { visible?: boolean; sort?: "ASC" | "DESC"; hide?: string[]; showCount?: boolean; expandFirstN?: number; expanded?: boolean; created_at_prefix?: boolean }>();
+  const rootConfig: { hide?: string[]; sort?: "ASC" | "DESC"; expandFirstN?: number } = {};
   if (col?.crawler) {
     const themeFolderConfigs = themeEngine.getFolderConfigs(col.crawler);
     const themeRootConfig = themeEngine.getRootConfig(col.crawler);
     if (themeRootConfig.hide) rootConfig.hide = themeRootConfig.hide;
+    if (themeRootConfig.sort) rootConfig.sort = themeRootConfig.sort;
+    if (themeRootConfig.expandFirstN) rootConfig.expandFirstN = themeRootConfig.expandFirstN;
 
     // Map folder-name-based configs to actual folder paths found in the entity paths
     const folderPaths = new Set<string>();
@@ -150,6 +153,9 @@ api.get("/api/collections/:name/tree", async (c) => {
       }
     }
   }
+
+  // Store root config at "" key so sortTree can apply it at the root level
+  folderConfigs.set("", rootConfig);
 
   // Apply root-level hide patterns to files at the root (no subdirectory)
   const rootHideCompiled = compileHidePatterns(rootConfig.hide ?? []);
@@ -569,7 +575,7 @@ function pickFirstTreeFile(
 function buildTreeFromPaths(
   paths: string[],
   titleByPath: Map<string, string> = new Map(),
-  folderConfigs: Map<string, { visible?: boolean; sort?: "ASC" | "DESC"; hide?: string[]; showCount?: boolean }> = new Map(),
+  folderConfigs: Map<string, { visible?: boolean; sort?: "ASC" | "DESC"; hide?: string[]; showCount?: boolean; expandFirstN?: number; expanded?: boolean; created_at_prefix?: boolean }> = new Map(),
 ): object[] {
   interface TreeNode {
     name: string;
@@ -577,6 +583,7 @@ function buildTreeFromPaths(
     type: "directory" | "file";
     title?: string;
     count?: number;
+    expanded?: boolean;
     children?: TreeNode[];
   }
 
@@ -623,7 +630,7 @@ function buildTreeFromPaths(
   }
 
   function sortTree(nodes: TreeNode[], parentPath: string = ""): TreeNode[] {
-    const config = parentPath ? folderConfigs.get(parentPath) : undefined;
+    const config = folderConfigs.get(parentPath);
     const sortOrder = config?.sort ?? "ASC";
     const folderHideCompiled = compileHidePatterns(config?.hide ?? []);
 
@@ -632,8 +639,25 @@ function buildTreeFromPaths(
       .filter((n) => {
         const childPath = parentPath ? `${parentPath}/${n.name}` : n.name;
         return folderConfigs.get(childPath)?.visible !== false;
-      })
-      .sort((a, b) => a.name.localeCompare(b.name));
+      });
+    if (sortOrder === "DESC") {
+      dirs.sort((a, b) => b.name.localeCompare(a.name));
+    } else {
+      dirs.sort((a, b) => a.name.localeCompare(b.name));
+    }
+    for (const dir of dirs) {
+      const childPath = parentPath ? `${parentPath}/${dir.name}` : dir.name;
+      if (folderConfigs.get(childPath)?.expanded === false) {
+        dir.expanded = false;
+      }
+    }
+    if (config?.expandFirstN && config.expandFirstN > 0) {
+      // Mark first N expanded, rest explicitly collapsed. The UI falls back to
+      // "expanded" when the flag is absent, so both sides must be set.
+      for (let i = 0; i < dirs.length; i++) {
+        dirs[i].expanded = i < config.expandFirstN;
+      }
+    }
 
     const files = nodes
       .filter((n) => n.type === "file")
@@ -642,6 +666,13 @@ function buildTreeFromPaths(
       files.sort((a, b) => b.name.localeCompare(a.name));
     } else {
       files.sort((a, b) => a.name.localeCompare(b.name));
+    }
+    if (config?.created_at_prefix) {
+      for (const file of files) {
+        const datePrefix = file.name.slice(0, 8);
+        const stored = titleByPath.get(file.path);
+        file.title = stored ? `${datePrefix} ${stored}` : file.name.replace(/\.md$/, "");
+      }
     }
 
     for (const dir of dirs) {


### PR DESCRIPTION
## Summary

- **RSS collection tree restructure** — years at the top level, DESC-sorted with the latest three expanded; post filenames slugified with a `YYYYMMDD-` prefix; display titles include the date. New `FolderConfig` flags (`expandFirstN`, `expanded`, `created_at_prefix`) drive this and are honored by both the worker API tree and the CLI `serve` tree. Also registers `RssTheme` in the worker's theme engine (it was missing, which is why the published site was ignoring sort/expand/prefix settings).
- **Republish performance** — skip `wrangler deploy` when bundle + config hash is unchanged, skip the entire D1 phase when the local entity fingerprint matches the last push, split D1 delta into parallel DELETE and INSERT phases, and emit multi-row `INSERT VALUES`. Adds a `--full` flag for path-only theme changes that contentHash can't detect, and logs publish progress from the management-API path so desktop-triggered republishes show what they're doing.
- **Desktop auto-updater fix** — switch `electron-updater` to a default-import + destructure so the CJS module resolves in the packaged app.
- **RSS sync fix** — `shouldInclude` now uses strict `>` against the watermark so the newest post isn't reprocessed every sync (which re-downloaded its image attachments).

## Test plan

- [x] `bun run ci` passes (markdown lint, typecheck, all bun + vitest suites, UI build, worker build).
- [x] Live-verified published worker returns years DESC with `expanded:true/false` on first 3 / rest, titles prefixed with `YYYYMMDD`, and `/html/*` + `/markdown/*` endpoints return 200 for slugified paths.
- [ ] Manual: first republish after this change actually deploys the new worker bundle (hash differs from stored).
- [ ] Manual: second republish with no local changes skips both deploy and D1 phase.
- [ ] Manual: desktop app — open/sync/publish a published RSS collection and confirm progress lines appear in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)