### PR TITLE
Throttle GitHub crawler, sharpen incremental sync, pad tree titles

### DIFF
--- a/packages/core/src/crawler/interface.ts
+++ b/packages/core/src/crawler/interface.ts
@@ -70,4 +70,10 @@ export interface Crawler {
    * by the UI/TUI to show what's happening under the hood.
    */
   setProgressCallback?(callback: (message: string) => void): void;
+  /**
+   * Optional: hand the crawler the set of externalIds already present in the
+   * local DB so it can skip re-fetching entities it already has (e.g. user
+   * profiles whose bios rarely change).
+   */
+  setExistingExternalIds?(ids: Set<string>): void;
 }

--- a/packages/core/src/crawler/sync-engine.ts
+++ b/packages/core/src/crawler/sync-engine.ts
@@ -175,6 +175,12 @@ export class SyncEngine {
     if (this.onProgress) {
       this.crawler.setProgressCallback?.(this.onProgress);
     }
+    // Hand the crawler the existing external-id set so it can skip re-fetching
+    // entities we already have (e.g. user profiles for returning contributors).
+    if (this.crawler.setExistingExternalIds) {
+      const rows = this.db.select({ externalId: entities.externalId }).from(entities).all();
+      this.crawler.setExistingExternalIds(new Set(rows.map((r: { externalId: string }) => r.externalId)));
+    }
 
     const metadata = new MetadataStore(this.dbPath);
 
@@ -213,8 +219,22 @@ export class SyncEngine {
 
       // Sync loop
       let hasMore = true;
+      let pausedByRateLimit = false;
       while (hasMore) {
-        const result = await this.crawler.sync(cursor);
+        let result: Awaited<ReturnType<Crawler["sync"]>>;
+        try {
+          result = await this.crawler.sync(cursor);
+        } catch (err) {
+          // RateLimitPauseError signals the crawler hit a wait longer than
+          // what's safe to sleep through inline (e.g. in a Workers request).
+          // Persist the cursor and exit cleanly so the next sync tick resumes.
+          if (err instanceof Error && err.name === "RateLimitPauseError") {
+            pausedByRateLimit = true;
+            this.onProgress?.(err.message);
+            break;
+          }
+          throw err;
+        }
         this.onBatchFetched?.({
           collectionName: this.collectionName,
           externalIds: result.entities.map((e) => e.externalId),
@@ -257,6 +277,23 @@ export class SyncEngine {
 
       // Persist cursor to DB; version goes to YAML (user-facing) and is mirrored in DB.
       metadata.setSyncState({ cursor: cursor ?? null });
+
+      if (pausedByRateLimit) {
+        // Don't bump version, reconcile (would delete unsynced entities as
+        // orphans), or write folder configs — the sync is mid-flight. Mark
+        // as failed so the UI shows an incomplete state and the next run
+        // resumes from the persisted cursor.
+        metadata.setSyncState({
+          lastStatus: "failed",
+          lastAt: new Date().toISOString().replace("T", " ").replace("Z", ""),
+          lastCreated: created,
+          lastUpdated: updated,
+          lastDeleted: deleted,
+          lastErrors: ["Paused due to GitHub rate limit; will resume on next sync"],
+        });
+        return { created, updated, deleted };
+      }
+
       metadata.setCollectionVersion(currentVersion);
       updateCollection(this.collectionName, { version: currentVersion });
 

--- a/packages/crawlers/src/github/__tests__/crawler.test.ts
+++ b/packages/crawlers/src/github/__tests__/crawler.test.ts
@@ -159,7 +159,9 @@ describe("GitHubCrawler", () => {
       expect(result.entities).toHaveLength(1);
       expect(result.entities[0].externalId).toBe("issue-10");
       expect(result.entities[0].entityType).toBe("issue");
-      expect(result.entities[0].title).toBe("Bug report");
+      // Title carries the zero-padded prefix for file-tree display.
+      expect(result.entities[0].title).toBe("00010 Bug report");
+      expect(result.entities[0].data.title).toBe("Bug report");
       expect(result.entities[0].url).toBe("https://github.com/owner/repo/issues/10");
       expect(result.entities[0].tags).toContain("bug");
       expect(result.entities[0].data.state).toBe("open");
@@ -200,7 +202,8 @@ describe("GitHubCrawler", () => {
       expect(result2.entities).toHaveLength(1);
       expect(result2.entities[0].externalId).toBe("pr-20");
       expect(result2.entities[0].entityType).toBe("pull_request");
-      expect(result2.entities[0].title).toBe("Add feature X");
+      expect(result2.entities[0].title).toBe("00020 Add feature X");
+      expect(result2.entities[0].data.title).toBe("Add feature X");
       expect(result2.entities[0].data.head).toBe("feat/x");
       expect(result2.entities[0].data.base).toBe("main");
       expect(result2.entities[0].data.merged).toBe(false);
@@ -612,6 +615,70 @@ describe("GitHubCrawler", () => {
     });
   });
 
+  describe("ETag caching", () => {
+    it("sends If-None-Match after caching an etag and treats 304 as empty", async () => {
+      const seen: Array<{ url: string; etag: string | null }> = [];
+      let call = 0;
+      crawler.setFetch(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const etag = (init?.headers as Record<string, string> | undefined)?.[
+          "If-None-Match"
+        ] ?? null;
+        seen.push({ url, etag });
+        call++;
+        if (url.includes("/issues?") && call === 1) {
+          return new Response(JSON.stringify([sampleIssue()]), {
+            status: 200,
+            headers: { etag: '"issues-v1"' },
+          });
+        }
+        if (url.includes("/issues?")) {
+          return new Response("", { status: 304 });
+        }
+        return new Response(JSON.stringify([]), { status: 200 });
+      });
+
+      const first = await crawler.sync(null);
+      expect(first.entities.length).toBeGreaterThan(0);
+
+      // Next sync run reuses the persisted etag cache but restarts the phase.
+      const second = await crawler.sync({
+        ...(first.nextCursor ?? {}),
+        phase: "issues",
+        issuesPage: 1,
+      });
+      const issuesCalls = seen.filter((s) => s.url.includes("/issues?"));
+      expect(issuesCalls[1]?.etag).toBe('"issues-v1"');
+      // 304 → treated as empty page → no new entities.
+      expect(
+        second.entities.filter((e) => e.entityType === "issue"),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe("skip existing users", () => {
+    it("does not fetch user profiles already in the local DB", async () => {
+      const urls: string[] = [];
+      crawler.setFetch(async (input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input.toString();
+        urls.push(url);
+        if (url.includes("/issues?"))
+          return new Response(JSON.stringify([sampleIssue()]), { status: 200 });
+        if (url.includes("/pulls?"))
+          return new Response(JSON.stringify([]), { status: 200 });
+        return new Response(JSON.stringify(sampleUserProfile()), { status: 200 });
+      });
+      // testuser already exists; dev1 does not.
+      crawler.setExistingExternalIds(new Set(["user-testuser"]));
+
+      let r = await crawler.sync(null);
+      while (r.hasMore) r = await crawler.sync(r.nextCursor);
+
+      expect(urls.some((u) => u.endsWith("/users/testuser"))).toBe(false);
+      expect(urls.some((u) => u.endsWith("/users/dev1"))).toBe(true);
+    });
+  });
+
   describe("openOnly mode", () => {
     let openOnlyCrawler: GitHubCrawler;
 
@@ -638,7 +705,9 @@ describe("GitHubCrawler", () => {
       expect(issuesUrl).not.toContain("state=all");
     });
 
-    it("does not use since parameter in openOnly mode", async () => {
+    it("uses incremental since parameter in openOnly mode", async () => {
+      // Deletion tracking was dropped, so openOnly can now ride the
+      // incremental `since` filter for the same speedup as full mode.
       const urls: string[] = [];
       openOnlyCrawler.setFetch(async (input: string | URL | Request) => {
         const url = typeof input === "string" ? input : input.toString();
@@ -646,7 +715,6 @@ describe("GitHubCrawler", () => {
         return new Response(JSON.stringify([]), { status: 200 });
       });
 
-      // Even with updatedSince in cursor, openOnly should not use since
       await openOnlyCrawler.sync({
         phase: "issues",
         issuesPage: 1,
@@ -654,53 +722,10 @@ describe("GitHubCrawler", () => {
       });
 
       const issuesUrl = urls.find((u) => u.includes("/issues?"));
-      expect(issuesUrl).not.toContain("since=");
+      expect(issuesUrl).toContain("since=2024-06-01");
     });
 
-    it("stores knownOpenIds in cursor after sync completes", async () => {
-      const issue = sampleIssue({ number: 10 });
-      openOnlyCrawler.setFetch(
-        mockFetch({
-          "/issues?": [issue],
-          "/pulls?": [],
-          "/users/testuser": sampleUserProfile(),
-          "/users/dev1": sampleUserProfile({ login: "dev1" }),
-        }),
-      );
-
-      // Issues phase
-      let r = await openOnlyCrawler.sync(null);
-      expect(r.hasMore).toBe(true);
-      // Pulls phase (empty), then users
-      r = await openOnlyCrawler.sync(r.nextCursor);
-      expect(r.hasMore).toBe(true);
-      // Users phase
-      r = await openOnlyCrawler.sync(r.nextCursor);
-      expect(r.hasMore).toBe(false);
-
-      const cursor = r.nextCursor as { knownOpenIds?: string[] };
-      expect(cursor.knownOpenIds).toContain("issue-10");
-    });
-
-    it("returns deletedExternalIds for items no longer open", async () => {
-      // First sync: issues 10 and 20 are open
-      openOnlyCrawler.setFetch(
-        mockFetch({
-          "/issues?": [sampleIssue({ number: 10 }), sampleIssue({ number: 20 })],
-          "/pulls?": [],
-          "/users/testuser": sampleUserProfile(),
-          "/users/dev1": sampleUserProfile({ login: "dev1" }),
-        }),
-      );
-
-      let r = await openOnlyCrawler.sync(null);
-      r = await openOnlyCrawler.sync(r.nextCursor); // pulls phase
-      r = await openOnlyCrawler.sync(r.nextCursor); // users phase
-      const firstCursor = r.nextCursor as { knownOpenIds: string[] };
-      expect(firstCursor.knownOpenIds).toEqual(["issue-10", "issue-20"]);
-      expect(r.deletedExternalIds).toEqual([]); // No previous known IDs to compare against
-
-      // Second sync: only issue 10 is still open (20 was closed)
+    it("never returns deletedExternalIds", async () => {
       openOnlyCrawler.setFetch(
         mockFetch({
           "/issues?": [sampleIssue({ number: 10 })],
@@ -709,57 +734,10 @@ describe("GitHubCrawler", () => {
           "/users/dev1": sampleUserProfile({ login: "dev1" }),
         }),
       );
-
-      let r2 = await openOnlyCrawler.sync({
-        ...firstCursor,
-        phase: "issues",
-        issuesPage: 1,
-      });
-      r2 = await openOnlyCrawler.sync(r2.nextCursor); // pulls phase
-      r2 = await openOnlyCrawler.sync(r2.nextCursor); // users phase
-
-      expect(r2.deletedExternalIds).toEqual(["issue-20"]);
-      const secondCursor = r2.nextCursor as { knownOpenIds: string[] };
-      expect(secondCursor.knownOpenIds).toEqual(["issue-10"]);
-    });
-
-    it("tracks PR IDs in knownOpenIds too", async () => {
-      openOnlyCrawler.setFetch(
-        mockFetch({
-          "/issues?": [sampleIssue({ number: 5 })],
-          "/pulls?": [samplePR({ number: 15 })],
-          "/reviews?": [],
-          "/check-runs?": { total_count: 0, check_runs: [] },
-          "/users/testuser": sampleUserProfile(),
-          "/users/dev1": sampleUserProfile({ login: "dev1" }),
-        }),
-      );
-
       let r = await openOnlyCrawler.sync(null);
-      r = await openOnlyCrawler.sync(r.nextCursor); // pulls phase
-      r = await openOnlyCrawler.sync(r.nextCursor); // users phase
-
-      const cursor = r.nextCursor as { knownOpenIds: string[] };
-      expect(cursor.knownOpenIds).toContain("issue-5");
-      expect(cursor.knownOpenIds).toContain("pr-15");
-    });
-
-    it("does not set updatedSince in openOnly cursor", async () => {
-      openOnlyCrawler.setFetch(
-        mockFetch({
-          "/issues?": [sampleIssue()],
-          "/pulls?": [],
-          "/users/testuser": sampleUserProfile(),
-          "/users/dev1": sampleUserProfile({ login: "dev1" }),
-        }),
-      );
-
-      let r = await openOnlyCrawler.sync(null);
-      r = await openOnlyCrawler.sync(r.nextCursor); // pulls
-      r = await openOnlyCrawler.sync(r.nextCursor); // users
-
-      const cursor = r.nextCursor as { updatedSince?: string };
-      expect(cursor.updatedSince).toBeUndefined();
+      r = await openOnlyCrawler.sync(r.nextCursor);
+      r = await openOnlyCrawler.sync(r.nextCursor);
+      expect(r.deletedExternalIds).toEqual([]);
     });
   });
 

--- a/packages/crawlers/src/github/__tests__/rate-limiter.test.ts
+++ b/packages/crawlers/src/github/__tests__/rate-limiter.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  createRateLimitedFetch,
+  RateLimitPauseError,
+  __resetRateLimiter,
+} from "../rate-limiter";
+
+function respond(
+  status: number,
+  headers: Record<string, string> = {},
+  body: string = "",
+): Response {
+  return new Response(body, { status, headers });
+}
+
+function futureUnix(seconds: number): string {
+  return String(Math.floor(Date.now() / 1000) + seconds);
+}
+
+beforeEach(() => {
+  __resetRateLimiter();
+});
+
+describe("rate-limiter", () => {
+  it("passes through with no pacing when budget is plentiful", async () => {
+    let calls = 0;
+    const baseFetch = (async () => {
+      calls++;
+      return respond(200, {
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4990",
+        "x-ratelimit-reset": futureUnix(3600),
+      });
+    }) as unknown as typeof fetch;
+
+    const f = createRateLimitedFetch(baseFetch, "tok-full");
+    const t0 = Date.now();
+    await f("https://api.github.com/x");
+    await f("https://api.github.com/x");
+    const elapsed = Date.now() - t0;
+    expect(calls).toBe(2);
+    // With 4990/5000 remaining for 3600s, pace is sub-second — definitely < 100ms.
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it("paces requests when budget is low", async () => {
+    // 10 remaining over 2s → ~222ms pace after safety margin (10*0.9 usable).
+    const resetSec = futureUnix(2);
+    const baseFetch = (async () =>
+      respond(200, {
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "10",
+        "x-ratelimit-reset": resetSec,
+      })) as unknown as typeof fetch;
+
+    const f = createRateLimitedFetch(baseFetch, "tok-low");
+    await f("https://api.github.com/x"); // primes pace from response headers
+    const t0 = Date.now();
+    await f("https://api.github.com/x");
+    const elapsed = Date.now() - t0;
+    // Pace is ~222ms (2s / 9 usable). elapsed-since-last eats some of it, so
+    // the floor we can safely assert is ~100ms.
+    expect(elapsed).toBeGreaterThanOrEqual(100);
+  });
+
+  it("retries after 429 with Retry-After", async () => {
+    let calls = 0;
+    const baseFetch = (async () => {
+      calls++;
+      if (calls === 1) {
+        return respond(429, { "retry-after": "1" });
+      }
+      return respond(200, {
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4999",
+        "x-ratelimit-reset": futureUnix(3600),
+      });
+    }) as unknown as typeof fetch;
+
+    const f = createRateLimitedFetch(baseFetch, "tok-429");
+    const t0 = Date.now();
+    const res = await f("https://api.github.com/x");
+    const elapsed = Date.now() - t0;
+    expect(res.status).toBe(200);
+    expect(calls).toBe(2);
+    expect(elapsed).toBeGreaterThanOrEqual(500); // at least ~0.75s (jitter of 1s)
+  });
+
+  it("throws RateLimitPauseError when wait exceeds inline cap", async () => {
+    const baseFetch = (async () =>
+      respond(403, {
+        "retry-after": "120", // 2 minutes
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": futureUnix(120),
+      })) as unknown as typeof fetch;
+
+    const f = createRateLimitedFetch(baseFetch, "tok-pause", {
+      maxInlineWaitMs: 5000,
+    });
+
+    await expect(f("https://api.github.com/x")).rejects.toBeInstanceOf(
+      RateLimitPauseError,
+    );
+  });
+
+  it("downshifts on secondary rate limit (403 with budget remaining)", async () => {
+    let calls = 0;
+    const baseFetch = (async () => {
+      calls++;
+      if (calls === 1) {
+        return respond(403, {
+          "retry-after": "1",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4000", // budget left → secondary
+          "x-ratelimit-reset": futureUnix(3600),
+        });
+      }
+      return respond(200, {
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "3999",
+        "x-ratelimit-reset": futureUnix(3600),
+      });
+    }) as unknown as typeof fetch;
+
+    const f = createRateLimitedFetch(baseFetch, "tok-secondary");
+    const res = await f("https://api.github.com/x");
+    expect(res.status).toBe(200);
+    expect(calls).toBe(2);
+    // Secondary bit is set; subsequent request should see doubled pace (≥1s floor).
+    const t0 = Date.now();
+    await f("https://api.github.com/x");
+    expect(Date.now() - t0).toBeGreaterThanOrEqual(800);
+  });
+
+  it("retries on 5xx with exponential backoff", async () => {
+    let calls = 0;
+    const baseFetch = (async () => {
+      calls++;
+      if (calls < 3) return respond(502);
+      return respond(200, {
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4999",
+        "x-ratelimit-reset": futureUnix(3600),
+      });
+    }) as unknown as typeof fetch;
+
+    const f = createRateLimitedFetch(baseFetch, "tok-5xx");
+    const res = await f("https://api.github.com/x");
+    expect(res.status).toBe(200);
+    expect(calls).toBe(3);
+  });
+});

--- a/packages/crawlers/src/github/crawler.ts
+++ b/packages/crawlers/src/github/crawler.ts
@@ -16,25 +16,36 @@ import type {
   GitHubCheckRun,
   GitHubUserProfile,
 } from "./types";
+import { createRateLimitedFetch } from "./rate-limiter";
 
 const PER_PAGE = 100;
 const API_BASE = "https://api.github.com";
+const NUMBER_PAD_WIDTH = 5;
+
+/** Build the file-tree display title: "00001 Raw title". */
+function paddedDisplayTitle(number: number, rawTitle: string): string {
+  return `${String(number).padStart(NUMBER_PAD_WIDTH, "0")} ${rawTitle}`;
+}
 
 interface GitHubSyncCursor extends SyncCursor {
   updatedSince?: string;
   issuesPage?: number;
   pullsPage?: number;
   phase?: "issues" | "pulls" | "users" | "done";
-  /** External IDs collected during the current sync run (openOnly mode). */
+  /** External IDs collected during the current sync run. */
   seenIds?: string[];
-  /** Open IDs from the previous completed sync (openOnly mode). */
-  knownOpenIds?: string[];
   /** Running count of entities fetched per type in this sync run. */
   issuesFetched?: number;
   pullsFetched?: number;
   totalFetched?: number;
   /** User logins collected from issues/PRs to fetch in the users phase. */
   collectedUsers?: string[];
+  /**
+   * ETag cache for list endpoints (issues, pulls). A cache hit returns 304
+   * and costs nothing against the rate-limit budget, short-circuiting an
+   * entire empty sync.
+   */
+  etags?: Record<string, string>;
 }
 
 export class GitHubCrawler implements Crawler {
@@ -69,6 +80,9 @@ export class GitHubCrawler implements Crawler {
   private maxIssues?: number;
   private maxPullRequests?: number;
   private fetchFn: typeof fetch = globalThis.fetch;
+  private fetchOverridden = false;
+  private existingExternalIds?: Set<string>;
+  private etags: Record<string, string> = {};
 
   async initialize(
     config: Record<string, unknown>,
@@ -87,10 +101,20 @@ export class GitHubCrawler implements Crawler {
     this.maxEntities = typeof cfg.maxEntities === "number" ? cfg.maxEntities : undefined;
     this.maxIssues = typeof cfg.maxIssues === "number" ? cfg.maxIssues : undefined;
     this.maxPullRequests = typeof cfg.maxPullRequests === "number" ? cfg.maxPullRequests : undefined;
+    if (!this.fetchOverridden) {
+      this.fetchFn = createRateLimitedFetch(globalThis.fetch, this.token, {
+        debug: process.env.GITHUB_RATE_LIMIT_DEBUG === "1",
+      });
+    }
   }
 
   setFetch(fn: typeof fetch): void {
     this.fetchFn = fn;
+    this.fetchOverridden = true;
+  }
+
+  setExistingExternalIds(ids: Set<string>): void {
+    this.existingExternalIds = ids;
   }
 
   async sync(cursor: SyncCursor | null): Promise<SyncResult> {
@@ -107,6 +131,9 @@ export class GitHubCrawler implements Crawler {
     let pullsFetched = c.pullsFetched ?? 0;
     let totalFetched = c.totalFetched ?? 0;
     const collectedUsers = new Set<string>(c.collectedUsers ?? []);
+    // Seed the ETag cache from the cursor so conditional requests survive
+    // across sync runs.
+    this.etags = { ...(c.etags ?? {}) };
 
     // Check if global limit already reached from previous pages
     if (this.maxEntities && totalFetched >= this.maxEntities) {
@@ -121,7 +148,7 @@ export class GitHubCrawler implements Crawler {
       }
 
       const page = c.issuesPage ?? 1;
-      const since = this.openOnly ? undefined : c.updatedSince;
+      const since = c.updatedSince;
       const state = this.openOnly ? "open" : "all";
       const items = await this.fetchIssues(page, since, state);
 
@@ -163,7 +190,7 @@ export class GitHubCrawler implements Crawler {
       if (!reachedTypeMax && items.length === PER_PAGE) {
         return {
           entities,
-          nextCursor: { ...c, phase: "issues", issuesPage: page + 1, seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers] },
+          nextCursor: { ...c, phase: "issues", issuesPage: page + 1, seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers], etags: { ...this.etags } },
           hasMore: true,
           deletedExternalIds: [],
         };
@@ -179,7 +206,7 @@ export class GitHubCrawler implements Crawler {
       }
 
       const page = c.pullsPage ?? 1;
-      const since = this.openOnly ? undefined : c.updatedSince;
+      const since = c.updatedSince;
       const state = this.openOnly ? "open" : "all";
       const items = await this.fetchPullRequests(page, since, state);
 
@@ -218,7 +245,7 @@ export class GitHubCrawler implements Crawler {
       if (!reachedTypeMax && items.length === PER_PAGE) {
         return {
           entities,
-          nextCursor: { ...c, phase: "pulls", pullsPage: page + 1, seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers] },
+          nextCursor: { ...c, phase: "pulls", pullsPage: page + 1, seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers], etags: { ...this.etags } },
           hasMore: true,
           deletedExternalIds: [],
         };
@@ -232,6 +259,9 @@ export class GitHubCrawler implements Crawler {
       const userLogins = c.collectedUsers ?? [];
       for (const login of userLogins) {
         if (this.maxEntities && totalFetched >= this.maxEntities) break;
+        // Skip users already in the DB. Profiles rarely change meaningfully
+        // between syncs and each fetch is a separate API call.
+        if (this.existingExternalIds?.has(`user-${login}`)) continue;
         const profile = await this.fetchUserProfile(login);
         if (profile) {
           entities.push(this.mapUserProfile(profile));
@@ -246,7 +276,7 @@ export class GitHubCrawler implements Crawler {
     if (phase === "issues" && !this.syncIssues && this.syncPullRequests) {
       return {
         entities: [],
-        nextCursor: { ...c, phase: "pulls", pullsPage: 1, seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers] },
+        nextCursor: { ...c, phase: "pulls", pullsPage: 1, seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers], etags: { ...this.etags } },
         hasMore: true,
         deletedExternalIds: [],
       };
@@ -257,7 +287,7 @@ export class GitHubCrawler implements Crawler {
       if (collectedUsers.size > 0) {
         return {
           entities: [],
-          nextCursor: { ...c, phase: "users", seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers] },
+          nextCursor: { ...c, phase: "users", seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers], etags: { ...this.etags } },
           hasMore: true,
           deletedExternalIds: [],
         };
@@ -287,7 +317,7 @@ export class GitHubCrawler implements Crawler {
     if (this.syncPullRequests) {
       return {
         entities,
-        nextCursor: { ...c, phase: "pulls", pullsPage: 1, seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers] },
+        nextCursor: { ...c, phase: "pulls", pullsPage: 1, seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers], etags: { ...this.etags } },
         hasMore: true,
         deletedExternalIds: [],
       };
@@ -295,7 +325,7 @@ export class GitHubCrawler implements Crawler {
     if (collectedUsers.size > 0) {
       return {
         entities,
-        nextCursor: { ...c, phase: "users", seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers] },
+        nextCursor: { ...c, phase: "users", seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers], etags: { ...this.etags } },
         hasMore: true,
         deletedExternalIds: [],
       };
@@ -316,7 +346,7 @@ export class GitHubCrawler implements Crawler {
     if (collectedUsers.size > 0) {
       return {
         entities,
-        nextCursor: { ...c, phase: "users", seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers] },
+        nextCursor: { ...c, phase: "users", seenIds, issuesFetched, pullsFetched, totalFetched, collectedUsers: [...collectedUsers], etags: { ...this.etags } },
         hasMore: true,
         deletedExternalIds: [],
       };
@@ -325,9 +355,9 @@ export class GitHubCrawler implements Crawler {
   }
 
   /**
-   * Build the final SyncResult after all phases have completed.
-   * In openOnly mode, computes deletedExternalIds by comparing the current
-   * seen set against the previously known open set.
+   * Build the final SyncResult after all phases have completed. Deletion
+   * tracking has been dropped so both full and openOnly modes can use the
+   * incremental `since` filter for speed.
    */
   private finalize(
     cursor: GitHubSyncCursor,
@@ -335,24 +365,18 @@ export class GitHubCrawler implements Crawler {
     seenIds: string[],
     _collectedUsers: Set<string>,
   ): SyncResult {
+    void seenIds;
     const latestUpdated = this.findLatestUpdated(entities);
-    let deletedExternalIds: string[] = [];
-
-    if (this.openOnly) {
-      const seenSet = new Set(seenIds);
-      const previousKnown = cursor.knownOpenIds ?? [];
-      deletedExternalIds = previousKnown.filter((id) => !seenSet.has(id));
-    }
 
     return {
       entities,
       nextCursor: {
         phase: "done",
-        updatedSince: this.openOnly ? undefined : (latestUpdated ?? cursor.updatedSince),
-        knownOpenIds: this.openOnly ? seenIds : undefined,
+        updatedSince: latestUpdated ?? cursor.updatedSince,
+        etags: { ...this.etags },
       },
       hasMore: false,
-      deletedExternalIds,
+      deletedExternalIds: [],
     };
   }
 
@@ -393,14 +417,8 @@ export class GitHubCrawler implements Crawler {
     });
     if (since) params.set("since", since);
 
-    const res = await this.fetchFn(
-      `${API_BASE}/repos/${this.owner}/${this.repo}/issues?${params}`,
-      { headers: this.buildHeaders(this.token) },
-    );
-    if (!res.ok) {
-      throw new Error(`GitHub API error ${res.status}: ${await res.text()}`);
-    }
-    return (await res.json()) as GitHubIssue[];
+    const url = `${API_BASE}/repos/${this.owner}/${this.repo}/issues?${params}`;
+    return (await this.fetchListWithEtag<GitHubIssue[]>(url)) ?? [];
   }
 
   private async fetchPullRequests(
@@ -417,14 +435,28 @@ export class GitHubCrawler implements Crawler {
     });
     if (since) params.set("since", since);
 
-    const res = await this.fetchFn(
-      `${API_BASE}/repos/${this.owner}/${this.repo}/pulls?${params}`,
-      { headers: this.buildHeaders(this.token) },
-    );
+    const url = `${API_BASE}/repos/${this.owner}/${this.repo}/pulls?${params}`;
+    return (await this.fetchListWithEtag<GitHubPullRequest[]>(url)) ?? [];
+  }
+
+  /**
+   * GET a list endpoint with ETag caching. Returns null on 304 (caller
+   * treats as empty page — cursor advances past already-synced items).
+   * 304s don't count against the rate-limit budget.
+   */
+  private async fetchListWithEtag<T>(url: string): Promise<T | null> {
+    const headers = this.buildHeaders(this.token);
+    const cached = this.etags[url];
+    if (cached) headers["If-None-Match"] = cached;
+
+    const res = await this.fetchFn(url, { headers });
+    if (res.status === 304) return null;
     if (!res.ok) {
       throw new Error(`GitHub API error ${res.status}: ${await res.text()}`);
     }
-    return (await res.json()) as GitHubPullRequest[];
+    const newEtag = res.headers.get("etag");
+    if (newEtag) this.etags[url] = newEtag;
+    return (await res.json()) as T;
   }
 
   private async fetchComments(issueNumber: number): Promise<GitHubComment[]> {
@@ -643,10 +675,13 @@ export class GitHubCrawler implements Crawler {
     return {
       externalId: `issue-${issue.number}`,
       entityType: "issue",
-      title: issue.title,
+      // entity.title drives the file-tree display. The raw GitHub title lives
+      // in data.title for rendering the content heading and slug.
+      title: paddedDisplayTitle(issue.number, issue.title),
       url: issue.html_url,
       tags,
       data: {
+        title: issue.title,
         number: issue.number,
         body: issue.body,
         state: issue.state,
@@ -771,10 +806,11 @@ export class GitHubCrawler implements Crawler {
     return {
       externalId: `pr-${pr.number}`,
       entityType: "pull_request",
-      title: pr.title,
+      title: paddedDisplayTitle(pr.number, pr.title),
       url: pr.html_url,
       tags,
       data: {
+        title: pr.title,
         number: pr.number,
         body: pr.body,
         state: pr.state,

--- a/packages/crawlers/src/github/rate-limiter.ts
+++ b/packages/crawlers/src/github/rate-limiter.ts
@@ -1,0 +1,251 @@
+/**
+ * Adaptive budget-aware rate limiter for the GitHub REST API.
+ *
+ * Reads `X-RateLimit-*` headers after each response and paces subsequent
+ * requests so the remaining budget covers the time until reset. Handles
+ * 429, secondary rate limits (403 + retry-after), and transient 5xx with
+ * exponential backoff. Waits longer than MAX_INLINE_WAIT_MS are surfaced as
+ * `RateLimitPauseError` so the caller can persist its cursor and resume on
+ * the next sync tick (important inside Cloudflare Workers, which cap CPU/
+ * request wall time).
+ *
+ * State is keyed by token so multiple collections sharing a PAT share a
+ * budget.
+ */
+
+const MAX_INLINE_WAIT_MS = 30_000;
+const MAX_PRIMARY_RETRIES = 5;
+const MAX_5XX_RETRIES = 3;
+const DEFAULT_CONCURRENCY = 4;
+const LOW_BUDGET_RATIO = 0.1;
+const HIGH_BUDGET_RATIO = 0.5;
+const SAFETY_MARGIN = 0.9;
+
+export class RateLimitPauseError extends Error {
+  readonly waitSeconds: number;
+  constructor(waitSeconds: number, message?: string) {
+    super(message ?? `GitHub rate limit requires pause of ${waitSeconds}s`);
+    this.name = "RateLimitPauseError";
+    this.waitSeconds = waitSeconds;
+  }
+}
+
+interface TokenState {
+  concurrencyCap: number;
+  inFlight: number;
+  waiters: Array<() => void>;
+  lastRequestAt: number;
+  paceMs: number;
+  remaining?: number;
+  limit?: number;
+  resetAtMs?: number;
+  secondaryHit: boolean;
+  debug: boolean;
+}
+
+const stateByToken = new Map<string, TokenState>();
+
+function getState(token: string, debug: boolean, initialCap: number): TokenState {
+  let s = stateByToken.get(token);
+  if (!s) {
+    s = {
+      concurrencyCap: initialCap,
+      inFlight: 0,
+      waiters: [],
+      lastRequestAt: 0,
+      paceMs: 0,
+      secondaryHit: false,
+      debug,
+    };
+    stateByToken.set(token, s);
+  } else {
+    s.debug = s.debug || debug;
+  }
+  return s;
+}
+
+function acquire(state: TokenState): Promise<void> {
+  if (state.inFlight < state.concurrencyCap) {
+    state.inFlight++;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    state.waiters.push(() => {
+      state.inFlight++;
+      resolve();
+    });
+  });
+}
+
+function release(state: TokenState): void {
+  state.inFlight--;
+  const next = state.waiters.shift();
+  if (next) next();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function jitter(ms: number): number {
+  return Math.floor(ms * (0.75 + Math.random() * 0.5));
+}
+
+function recomputePace(state: TokenState): void {
+  if (
+    state.remaining === undefined ||
+    state.resetAtMs === undefined ||
+    state.limit === undefined
+  ) {
+    state.paceMs = 0;
+    return;
+  }
+  const msUntilReset = Math.max(0, state.resetAtMs - Date.now());
+  const usable = Math.max(1, Math.floor(state.remaining * SAFETY_MARGIN));
+  // Full speed while the budget is abundant; start pacing only once we've
+  // spent half of it so small repos on fresh tokens never pay latency.
+  let pace =
+    state.remaining >= state.limit * HIGH_BUDGET_RATIO
+      ? 0
+      : Math.ceil(msUntilReset / usable);
+
+  if (state.remaining < state.limit * LOW_BUDGET_RATIO) {
+    state.concurrencyCap = 1;
+  }
+  if (state.secondaryHit) {
+    pace = Math.max(pace, 500) * 2;
+    state.concurrencyCap = 1;
+  }
+  state.paceMs = pace;
+}
+
+function readHeaders(state: TokenState, res: Response): void {
+  const remaining = res.headers.get("x-ratelimit-remaining");
+  const reset = res.headers.get("x-ratelimit-reset");
+  const limit = res.headers.get("x-ratelimit-limit");
+  if (remaining !== null) state.remaining = Number(remaining);
+  if (reset !== null) state.resetAtMs = Number(reset) * 1000;
+  if (limit !== null) state.limit = Number(limit);
+  recomputePace(state);
+  if (state.debug) {
+    const resetIn = state.resetAtMs ? state.resetAtMs - Date.now() : undefined;
+    // eslint-disable-next-line no-console
+    console.log(
+      `[rate-limit] remaining=${state.remaining ?? "?"} resetMs=${resetIn ?? "?"} pace=${state.paceMs}ms cap=${state.concurrencyCap}`,
+    );
+  }
+}
+
+function isRateLimitResponse(res: Response): boolean {
+  if (res.status === 429) return true;
+  if (res.status !== 403) return false;
+  if (res.headers.get("retry-after")) return true;
+  if (res.headers.get("x-ratelimit-remaining") === "0") return true;
+  return false;
+}
+
+async function drain(res: Response): Promise<void> {
+  try {
+    await res.body?.cancel();
+  } catch {
+    // ignore
+  }
+}
+
+export interface RateLimitedFetchOptions {
+  debug?: boolean;
+  maxConcurrency?: number;
+  /** Override wait cap for pause error — tests use this to exercise the path cheaply. */
+  maxInlineWaitMs?: number;
+}
+
+export function createRateLimitedFetch(
+  baseFetch: typeof fetch,
+  token: string,
+  options: RateLimitedFetchOptions = {},
+): typeof fetch {
+  const debug = options.debug === true;
+  const cap = options.maxConcurrency ?? DEFAULT_CONCURRENCY;
+  const maxInlineWait = options.maxInlineWaitMs ?? MAX_INLINE_WAIT_MS;
+  const state = getState(token, debug, cap);
+
+  const wrapped = async (input: RequestInfo | URL, init?: RequestInit) => {
+    await acquire(state);
+    try {
+      let attempt = 0;
+      let fiveXxAttempts = 0;
+      while (true) {
+        if (state.paceMs > 0) {
+          const elapsed = Date.now() - state.lastRequestAt;
+          const waitMs = state.paceMs - elapsed;
+          if (waitMs > 0) {
+            if (waitMs >= maxInlineWait) {
+              throw new RateLimitPauseError(Math.ceil(waitMs / 1000));
+            }
+            await sleep(waitMs);
+          }
+        }
+
+        state.lastRequestAt = Date.now();
+        const res = await baseFetch(input, init);
+        readHeaders(state, res);
+
+        if (isRateLimitResponse(res)) {
+          const retryAfter = res.headers.get("retry-after");
+          let waitMs: number;
+          if (retryAfter) {
+            waitMs = Number(retryAfter) * 1000;
+          } else if (state.resetAtMs) {
+            waitMs = Math.max(0, state.resetAtMs - Date.now());
+          } else {
+            waitMs = Math.min(16_000, Math.pow(2, attempt) * 1000);
+          }
+
+          // 403 with budget left suggests secondary/abuse throttling — halve pace
+          // for the rest of the run and clamp concurrency to 1.
+          if (
+            res.status === 403 &&
+            state.remaining !== undefined &&
+            state.remaining > 0
+          ) {
+            state.secondaryHit = true;
+            state.concurrencyCap = 1;
+            recomputePace(state);
+          }
+
+          await drain(res);
+
+          if (waitMs >= maxInlineWait) {
+            throw new RateLimitPauseError(Math.ceil(waitMs / 1000));
+          }
+          if (attempt >= MAX_PRIMARY_RETRIES) {
+            // Hand back the last rate-limited response; caller will surface as error.
+            return res;
+          }
+          await sleep(jitter(waitMs));
+          attempt++;
+          continue;
+        }
+
+        if (res.status >= 500 && res.status < 600) {
+          if (fiveXxAttempts >= MAX_5XX_RETRIES) return res;
+          await drain(res);
+          await sleep(jitter(Math.pow(2, fiveXxAttempts) * 500));
+          fiveXxAttempts++;
+          continue;
+        }
+
+        return res;
+      }
+    } finally {
+      release(state);
+    }
+  };
+
+  return wrapped as unknown as typeof fetch;
+}
+
+/** Test-only: wipe per-token state so tests don't leak budgets into each other. */
+export function __resetRateLimiter(): void {
+  stateByToken.clear();
+}

--- a/packages/crawlers/src/github/theme.ts
+++ b/packages/crawlers/src/github/theme.ts
@@ -24,6 +24,18 @@ function slugify(text: string): string {
     .replace(/^-|-$/g, "");
 }
 
+/**
+ * Recover the raw GitHub title from an entity. New entities store it in
+ * `data.title`; older ones only have `entity.title`, which may already be
+ * zero-prefixed from a prior generate run — strip that so the result is
+ * idempotent.
+ */
+function resolveRawTitle(entityTitle: string, dataTitle: unknown): string {
+  if (typeof dataTitle === "string" && dataTitle.length > 0) return dataTitle;
+  const m = entityTitle.match(/^\d{5} (.+)$/);
+  return m ? m[1] : entityTitle;
+}
+
 interface MappedUser {
   login: string;
   avatarUrl: string;
@@ -403,12 +415,24 @@ export class GitHubTheme implements Theme {
     }
 
     const number = entity.data.number as number;
-    const slug = slugify(entity.title);
+    // Slugify the raw GitHub title so filenames stay `1-title-slug.md`
+    // even though entity.title carries the zero-padded display prefix.
+    const rawTitle = resolveRawTitle(entity.title, entity.data.title);
+    const slug = slugify(rawTitle);
 
     if (entity.entityType === "pull_request") {
       return `pull-requests/${number}-${slug}.md`;
     }
     return `issues/${number}-${slug}.md`;
+  }
+
+  getTitle(context: ThemeRenderContext): string | undefined {
+    const { entity } = context;
+    if (entity.entityType === "user") return undefined;
+    const number = entity.data.number as number | undefined;
+    if (number === undefined) return undefined;
+    const raw = resolveRawTitle(entity.title, entity.data.title);
+    return `${String(number).padStart(5, "0")} ${raw}`;
   }
 
   folderConfigs() {
@@ -456,9 +480,11 @@ export class GitHubTheme implements Theme {
     const user = d.user as MappedUser | null;
     const sections: string[] = [];
 
+    const rawTitle = resolveRawTitle(entity.title, d.title);
+
     // Frontmatter
     const fm: Record<string, unknown> = {
-      title: entity.title,
+      title: rawTitle,
       type: "issue",
       number: d.number,
       state: d.state,
@@ -480,7 +506,7 @@ export class GitHubTheme implements Theme {
     sections.push(frontmatter(fm));
 
     // Title
-    sections.push(`# ${entity.title}`);
+    sections.push(`# ${rawTitle}`);
 
     // Metadata callout
     const metaParts: string[] = [];
@@ -537,9 +563,11 @@ export class GitHubTheme implements Theme {
     else if (d.state === "closed") reviewStatus = "closed";
     else if (d.draft) reviewStatus = "draft";
 
+    const rawTitle = resolveRawTitle(entity.title, d.title);
+
     // Frontmatter
     const fm: Record<string, unknown> = {
-      title: entity.title,
+      title: rawTitle,
       type: "pull_request",
       number: d.number,
       state: d.state,
@@ -566,7 +594,7 @@ export class GitHubTheme implements Theme {
     sections.push(frontmatter(fm));
 
     // Title
-    sections.push(`# ${entity.title}`);
+    sections.push(`# ${rawTitle}`);
 
     // Metadata callout
     const metaParts: string[] = [];
@@ -744,6 +772,7 @@ export class GitHubTheme implements Theme {
     const assignees = d.assignees as MappedUser[] | undefined;
     const comments = d.comments as MappedComment[] | undefined;
     const reactions = d.reactions as MappedReactions | null;
+    const rawTitle = resolveRawTitle(entity.title, d.title);
 
     // Build repo slug from entity URL for GitHub ref shortening
     const repoSlug = this.extractRepoSlug(entity.url);
@@ -760,7 +789,7 @@ export class GitHubTheme implements Theme {
 
     // Header
     parts.push(`<div class="gh-header">`);
-    parts.push(`<h1 class="gh-title">${esc(entity.title)} <span class="gh-title-number">#${d.number}</span></h1>`);
+    parts.push(`<h1 class="gh-title">${esc(rawTitle)} <span class="gh-title-number">#${d.number}</span></h1>`);
     parts.push(`<div class="gh-header-meta">`);
     parts.push(`<span class="gh-state-badge ${stateClass}">${stateIcon} ${esc(stateLabel)}</span>`);
     if (user) {
@@ -833,6 +862,7 @@ export class GitHubTheme implements Theme {
     const mdOpts: MarkdownOptions = { resolveUser: resolve, repo: repoSlug, lookupEntityPath: context.lookupEntityPath };
     const checkRuns = d.checkRuns as MappedCheckRun[] | undefined;
     const reactions = d.reactions as MappedReactions | null;
+    const rawTitle = resolveRawTitle(entity.title, d.title);
 
     let stateClass: string;
     let stateIcon: string;
@@ -856,7 +886,7 @@ export class GitHubTheme implements Theme {
 
     // Header
     parts.push(`<div class="gh-header">`);
-    parts.push(`<h1 class="gh-title">${esc(entity.title)} <span class="gh-title-number">#${d.number}</span></h1>`);
+    parts.push(`<h1 class="gh-title">${esc(rawTitle)} <span class="gh-title-number">#${d.number}</span></h1>`);
     parts.push(`<div class="gh-header-meta">`);
     parts.push(`<span class="gh-state-badge ${stateClass}">${stateIcon} ${esc(stateLabel)}</span>`);
     if (user) {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -348,9 +348,17 @@ export default function App() {
   }, []);
 
   const handleUIModeChange = useCallback((mode: UIMode) => {
+    // When leaving manage for browse, carry the collection the user was
+    // looking at (or editing) over to the browse view so they don't have
+    // to re-pick it from the dropdown. The enabled-only effect will fall
+    // back to the first enabled collection if this one isn't browsable.
+    if (mode === "browse") {
+      const carryOver = viewingCollection ?? editingCollection;
+      if (carryOver) setSelectedCollection(carryOver);
+    }
     setUIMode(mode);
     saveUIMode(mode);
-  }, []);
+  }, [viewingCollection, editingCollection]);
 
   const handleThemeChange = useCallback((newTheme: ThemeId) => {
     setTheme(newTheme);

--- a/packages/website/src/catalog.json
+++ b/packages/website/src/catalog.json
@@ -11,6 +11,12 @@
       "url": "https://sam-altman.vboctor.workers.dev",
       "description": "Posts from Sam Altman's personal blog, synced from its Atom feed. Useful grounding for agents reasoning about OpenAI history, startup advice, and AI policy.",
       "crawler": "rss"
+    },
+    {
+      "title": "Turso / libSQL",
+      "url": "https://turso-database-libsql.vboctor.workers.dev",
+      "description": "Issues and pull requests from the tursodatabase/libsql repository, synced from GitHub. Useful grounding for agents working with libSQL, Turso, or SQLite-based edge databases.",
+      "crawler": "github"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adaptive, header-driven GitHub rate limiter with backoff, retries, and a `RateLimitPauseError` escape hatch so the sync engine can persist its cursor and resume on the next tick (safe inside Cloudflare Workers).
- Incremental sync wins: ETag caching on list endpoints (empty syncs cost 0 budget), `openOnly` now uses the `since` filter too (deletion tracking dropped), and already-synced user profiles are skipped via a new `setExistingExternalIds` crawler hook.
- GitHub issue/PR titles carry a zero-padded prefix (`00042 Foo`) in the file tree; file paths, URLs, frontmatter, and the rendered H1 keep the raw title.
- Desktop: switching from manage back to browse now auto-selects the collection the user was viewing.
- Catalog: added the Turso / libSQL collection.

## Test plan
- [x] `bun run ci` — 213 tests pass (lint, typecheck, bun + vitest suites, UI build, worker build)
- [x] `bun run generate` re-ran on both live GitHub collections (`mantisbt-source-integration`, `turso-database-libsql`) — DB titles padded, file paths unchanged, rendered H1s unchanged.
- [ ] Spot-check a large public repo sync to confirm pacing kicks in as the budget tightens (run locally with `GITHUB_RATE_LIMIT_DEBUG=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)