### PR TITLE
Obsidian publishing parity + UI polish

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
         "react-dom": "^19.0.0",
         "react-markdown": "^9.0.0",
         "rehype-highlight": "^7.0.2",
+        "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.0",
       },
       "devDependencies": {
@@ -945,13 +946,23 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
     "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
 
+    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
+
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
 
     "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
@@ -960,6 +971,8 @@
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
@@ -1313,6 +1326,8 @@
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
@@ -1400,6 +1415,8 @@
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "rehype-highlight": ["rehype-highlight@7.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-text": "^4.0.0", "lowlight": "^3.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA=="],
+
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
@@ -1643,6 +1660,8 @@
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
+
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
@@ -1652,6 +1671,8 @@
     "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
+
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
@@ -1736,8 +1757,6 @@
     "@electron/universal/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
-
-    "@frozenink/ui/react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "@frozenink/worker/esbuild": ["esbuild@0.24.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.24.2", "@esbuild/android-arm": "0.24.2", "@esbuild/android-arm64": "0.24.2", "@esbuild/android-x64": "0.24.2", "@esbuild/darwin-arm64": "0.24.2", "@esbuild/darwin-x64": "0.24.2", "@esbuild/freebsd-arm64": "0.24.2", "@esbuild/freebsd-x64": "0.24.2", "@esbuild/linux-arm": "0.24.2", "@esbuild/linux-arm64": "0.24.2", "@esbuild/linux-ia32": "0.24.2", "@esbuild/linux-loong64": "0.24.2", "@esbuild/linux-mips64el": "0.24.2", "@esbuild/linux-ppc64": "0.24.2", "@esbuild/linux-riscv64": "0.24.2", "@esbuild/linux-s390x": "0.24.2", "@esbuild/linux-x64": "0.24.2", "@esbuild/netbsd-arm64": "0.24.2", "@esbuild/netbsd-x64": "0.24.2", "@esbuild/openbsd-arm64": "0.24.2", "@esbuild/openbsd-x64": "0.24.2", "@esbuild/sunos-x64": "0.24.2", "@esbuild/win32-arm64": "0.24.2", "@esbuild/win32-ia32": "0.24.2", "@esbuild/win32-x64": "0.24.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA=="],
 
@@ -1858,6 +1877,8 @@
     "ora/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -88,11 +88,10 @@
       "version": "0.1.0",
       "dependencies": {
         "highlight.js": "^11.11.1",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "react-markdown": "^9.0.0",
         "rehype-highlight": "^7.0.2",
-        "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.0",
       },
       "devDependencies": {
@@ -946,23 +945,13 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
-
     "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
 
-    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
-
-    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
-
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
-
-    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
 
     "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
-
-    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
@@ -971,8 +960,6 @@
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
-
-    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
@@ -1326,8 +1313,6 @@
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
-    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
@@ -1396,7 +1381,7 @@
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
-    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
@@ -1415,8 +1400,6 @@
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "rehype-highlight": ["rehype-highlight@7.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-text": "^4.0.0", "lowlight": "^3.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA=="],
-
-    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
@@ -1660,8 +1643,6 @@
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
-    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
-
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
@@ -1671,8 +1652,6 @@
     "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
-
-    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
@@ -1877,8 +1856,6 @@
     "ora/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
-
-    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -346,7 +346,12 @@ export async function prepareCollection(
   // and any source-directory .folder.yml files, e.g. from an Obsidian vault).
   const collectionHide = col.hide ?? [];
   const credentialsObj = typeof col.credentials === "object" && col.credentials !== null ? col.credentials as Record<string, unknown> : {};
-  const sourceConfigs = themeEngine.getSourceFolderConfigs(crawlerType, col.config ?? {}, credentialsObj);
+  let sourceConfigs: Record<string, FolderConfig> = {};
+  if (crawlerType === "obsidian") {
+    const { readVaultFolderConfigs } = await import("@frozenink/crawlers/obsidian/vault-folder-configs");
+    const vaultPath = (credentialsObj.vaultPath ?? (col.config as Record<string, unknown> | null)?.vaultPath) as string | undefined;
+    if (vaultPath) sourceConfigs = readVaultFolderConfigs(vaultPath);
+  }
   const ymlUpdated = await writeFolderConfigFiles(themeEngine, crawlerType, storage, basePath, collectionHide, sourceConfigs);
   if (ymlUpdated) log(`  Folder config files updated`);
 

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -90,6 +90,7 @@ async function writeFolderConfigFiles(
   storage: LocalStorageBackend,
   basePath: string,
   collectionHide: string[] = [],
+  sourceConfigs: Record<string, FolderConfig> = {},
 ): Promise<boolean> {
   const configs = themeEngine.getFolderConfigs(crawlerType);
   let wrote = false;
@@ -116,13 +117,33 @@ async function writeFolderConfigFiles(
     }
   }
 
-  // Write root content.yml merging theme rootConfig with collection-level hide patterns
+  // Write source-derived subdirectory configs (e.g. from vault .folder.yml files).
+  // Keys are content-relative paths; "" is handled below as root.
+  for (const [relPath, srcConfig] of Object.entries(sourceConfigs)) {
+    if (relPath === "") continue; // root handled below
+    const folderName = relPath.split("/").pop()!;
+    const ymlPath = `${basePath}/${relPath}/${folderName}.yml`;
+    const ymlContent = serializeFolderConfig(srcConfig);
+    try {
+      const existing = await storage.read(ymlPath);
+      if (existing === ymlContent) continue;
+    } catch { /* file doesn't exist yet */ }
+    await storage.write(ymlPath, ymlContent);
+    wrote = true;
+  }
+
+  // Write root content.yml merging theme rootConfig, source root config, and collection-level hide patterns.
   const themeRootConfig = themeEngine.getRootConfig(crawlerType);
+  const sourceRootConfig = sourceConfigs[""] ?? {};
   const mergedHide = [
     ...(themeRootConfig.hide ?? []),
     ...collectionHide.filter((p) => !(themeRootConfig.hide ?? []).includes(p)),
   ];
-  const rootConfig = { ...themeRootConfig, ...(mergedHide.length > 0 ? { hide: mergedHide } : {}) };
+  const rootConfig = {
+    ...themeRootConfig,
+    ...sourceRootConfig,
+    ...(mergedHide.length > 0 ? { hide: mergedHide } : {}),
+  };
   const hasRootConfig = Object.keys(rootConfig).length > 0;
   if (hasRootConfig) {
     const rootYmlContent = serializeFolderConfig(rootConfig);
@@ -321,9 +342,12 @@ export async function prepareCollection(
     meta.close();
   }
 
-  // Step 1: Write folder yml files and root content.yml (incorporating collection-level hide)
+  // Step 1: Write folder yml files and root content.yml (incorporating collection-level hide
+  // and any source-directory .folder.yml files, e.g. from an Obsidian vault).
   const collectionHide = col.hide ?? [];
-  const ymlUpdated = await writeFolderConfigFiles(themeEngine, crawlerType, storage, basePath, collectionHide);
+  const credentialsObj = typeof col.credentials === "object" && col.credentials !== null ? col.credentials as Record<string, unknown> : {};
+  const sourceConfigs = themeEngine.getSourceFolderConfigs(crawlerType, col.config ?? {}, credentialsObj);
+  const ymlUpdated = await writeFolderConfigFiles(themeEngine, crawlerType, storage, basePath, collectionHide, sourceConfigs);
   if (ymlUpdated) log(`  Folder config files updated`);
 
   // Step 1b: Always write AGENTS.md and CLAUDE.md (at collection root, outside content/)

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -23,6 +23,7 @@ import {
 } from "@frozenink/core";
 import { getPublishCredentialKey } from "./publish-credentials";
 import type { EntityData } from "@frozenink/core";
+import type { FolderConfig } from "@frozenink/core/theme";
 
 const __moduleDir = getModuleDir(import.meta.url);
 import { assertInitialPublishConfirmation } from "./publish-policy";
@@ -56,6 +57,56 @@ function collectFiles(dir: string, base: string = ""): Array<{ relativePath: str
     }
   }
   return files;
+}
+
+/** Walk `content/` and collect every folder yml (content.yml at root, and
+ * `{folder}/{folder}.yml` inside each subdir) into a map keyed by the
+ * content-relative folder path ("" for root). */
+function collectFolderYmls(
+  dir: string,
+  relPath: string,
+  out: Record<string, FolderConfig>,
+): void {
+  // Root uses "content.yml"; subdirs use "{folderName}.yml"
+  const folderName = relPath ? relPath.split("/").pop()! : "";
+  const ymlPath = relPath
+    ? join(dir, `${folderName}.yml`)
+    : join(dir, "content.yml");
+  if (existsSync(ymlPath)) {
+    const cfg = parseFolderYml(ymlPath);
+    if (Object.keys(cfg).length > 0) out[relPath] = cfg;
+  }
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith(".")) continue;
+    const childRel = relPath ? `${relPath}/${entry.name}` : entry.name;
+    collectFolderYmls(join(dir, entry.name), childRel, out);
+  }
+}
+
+function parseFolderYml(ymlPath: string): FolderConfig {
+  const cfg: FolderConfig = {};
+  try {
+    for (const line of readFileSync(ymlPath, "utf-8").split("\n")) {
+      const m = line.match(/^(\w+):\s*(.+)$/);
+      if (!m) continue;
+      const [, key, val] = m;
+      const v = val.trim();
+      if (key === "sort") cfg.sort = v === "DESC" ? "DESC" : "ASC";
+      else if (key === "visible") cfg.visible = v !== "false";
+      else if (key === "showCount") cfg.showCount = v === "true";
+      else if (key === "expanded") cfg.expanded = v !== "false";
+      else if (key === "hide") {
+        const arr = v.match(/^\[(.+)\]$/);
+        if (arr) {
+          cfg.hide = arr[1].split(",").map((s) => s.trim().replace(/^["']|["']$/g, "")).filter(Boolean);
+        }
+      }
+    }
+  } catch { /* best effort */ }
+  return cfg;
 }
 
 const MIME_TYPES: Record<string, string> = {
@@ -424,13 +475,16 @@ export async function publishCollections(
       });
     }
   } else {
-    // Fetch existing R2 objects once — used for both upload skipping and stale cleanup
-    const existingR2Objects = new Map<string, number>();
+    // Fetch existing R2 objects once — used for both upload skipping and stale cleanup.
+    // We track both size and etag (MD5): size alone can't detect content changes when
+    // length is coincidentally identical (e.g. an index.html whose asset hash string
+    // changes but stays the same byte length).
+    const existingR2Objects = new Map<string, { size: number; etag: string }>();
     if (isUpdate) {
       try {
         onProgress("r2-list", "Listing existing R2 objects...");
         const remoteObjects = await listR2Objects(r2BucketName);
-        for (const obj of remoteObjects) existingR2Objects.set(obj.key, obj.size);
+        for (const obj of remoteObjects) existingR2Objects.set(obj.key, { size: obj.size, etag: obj.etag });
       } catch {
         // Treat as empty on error; all files will be uploaded
       }
@@ -442,6 +496,15 @@ export async function publishCollections(
       for (const file of collectFiles(join(collectionDir, "content"))) {
         if (file.relativePath.endsWith(".md") || file.relativePath.endsWith(".yml")) continue;
         uploads.push({ r2Key: `${colName}/content/${file.relativePath}`, fullPath: file.fullPath });
+      }
+      // Upload the sibling attachments/ directory — the worker serves these at
+      // /api/attachments/{name}/* and the UI rewrites markdown image paths to
+      // that endpoint. Without this, embedded images 404 on the published site.
+      const attachmentsDir = join(collectionDir, "attachments");
+      if (existsSync(attachmentsDir)) {
+        for (const file of collectFiles(attachmentsDir)) {
+          uploads.push({ r2Key: `${colName}/attachments/${file.relativePath}`, fullPath: file.fullPath });
+        }
       }
     }
     if (existsSync(uiDistDir)) {
@@ -455,11 +518,14 @@ export async function publishCollections(
     for (const { r2Key, fullPath } of uploads) {
       const localSize = statSync(fullPath).size;
       fileSizes.set(r2Key, localSize);
-      if (existingR2Objects.get(r2Key) === localSize) {
-        skippedCount++;
-      } else {
-        toUpload.push({ r2Key, fullPath });
+      const existing = existingR2Objects.get(r2Key);
+      let skip = false;
+      if (existing && existing.size === localSize) {
+        const localMd5 = createHash("md5").update(readFileSync(fullPath)).digest("hex");
+        if (localMd5 === existing.etag) skip = true;
       }
+      if (skip) skippedCount++;
+      else toUpload.push({ r2Key, fullPath });
     }
     if (skippedCount > 0) {
       onProgress("r2-upload", `${skippedCount} unchanged files skipped, uploading ${toUpload.length}...`);
@@ -780,6 +846,21 @@ export async function publishCollections(
       lines.push(`crawler: ${colConfig.crawler}`);
       if (colConfig.description) lines.push(`description: ${colConfig.description}`);
       await putR2String(r2BucketName, `_config/${colName}.yml`, lines.join("\n") + "\n", "text/yaml");
+
+      // Aggregate all content/*.yml folder configs (content.yml + per-subdir yml)
+      // into a single JSON the worker can read in one R2 fetch when building the
+      // tree. Worker has no `node:fs` and we want to avoid N+1 reads per request.
+      const contentDir = join(home, "collections", colName, "content");
+      const folderConfigs: Record<string, FolderConfig> = {};
+      if (existsSync(contentDir)) {
+        collectFolderYmls(contentDir, "", folderConfigs);
+      }
+      await putR2String(
+        r2BucketName,
+        `_config/${colName}-folders.json`,
+        JSON.stringify(folderConfigs),
+        "application/json",
+      );
     }
   }
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -73,6 +73,9 @@ const MIME_TYPES: Record<string, string> = {
   ".json": "application/json",
   ".md": "text/markdown",
   ".txt": "text/plain",
+  ".log": "text/plain",
+  ".php": "text/plain",
+  ".csv": "text/plain",
   ".html": "text/html",
   ".css": "text/css",
   ".js": "application/javascript",
@@ -863,6 +866,34 @@ export function createApiServer(
 
         const content = readFileSync(fullPath);
         return new Response(content, {
+          status: 200,
+          headers: { "Content-Type": getMimeType(fullPath) },
+        });
+      }
+
+      // GET /api/collections/:name/file/*storagePath — serve a stored asset by its
+      // storagePath (relative to the collection root, e.g. content/xdebug/issues/assets/981-foo.png).
+      // Used by the HTML theme to render inline images and lazy-load text attachments.
+      const collectionFileMatch = path.match(
+        /^\/api\/collections\/([^/]+)\/file\/(.+)$/,
+      );
+      if (collectionFileMatch && req.method === "GET") {
+        const colName = decodeURIComponent(collectionFileMatch[1]);
+        const filePath = decodeURIComponent(collectionFileMatch[2]);
+        const collectionDir = join(home, "collections", colName);
+        const fullPath = join(collectionDir, filePath);
+
+        // Prevent path traversal
+        if (!join(fullPath, "/").startsWith(join(collectionDir, "/"))) {
+          return errorResponse("Forbidden", 403);
+        }
+
+        if (!existsSync(fullPath)) {
+          return errorResponse("File not found", 404);
+        }
+
+        const fileContent = readFileSync(fullPath);
+        return new Response(fileContent, {
           status: 200,
           headers: { "Content-Type": getMimeType(fullPath) },
         });

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -240,6 +240,7 @@ function buildFileTree(
   basePath: string = "",
   themeConfigs: Record<string, FolderConfig> = {},
   themeRootConfig: FolderConfig = {},
+  labelFilesWithTitle: boolean = true,
 ): object[] {
   if (!existsSync(dirPath)) return [];
 
@@ -268,7 +269,7 @@ function buildFileTree(
       const childYmlCfg = readFolderConfig(childDirPath);
       const childMerged: FolderConfig = { ...childThemeCfg, ...childYmlCfg };
       if (childMerged.visible === false) continue;
-      const children = buildFileTree(childDirPath, titleByPath, relativePath, themeConfigs, themeRootConfig);
+      const children = buildFileTree(childDirPath, titleByPath, relativePath, themeConfigs, themeRootConfig, labelFilesWithTitle);
       // Hide directories with no (visible) files in their subtree so stale
       // empty folders on disk don't leak into the tree.
       if (countFiles(children) === 0) continue;
@@ -295,9 +296,9 @@ function buildFileTree(
       };
       if (merged.created_at_prefix) {
         const datePrefix = entry.name.slice(0, 8);
-        const stored = titleByPath.get(relativePath);
+        const stored = labelFilesWithTitle ? titleByPath.get(relativePath) : undefined;
         node.title = stored ? `${datePrefix} ${stored}` : entry.name.replace(/\.md$/, "");
-      } else {
+      } else if (labelFilesWithTitle) {
         const title = titleByPath.get(relativePath);
         if (title) node.title = title;
       }
@@ -430,7 +431,8 @@ export function createApiServer(
         const crawlerType = effectiveCrawlerType(col, dbPath);
         const themeConfigs = themeEngine.getFolderConfigs(crawlerType);
         const themeRootConfig = themeEngine.getRootConfig(crawlerType);
-        const tree = buildFileTree(contentDir, titleByPath, "", themeConfigs, themeRootConfig);
+        const labelWithTitle = themeEngine.labelFilesWithTitle(crawlerType);
+        const tree = buildFileTree(contentDir, titleByPath, "", themeConfigs, themeRootConfig, labelWithTitle);
         return jsonResponse(tree);
       }
 

--- a/packages/cli/src/commands/wrangler-api.ts
+++ b/packages/cli/src/commands/wrangler-api.ts
@@ -382,8 +382,8 @@ export async function deleteR2Bucket(name: string): Promise<void> {
   await runWrangler(["r2", "bucket", "delete", name], { allowFailure: true });
 }
 
-export async function listR2Objects(bucket: string, prefix?: string): Promise<Array<{ key: string; size: number }>> {
-  const objects: Array<{ key: string; size: number }> = [];
+export async function listR2Objects(bucket: string, prefix?: string): Promise<Array<{ key: string; size: number; etag: string }>> {
+  const objects: Array<{ key: string; size: number; etag: string }> = [];
   let cursor: string | undefined;
   for (;;) {
     const pageCursor = cursor;
@@ -400,8 +400,8 @@ export async function listR2Objects(bucket: string, prefix?: string): Promise<Ar
       };
     });
     if (!res.ok) break;
-    const data = await res.json() as { result: Array<{ key: string; size: number }>; result_info?: { cursor?: string } };
-    for (const obj of data.result ?? []) objects.push({ key: obj.key, size: obj.size ?? 0 });
+    const data = await res.json() as { result: Array<{ key: string; size: number; etag?: string }>; result_info?: { cursor?: string } };
+    for (const obj of data.result ?? []) objects.push({ key: obj.key, size: obj.size ?? 0, etag: (obj.etag ?? "").replace(/"/g, "") });
     cursor = data.result_info?.cursor;
     if (!cursor || (data.result ?? []).length === 0) break;
   }

--- a/packages/core/src/crawler/sync-engine.ts
+++ b/packages/core/src/crawler/sync-engine.ts
@@ -566,6 +566,7 @@ export class SyncEngine {
 
   /** Check if a filename has an allowed image extension. */
   private isAllowedAsset(filename: string): boolean {
+    if (this.allowedExtensions.size === 0) return true;
     const dot = filename.lastIndexOf(".");
     if (dot === -1) return false;
     return this.allowedExtensions.has(filename.slice(dot).toLowerCase());

--- a/packages/core/src/crawler/sync-engine.ts
+++ b/packages/core/src/crawler/sync-engine.ts
@@ -73,9 +73,8 @@ export function extractWikilinks(markdown: string, sourceFilePath?: string): str
 }
 
 /** Default file extensions allowed for asset downloads. */
-const DEFAULT_ASSET_EXTENSIONS = [
-  ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".ico", ".avif", ".pdf",
-];
+/** Empty = no extension filter (all file types allowed). */
+const DEFAULT_ASSET_EXTENSIONS: string[] = [];
 
 /** Default max asset size: 10 MB in KB. */
 const DEFAULT_ASSET_MAX_SIZE_KB = 10240;

--- a/packages/core/src/theme/engine.ts
+++ b/packages/core/src/theme/engine.ts
@@ -49,6 +49,12 @@ export class ThemeEngine {
     return theme?.folderConfigs?.() ?? {};
   }
 
+  /** Return whether entity titles should label file tree nodes for the given crawler type. */
+  labelFilesWithTitle(crawlerType: string): boolean {
+    const theme = this.themes.get(crawlerType);
+    return theme?.labelFilesWithTitle?.() ?? true;
+  }
+
   /** Return the root config for the given crawler type, or empty object if none defined. */
   getRootConfig(crawlerType: string): FolderConfig {
     const theme = this.themes.get(crawlerType);

--- a/packages/core/src/theme/engine.ts
+++ b/packages/core/src/theme/engine.ts
@@ -49,6 +49,16 @@ export class ThemeEngine {
     return theme?.folderConfigs?.() ?? {};
   }
 
+  /** Read folder configs from the source vault/directory (theme-specific). */
+  getSourceFolderConfigs(
+    crawlerType: string,
+    config: Record<string, unknown>,
+    credentials: Record<string, unknown>,
+  ): Record<string, FolderConfig> {
+    const theme = this.themes.get(crawlerType);
+    return theme?.getSourceFolderConfigs?.(config, credentials) ?? {};
+  }
+
   /** Return whether entity titles should label file tree nodes for the given crawler type. */
   labelFilesWithTitle(crawlerType: string): boolean {
     const theme = this.themes.get(crawlerType);

--- a/packages/core/src/theme/engine.ts
+++ b/packages/core/src/theme/engine.ts
@@ -49,16 +49,6 @@ export class ThemeEngine {
     return theme?.folderConfigs?.() ?? {};
   }
 
-  /** Read folder configs from the source vault/directory (theme-specific). */
-  getSourceFolderConfigs(
-    crawlerType: string,
-    config: Record<string, unknown>,
-    credentials: Record<string, unknown>,
-  ): Record<string, FolderConfig> {
-    const theme = this.themes.get(crawlerType);
-    return theme?.getSourceFolderConfigs?.(config, credentials) ?? {};
-  }
-
   /** Return whether entity titles should label file tree nodes for the given crawler type. */
   labelFilesWithTitle(crawlerType: string): boolean {
     const theme = this.themes.get(crawlerType);

--- a/packages/core/src/theme/interface.ts
+++ b/packages/core/src/theme/interface.ts
@@ -89,6 +89,17 @@ export interface Theme {
    */
   rootConfig?(): FolderConfig;
   /**
+   * Optional: read folder configs from the source vault/directory at prepare time.
+   * Called with the collection's config and credentials so the theme can locate
+   * the source directory. Returns a map of content-relative directory paths to
+   * FolderConfig; use "" (empty string) for the content root.
+   * These configs are merged on top of the static rootConfig()/folderConfigs() values.
+   */
+  getSourceFolderConfigs?(
+    config: Record<string, unknown>,
+    credentials: Record<string, unknown>,
+  ): Record<string, FolderConfig>;
+  /**
    * Optional: whether to use the entity title as the display label in the
    * file tree. Defaults to true. Set to false for crawlers where the filename
    * is the primary identifier (e.g. Obsidian vaults) so the sidebar always

--- a/packages/core/src/theme/interface.ts
+++ b/packages/core/src/theme/interface.ts
@@ -89,6 +89,13 @@ export interface Theme {
    */
   rootConfig?(): FolderConfig;
   /**
+   * Optional: whether to use the entity title as the display label in the
+   * file tree. Defaults to true. Set to false for crawlers where the filename
+   * is the primary identifier (e.g. Obsidian vaults) so the sidebar always
+   * shows the filename rather than the H1 heading.
+   */
+  labelFilesWithTitle?(): boolean;
+  /**
    * Optional: generate the body of AGENTS.md for this collection.
    * Called during prepare to create/update the AI guidance file.
    */

--- a/packages/core/src/theme/interface.ts
+++ b/packages/core/src/theme/interface.ts
@@ -89,17 +89,6 @@ export interface Theme {
    */
   rootConfig?(): FolderConfig;
   /**
-   * Optional: read folder configs from the source vault/directory at prepare time.
-   * Called with the collection's config and credentials so the theme can locate
-   * the source directory. Returns a map of content-relative directory paths to
-   * FolderConfig; use "" (empty string) for the content root.
-   * These configs are merged on top of the static rootConfig()/folderConfigs() values.
-   */
-  getSourceFolderConfigs?(
-    config: Record<string, unknown>,
-    credentials: Record<string, unknown>,
-  ): Record<string, FolderConfig>;
-  /**
    * Optional: whether to use the entity title as the display label in the
    * file tree. Defaults to true. Set to false for crawlers where the filename
    * is the primary identifier (e.g. Obsidian vaults) so the sidebar always

--- a/packages/crawlers/package.json
+++ b/packages/crawlers/package.json
@@ -7,7 +7,8 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./themes": "./src/themes.ts"
+    "./themes": "./src/themes.ts",
+    "./obsidian/vault-folder-configs": "./src/obsidian/vault-folder-configs.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/crawlers/src/mantishub/crawler.ts
+++ b/packages/crawlers/src/mantishub/crawler.ts
@@ -144,9 +144,12 @@ export class MantisHubCrawler implements Crawler {
   /** Returns true if the attachment should be downloaded based on extension and size. */
   private shouldDownloadAttachment(filename: string, sizeBytes: number): boolean {
     if (!this.assetFilter) return true;
+    if (sizeBytes > this.assetFilter.maxSizeBytes) return false;
+    // Empty extension set means no filter — allow all types.
+    if (this.assetFilter.allowedExtensions.size === 0) return true;
     const dot = filename.lastIndexOf(".");
     const ext = dot === -1 ? "" : filename.slice(dot).toLowerCase();
-    return this.assetFilter.allowedExtensions.has(ext) && sizeBytes <= this.assetFilter.maxSizeBytes;
+    return this.assetFilter.allowedExtensions.has(ext);
   }
 
   /** Accept both new field names and legacy field names for backward compat. */
@@ -517,14 +520,31 @@ export class MantisHubCrawler implements Crawler {
         this.reportProgress(`Fetching ${users.length} user profile(s)`);
       }
       let i = 0;
+      let consecutiveForbidden = 0;
+      let allForbidden = false;
       for (const basic of users) {
         i++;
+        if (allForbidden) {
+          // Server denied access to all users — emit shell entities for remaining.
+          entities.push(this.buildUserEntity({ id: basic.id, name: basic.name, email: basic.email }));
+          continue;
+        }
         this.reportProgress(`Fetching user ${basic.name} (${i}/${users.length})`);
         try {
           const profile = await this.fetchUser(basic.id);
           entities.push(this.buildUserEntity(profile));
+          consecutiveForbidden = 0;
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
+          if (message.includes("→ 403")) {
+            consecutiveForbidden++;
+            if (consecutiveForbidden >= 10) {
+              console.warn(`  Warning: 10 consecutive 403s fetching users — assuming all user profiles are forbidden. Creating shell entries for remaining ${users.length - i} user(s).`);
+              allForbidden = true;
+            }
+          } else {
+            consecutiveForbidden = 0;
+          }
           console.warn(`  Warning: entity type=user id=${basic.id} name=${basic.name}: ${message}`);
           // Build a minimal user entity from data collected during issue sync.
           entities.push(this.buildUserEntity({
@@ -602,7 +622,35 @@ export class MantisHubCrawler implements Crawler {
       headers["Authorization"] = this.token;
     }
 
-    const response = await this.fetchFn(url, { headers });
+    const MAX_RETRIES = 3;
+    let lastNetworkErr: unknown;
+    let response: Response | undefined;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await new Promise((r) => setTimeout(r, Math.min(1000 * 2 ** (attempt - 1), 8000)));
+      }
+      try {
+        response = await this.fetchFn(url, { headers });
+      } catch (err) {
+        lastNetworkErr = err;
+        continue;
+      }
+      // Retry transient server errors, but not auth/client errors
+      if (response.status >= 500 && response.status < 600 && attempt < MAX_RETRIES) {
+        try { await response.body?.cancel(); } catch { /* ignore */ }
+        lastNetworkErr = new Error(`HTTP ${response.status}`);
+        response = undefined;
+        continue;
+      }
+      break;
+    }
+
+    if (!response) {
+      const message = lastNetworkErr instanceof Error ? lastNetworkErr.message : String(lastNetworkErr);
+      throw new Error(`MantisHub API error: GET ${url} → network failure after ${MAX_RETRIES} retries: ${message}`);
+    }
+
     if (!response.ok) {
       let bodySnippet = "";
       try {
@@ -1146,7 +1194,11 @@ export class MantisHubCrawler implements Crawler {
           content = await this.downloadAttachment(issue.id, file.id, file.download_url, label);
         }
       } else {
-        content = await this.downloadAttachment(issue.id, file.id, file.download_url, label);
+        // Plain MantisBT: use download_url if provided, otherwise construct the
+        // standard file_download.php URL (works on public trackers without auth).
+        const effectiveUrl = file.download_url
+          ?? `${this.baseUrl}/file_download.php?file_id=${file.id}&type=bug`;
+        content = await this.downloadAttachment(issue.id, file.id, effectiveUrl, label);
       }
 
       if (content) {
@@ -1181,7 +1233,11 @@ export class MantisHubCrawler implements Crawler {
             content = await this.downloadAttachment(issue.id, att.id, att.download_url, label);
           }
         } else {
-          content = await this.downloadAttachment(issue.id, att.id, att.download_url, label);
+          // Plain MantisBT: use download_url if provided, otherwise construct the
+          // standard file_download.php URL (works on public trackers without auth).
+          const effectiveUrl = att.download_url
+            ?? `${this.baseUrl}/file_download.php?file_id=${att.id}&type=bugnote`;
+          content = await this.downloadAttachment(issue.id, att.id, effectiveUrl, label);
         }
 
         if (content) {
@@ -1223,6 +1279,7 @@ export class MantisHubCrawler implements Crawler {
         attachments: (issue.attachments ?? []).map((f) => {
           const sp = `${assetPrefix}/${assetFilename(f.id, f.filename)}`;
           return {
+            id: f.id,
             filename: f.filename,
             content_type: f.content_type,
             size: f.size,

--- a/packages/crawlers/src/mantishub/theme.ts
+++ b/packages/crawlers/src/mantishub/theme.ts
@@ -24,6 +24,38 @@ function assetRef(storagePath: string | undefined): string {
   return `assets/${filename}`;
 }
 
+const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"]);
+
+function isImageFile(filename: string): boolean {
+  const dot = filename.lastIndexOf(".");
+  return dot !== -1 && IMAGE_EXTS.has(filename.slice(dot).toLowerCase());
+}
+
+/**
+ * Render a single attachment in HTML.
+ * Images: inline <img>. Text files: lazy-loading <details> block matching MantisBT UI.
+ * If not downloaded locally, shows a link to download directly from the source.
+ */
+function renderAttachmentHtml(
+  att: { filename: string; storagePath?: string; size: number },
+  collectionName: string,
+  fallbackUrl?: string,
+): string {
+  const sizeKb = Math.round(att.size / 1024) || "<1";
+  if (!att.storagePath) {
+    const link = fallbackUrl
+      ? ` <a class="mt-attachment-download-link" href="${esc(fallbackUrl)}" target="_blank" rel="noopener noreferrer">↓ download</a>`
+      : "";
+    return `<div class="mt-attachment-item mt-attachment-unavailable">${esc(att.filename)} <span class="mt-attachment-size">(${sizeKb} KB — not downloaded${link})</span></div>`;
+  }
+  const fileUrl = `/api/collections/${encodeURIComponent(collectionName)}/file/${att.storagePath.split("/").map(encodeURIComponent).join("/")}`;
+  if (isImageFile(att.filename)) {
+    return `<div class="mt-attachment-item mt-attachment-image-wrap"><img src="${fileUrl}" alt="${esc(att.filename)}" class="mt-attachment-image" loading="lazy"></div>`;
+  }
+  // Text / binary: collapsible block with lazy content load
+  return `<details class="mt-attachment-item mt-attachment-text" data-url="${fileUrl}"><summary>${esc(att.filename)} <span class="mt-attachment-size">(${sizeKb} KB)</span></summary><pre class="mt-attachment-content">Loading…</pre></details>`;
+}
+
 /** Returns the wikilink path (no extension) for an issue by id and summary. */
 function issueFilePath(id: number, summary: string, projectName?: string): string {
   const slug = slugify(summary);
@@ -473,7 +505,7 @@ export class MantisHubTheme implements Theme {
     return {
       issues: { sort: "DESC" as const, showCount: true },
       pages: { showCount: true },
-      users: { showCount: true },
+      users: { showCount: true, expanded: false },
       assets: { visible: false },
     };
   }
@@ -632,13 +664,14 @@ export class MantisHubTheme implements Theme {
     }
 
     // Issue-level attachments
-    const files = d.attachments as Array<{ filename: string; storagePath?: string; size: number }> | undefined;
+    const issueBaseUrl = context.entity.url ? new URL(context.entity.url).origin : "";
+    const files = d.attachments as Array<{ id?: number; filename: string; storagePath?: string; size: number }> | undefined;
     if (files?.length) {
       parts.push(`<h3 class="mt-subsection-title">Attachments</h3>`);
       parts.push(`<div class="mt-attachments">`);
       for (const f of files) {
-        const sizeKb = Math.round(f.size / 1024);
-        parts.push(`<div class="mt-attachment-item">${esc(f.filename)} <span class="mt-attachment-size">(${sizeKb} KB)</span></div>`);
+        const fallback = (issueBaseUrl && f.id) ? `${issueBaseUrl}/file_download.php?file_id=${f.id}&type=bug` : undefined;
+        parts.push(renderAttachmentHtml(f, context.collectionName, fallback));
       }
       parts.push(`</div>`);
     }
@@ -675,7 +708,7 @@ export class MantisHubTheme implements Theme {
       text: string;
       view_state?: { name: string };
       created_at: string;
-      attachments?: Array<{ filename: string; storagePath?: string; size: number }>;
+      attachments?: Array<{ id?: number; filename: string; storagePath?: string; size: number }>;
     }> | undefined;
 
     const history = (d.history ?? []) as Array<{
@@ -731,8 +764,8 @@ export class MantisHubTheme implements Theme {
           if (note.attachments?.length) {
             parts.push(`<div class="mt-note-attachments">`);
             for (const att of note.attachments) {
-              const sizeKb = Math.round(att.size / 1024);
-              parts.push(`<div class="mt-attachment-item">${esc(att.filename)} <span class="mt-attachment-size">(${sizeKb} KB)</span></div>`);
+              const fallback = (issueBaseUrl && att.id) ? `${issueBaseUrl}/file_download.php?file_id=${att.id}&type=bugnote` : undefined;
+              parts.push(renderAttachmentHtml(att, context.collectionName, fallback));
             }
             parts.push(`</div>`);
           }

--- a/packages/crawlers/src/obsidian/crawler.ts
+++ b/packages/crawlers/src/obsidian/crawler.ts
@@ -226,7 +226,9 @@ export class ObsidianCrawler implements Crawler {
     const imageRefMap: Record<string, string> = {};
 
     for (const ref of imageRefs) {
-      const attFile = attachmentLookup.get(ref);
+      // Try exact ref, then basename — handles paths like ../attachments/assets/img.png
+      // that embed the output layout rather than the vault-relative path.
+      const attFile = attachmentLookup.get(ref) ?? attachmentLookup.get(basename(ref));
       if (!attFile) continue;
       imageRefMap[ref] = attFile.relativePath;
       if (seenPaths.has(attFile.relativePath)) continue;

--- a/packages/crawlers/src/obsidian/theme.ts
+++ b/packages/crawlers/src/obsidian/theme.ts
@@ -1,4 +1,6 @@
-import type { Theme, ThemeRenderContext } from "@frozenink/core/theme";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { FolderConfig, Theme, ThemeRenderContext } from "@frozenink/core/theme";
 import { wikilink, embed, basename } from "@frozenink/core/theme";
 
 export class ObsidianTheme implements Theme {
@@ -50,6 +52,59 @@ export class ObsidianTheme implements Theme {
 
   labelFilesWithTitle() {
     return false;
+  }
+
+  getSourceFolderConfigs(
+    config: Record<string, unknown>,
+    credentials: Record<string, unknown>,
+  ): Record<string, FolderConfig> {
+    const vaultPath = (credentials.vaultPath ?? config.vaultPath) as string | undefined;
+    if (!vaultPath || !existsSync(vaultPath)) return {};
+    return this.readVaultFolderConfigs(vaultPath, vaultPath, "");
+  }
+
+  private readVaultFolderConfigs(
+    vaultPath: string,
+    dirPath: string,
+    relPath: string,
+  ): Record<string, FolderConfig> {
+    const result: Record<string, FolderConfig> = {};
+
+    const dotyml = join(dirPath, ".folder.yml");
+    if (existsSync(dotyml)) {
+      const cfg = this.parseFolderYml(dotyml);
+      if (Object.keys(cfg).length > 0) result[relPath] = cfg;
+    }
+
+    let entries;
+    try { entries = readdirSync(dirPath, { withFileTypes: true }); } catch { return result; }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(".")) continue;
+      const childRel = relPath ? `${relPath}/${entry.name}` : entry.name;
+      const childAbs = join(dirPath, entry.name);
+      Object.assign(result, this.readVaultFolderConfigs(vaultPath, childAbs, childRel));
+    }
+
+    return result;
+  }
+
+  private parseFolderYml(ymlPath: string): FolderConfig {
+    try {
+      const cfg: FolderConfig = {};
+      for (const line of readFileSync(ymlPath, "utf-8").split("\n")) {
+        const m = line.match(/^(\w+):\s*(.+)$/);
+        if (!m) continue;
+        const [, key, val] = m;
+        if (key === "sort") cfg.sort = val.trim() === "DESC" ? "DESC" : "ASC";
+        if (key === "visible") cfg.visible = val.trim() !== "false";
+        if (key === "showCount") cfg.showCount = val.trim() === "true";
+        if (key === "expanded") cfg.expanded = val.trim() !== "false";
+      }
+      return cfg;
+    } catch {
+      return {};
+    }
   }
 
   folderConfigs() {

--- a/packages/crawlers/src/obsidian/theme.ts
+++ b/packages/crawlers/src/obsidian/theme.ts
@@ -1,6 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-import type { FolderConfig, Theme, ThemeRenderContext } from "@frozenink/core/theme";
+import type { Theme, ThemeRenderContext } from "@frozenink/core/theme";
 import { wikilink, embed, basename } from "@frozenink/core/theme";
 
 export class ObsidianTheme implements Theme {
@@ -52,59 +50,6 @@ export class ObsidianTheme implements Theme {
 
   labelFilesWithTitle() {
     return false;
-  }
-
-  getSourceFolderConfigs(
-    config: Record<string, unknown>,
-    credentials: Record<string, unknown>,
-  ): Record<string, FolderConfig> {
-    const vaultPath = (credentials.vaultPath ?? config.vaultPath) as string | undefined;
-    if (!vaultPath || !existsSync(vaultPath)) return {};
-    return this.readVaultFolderConfigs(vaultPath, vaultPath, "");
-  }
-
-  private readVaultFolderConfigs(
-    vaultPath: string,
-    dirPath: string,
-    relPath: string,
-  ): Record<string, FolderConfig> {
-    const result: Record<string, FolderConfig> = {};
-
-    const dotyml = join(dirPath, ".folder.yml");
-    if (existsSync(dotyml)) {
-      const cfg = this.parseFolderYml(dotyml);
-      if (Object.keys(cfg).length > 0) result[relPath] = cfg;
-    }
-
-    let entries;
-    try { entries = readdirSync(dirPath, { withFileTypes: true }); } catch { return result; }
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      if (entry.name.startsWith(".")) continue;
-      const childRel = relPath ? `${relPath}/${entry.name}` : entry.name;
-      const childAbs = join(dirPath, entry.name);
-      Object.assign(result, this.readVaultFolderConfigs(vaultPath, childAbs, childRel));
-    }
-
-    return result;
-  }
-
-  private parseFolderYml(ymlPath: string): FolderConfig {
-    try {
-      const cfg: FolderConfig = {};
-      for (const line of readFileSync(ymlPath, "utf-8").split("\n")) {
-        const m = line.match(/^(\w+):\s*(.+)$/);
-        if (!m) continue;
-        const [, key, val] = m;
-        if (key === "sort") cfg.sort = val.trim() === "DESC" ? "DESC" : "ASC";
-        if (key === "visible") cfg.visible = val.trim() !== "false";
-        if (key === "showCount") cfg.showCount = val.trim() === "true";
-        if (key === "expanded") cfg.expanded = val.trim() !== "false";
-      }
-      return cfg;
-    } catch {
-      return {};
-    }
   }
 
   folderConfigs() {

--- a/packages/crawlers/src/obsidian/theme.ts
+++ b/packages/crawlers/src/obsidian/theme.ts
@@ -48,6 +48,10 @@ export class ObsidianTheme implements Theme {
     return result;
   }
 
+  labelFilesWithTitle() {
+    return false;
+  }
+
   folderConfigs() {
     return {
       assets: { visible: false },

--- a/packages/crawlers/src/obsidian/vault-folder-configs.ts
+++ b/packages/crawlers/src/obsidian/vault-folder-configs.ts
@@ -1,0 +1,56 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { FolderConfig } from "@frozenink/core/theme";
+
+// Reads `.folder.yml` files from an Obsidian vault directory tree and returns
+// them keyed by vault-relative folder path (root = "").
+//
+// Lives outside ObsidianTheme because ObsidianTheme is bundled into the
+// Cloudflare Worker, which has no `node:fs`. This helper is only imported by
+// publish/prepare in the CLI (Node/Bun).
+export function readVaultFolderConfigs(
+  vaultPath: string,
+): Record<string, FolderConfig> {
+  if (!existsSync(vaultPath)) return {};
+  return readDir(vaultPath, "");
+}
+
+function readDir(dirPath: string, relPath: string): Record<string, FolderConfig> {
+  const result: Record<string, FolderConfig> = {};
+
+  const dotyml = join(dirPath, ".folder.yml");
+  if (existsSync(dotyml)) {
+    const cfg = parseFolderYml(dotyml);
+    if (Object.keys(cfg).length > 0) result[relPath] = cfg;
+  }
+
+  let entries;
+  try { entries = readdirSync(dirPath, { withFileTypes: true }); } catch { return result; }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith(".")) continue;
+    const childRel = relPath ? `${relPath}/${entry.name}` : entry.name;
+    const childAbs = join(dirPath, entry.name);
+    Object.assign(result, readDir(childAbs, childRel));
+  }
+
+  return result;
+}
+
+function parseFolderYml(ymlPath: string): FolderConfig {
+  try {
+    const cfg: FolderConfig = {};
+    for (const line of readFileSync(ymlPath, "utf-8").split("\n")) {
+      const m = line.match(/^(\w+):\s*(.+)$/);
+      if (!m) continue;
+      const [, key, val] = m;
+      if (key === "sort") cfg.sort = val.trim() === "DESC" ? "DESC" : "ASC";
+      if (key === "visible") cfg.visible = val.trim() !== "false";
+      if (key === "showCount") cfg.showCount = val.trim() === "true";
+      if (key === "expanded") cfg.expanded = val.trim() !== "false";
+    }
+    return cfg;
+  } catch {
+    return {};
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^19.0.0",
     "react-markdown": "^9.0.0",
     "rehype-highlight": "^7.0.2",
+    "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,11 +12,10 @@
   },
   "dependencies": {
     "highlight.js": "^11.11.1",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "react-markdown": "^9.0.0",
     "rehype-highlight": "^7.0.2",
-    "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -3118,6 +3118,19 @@ select.form-input { cursor: pointer; }
   flex-direction: column;
   gap: 10px;
 }
+.collection-section-heading {
+  font-size: 0.85em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted, #888);
+  margin: 24px 0 8px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.collection-cards-disabled .collection-card {
+  opacity: 0.65;
+}
 .collection-card {
   border: 1px solid var(--border);
   border-radius: var(--radius);

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -881,6 +881,16 @@ body {
   color: var(--accent);
 }
 
+.markdown-view .obs-tag {
+  display: inline-block;
+  background: var(--accent-muted, color-mix(in srgb, var(--accent) 15%, transparent));
+  color: var(--accent);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
 .markdown-view .wikilink-missing {
   color: var(--text-muted, var(--text-secondary));
   opacity: 0.6;

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -2214,6 +2214,60 @@ body {
   font-size: 12px;
 }
 
+.mt-attachment-image-wrap {
+  margin: 8px 0;
+}
+.mt-attachment-image {
+  max-width: 100%;
+  max-height: 480px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  display: block;
+}
+
+.mt-attachment-text > summary {
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.mt-attachment-text > summary::before {
+  content: "▶";
+  font-size: 10px;
+  transition: transform 0.15s;
+  flex-shrink: 0;
+}
+.mt-attachment-text[open] > summary::before {
+  transform: rotate(90deg);
+}
+.mt-attachment-content {
+  margin: 6px 0 0;
+  padding: 10px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
+.mt-attachment-unavailable {
+  opacity: 0.5;
+  font-style: italic;
+}
+
+.mt-attachment-download-link {
+  font-style: normal;
+  font-size: 11px;
+  opacity: 0.8;
+  margin-left: 4px;
+}
+
 /* Relationships */
 .mt-relationship {
   display: flex;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -73,8 +73,11 @@ function saveCollectionTabs(collection: string, tabs: { file: string }[], active
 }
 
 // --- Server-side preference helpers (survive port changes in desktop mode) ---
+// Only the local/desktop server has /api/preferences; the published worker
+// doesn't expose it, so we skip the calls there to avoid console 404 noise.
 
 function savePreferenceToServer(key: string, value: unknown) {
+  if (isPublishedDeployment()) return;
   fetch("/api/preferences", {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
@@ -84,6 +87,7 @@ function savePreferenceToServer(key: string, value: unknown) {
 
 /** Load all server-side preferences and hydrate localStorage + return them. */
 async function loadServerPreferences(): Promise<Record<string, unknown>> {
+  if (isPublishedDeployment()) return {};
   try {
     const res = await fetch("/api/preferences");
     if (!res.ok) return {};

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -545,7 +545,7 @@ export default function App() {
         setFileNotFound(true);
       })
       .finally(() => setLoading(false));
-  }, [viewMode, selectedCollection, selectedFile]);
+  }, [viewMode, selectedCollection, selectedFile, refreshKey]);
 
   // Fetch backlinks for the current file (only when links panel is open)
   useEffect(() => {
@@ -618,7 +618,7 @@ export default function App() {
         setHtmlContent(null);
         setHtmlLoading(false);
       });
-  }, [viewMode, htmlAvailable, selectedCollection, selectedFile]);
+  }, [viewMode, htmlAvailable, selectedCollection, selectedFile, refreshKey]);
 
   // Core navigation: open a file, optionally in a new tab.
   // Uses functional state updates throughout to avoid stale closure issues.

--- a/packages/ui/src/components/HtmlView.tsx
+++ b/packages/ui/src/components/HtmlView.tsx
@@ -31,6 +31,24 @@ export default function HtmlView({ html, onWikilinkClick }: HtmlViewProps) {
     for (const block of codeBlocks) {
       hljs.highlightElement(block as HTMLElement);
     }
+
+    // Lazy-load text attachment content when a <details> is toggled open.
+    // (Scripts injected via dangerouslySetInnerHTML don't execute, so we handle it here.)
+    const details = containerRef.current.querySelectorAll<HTMLDetailsElement>(".mt-attachment-text");
+    for (const el of details) {
+      el.addEventListener("toggle", function onToggle() {
+        if (!el.open) return;
+        const pre = el.querySelector<HTMLElement>("pre");
+        if (!pre || pre.dataset.loaded) return;
+        pre.dataset.loaded = "1";
+        const url = el.dataset.url;
+        if (!url) return;
+        fetch(url)
+          .then((r) => r.text())
+          .then((t) => { pre.textContent = t; })
+          .catch(() => { pre.textContent = "(failed to load)"; });
+      });
+    }
   }, [html]);
 
   const handleClick = useCallback(

--- a/packages/ui/src/components/MarkdownView.tsx
+++ b/packages/ui/src/components/MarkdownView.tsx
@@ -52,6 +52,19 @@ function preprocessMarkdown(raw: string, collection: string, filePath?: string):
       `![${alt}](/api/attachments/${encodeURIComponent(collection)}/${path})`,
   );
 
+  // Rewrite MantisBT-style relative asset paths: ![alt](assets/filename)
+  // The file is stored at content/{dir}/assets/{filename} relative to the collection root.
+  if (filePath) {
+    const dir = filePath.includes("/") ? filePath.slice(0, filePath.lastIndexOf("/")) : "";
+    content = content.replace(
+      /!\[([^\]]*)\]\(assets\/([^)]+)\)/g,
+      (_match, alt: string, filename: string) => {
+        const storagePath = dir ? `content/${dir}/assets/${filename}` : `content/assets/${filename}`;
+        return `![${alt}](/api/collections/${encodeURIComponent(collection)}/file/${storagePath})`;
+      },
+    );
+  }
+
   // Replace Obsidian wikilinks: [[target|label]] and [[target]]
   // (backward compatibility for Obsidian vault content)
   content = content.replace(

--- a/packages/ui/src/components/MarkdownView.tsx
+++ b/packages/ui/src/components/MarkdownView.tsx
@@ -2,6 +2,7 @@ import { useMemo, type ComponentProps } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
+import rehypeRaw from "rehype-raw";
 
 const WIKILINK_PREFIX = "#wikilink/";
 
@@ -93,6 +94,15 @@ function preprocessMarkdown(raw: string, collection: string, filePath?: string):
       }
       return `[${label}](${WIKILINK_PREFIX}${encodeURIComponent(target)})`;
     },
+  );
+
+  // Convert Obsidian inline hashtags (#Tag) to styled spans.
+  // Matches # followed by word characters (no space), not at the start of a line
+  // (which would be a heading). Skips tags inside code spans/blocks.
+  content = content.replace(
+    /(^|\s)(#[A-Za-z][A-Za-z0-9_/-]*)/g,
+    (_match, pre: string, tag: string) =>
+      `${pre}<span class="obs-tag">${tag}</span>`,
   );
 
   return content;
@@ -215,7 +225,7 @@ export default function MarkdownView({
     <article className="markdown-view">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeHighlight]}
+        rehypePlugins={[rehypeRaw, rehypeHighlight]}
         components={components}
       >
         {processed}

--- a/packages/ui/src/components/MarkdownView.tsx
+++ b/packages/ui/src/components/MarkdownView.tsx
@@ -2,7 +2,6 @@ import { useMemo, type ComponentProps } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
-import rehypeRaw from "rehype-raw";
 
 const WIKILINK_PREFIX = "#wikilink/";
 
@@ -96,13 +95,13 @@ function preprocessMarkdown(raw: string, collection: string, filePath?: string):
     },
   );
 
-  // Convert Obsidian inline hashtags (#Tag) to styled spans.
-  // Matches # followed by word characters (no space), not at the start of a line
-  // (which would be a heading). Skips tags inside code spans/blocks.
+  // Convert Obsidian inline hashtags (#Tag) to inline code so the ReactMarkdown
+  // code component can render them as styled tag badges.
+  // Matches # followed by a letter then word chars — avoids heading syntax which
+  // requires a space (# heading) and skips URLs/anchors.
   content = content.replace(
     /(^|\s)(#[A-Za-z][A-Za-z0-9_/-]*)/g,
-    (_match, pre: string, tag: string) =>
-      `${pre}<span class="obs-tag">${tag}</span>`,
+    (_match, pre: string, tag: string) => `${pre}\`${tag}\``,
   );
 
   return content;
@@ -150,6 +149,14 @@ export default function MarkdownView({
 
   const components: ComponentProps<typeof ReactMarkdown>["components"] = useMemo(
     () => ({
+      code({ className, children }) {
+        const text = typeof children === "string" ? children : "";
+        // Inline code with no language class that looks like a hashtag → tag badge
+        if (!className && /^#[A-Za-z]/.test(text) && !text.includes(" ")) {
+          return <span className="obs-tag">{text}</span>;
+        }
+        return <code className={className}>{children}</code>;
+      },
       a({ href, children }) {
         if (href?.startsWith(WIKILINK_PREFIX)) {
           const target = decodeURIComponent(href.slice(WIKILINK_PREFIX.length));
@@ -225,7 +232,7 @@ export default function MarkdownView({
     <article className="markdown-view">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw, rehypeHighlight]}
+        rehypePlugins={[rehypeHighlight]}
         components={components}
       >
         {processed}

--- a/packages/ui/src/components/MarkdownView.tsx
+++ b/packages/ui/src/components/MarkdownView.tsx
@@ -44,10 +44,11 @@ function preprocessMarkdown(raw: string, collection: string, filePath?: string):
       `![${path}](/api/attachments/${encodeURIComponent(collection)}/${path})`,
   );
 
-  // Rewrite relative attachment paths (../../attachments/...) to API URLs
+  // Rewrite relative attachment paths (../attachments/... or ../../attachments/...) to API URLs
   // so they resolve in the web viewer where files aren't on the local filesystem.
+  // Root-level vault notes produce ../attachments/...; nested notes produce ../../attachments/...
   content = content.replace(
-    /!\[([^\]]*)\]\(\.\.\/\.\.\/attachments\/([^)]+)\)/g,
+    /!\[([^\]]*)\]\((?:\.\.\/)+attachments\/([^)]+)\)/g,
     (_match, alt: string, path: string) =>
       `![${alt}](/api/attachments/${encodeURIComponent(collection)}/${path})`,
   );

--- a/packages/ui/src/components/manage/CollectionList.tsx
+++ b/packages/ui/src/components/manage/CollectionList.tsx
@@ -139,8 +139,13 @@ export default function CollectionList({ onSelect, onAdd, onSyncComplete, onColl
 
       {syncing && <SyncProgress onComplete={handleSyncComplete} />}
 
-      <div className="collection-cards">
-        {collections.map((col) => {
+      {(() => {
+        const byName = (a: Collection, b: Collection) =>
+          (a.title || a.name).localeCompare(b.title || b.name);
+        const enabled = collections.filter((c) => c.enabled).sort(byName);
+        const disabled = collections.filter((c) => !c.enabled).sort(byName);
+
+        const renderCard = (col: Collection) => {
           const status = statuses[col.name];
           return (
             <div
@@ -179,13 +184,34 @@ export default function CollectionList({ onSelect, onAdd, onSyncComplete, onColl
               </div>
             </div>
           );
-        })}
-        {collections.length === 0 && (
-          <div className="empty-state-manage">
-            <p>No collections yet. Add your first collection to get started.</p>
-          </div>
-        )}
-      </div>
+        };
+
+        if (collections.length === 0) {
+          return (
+            <div className="collection-cards">
+              <div className="empty-state-manage">
+                <p>No collections yet. Add your first collection to get started.</p>
+              </div>
+            </div>
+          );
+        }
+
+        return (
+          <>
+            {enabled.length > 0 && (
+              <div className="collection-cards">{enabled.map(renderCard)}</div>
+            )}
+            {disabled.length > 0 && (
+              <>
+                <h2 className="collection-section-heading">Disabled</h2>
+                <div className="collection-cards collection-cards-disabled">
+                  {disabled.map(renderCard)}
+                </div>
+              </>
+            )}
+          </>
+        );
+      })()}
     </div>
   );
 }

--- a/packages/website/src/catalog.json
+++ b/packages/website/src/catalog.json
@@ -31,6 +31,14 @@
       "crawler": "mantishub",
       "entityCount": 4120,
       "sizeInMB": 115
+    },
+    {
+      "title": "Victor Boctor's Blog",
+      "url": "https://victor-blog.vboctor.workers.dev",
+      "description": "A sample blog published from a folder within an Obsidian vault, demonstrating how a sub-vault can be synced and published as its own collection.",
+      "crawler": "obsidian",
+      "entityCount": 2,
+      "sizeInMB": 1
     }
   ]
 }

--- a/packages/website/src/catalog.json
+++ b/packages/website/src/catalog.json
@@ -4,19 +4,33 @@
       "title": "MantisBT Issue Tracker",
       "url": "https://mantisbt.vboctor.workers.dev",
       "description": "A replica of the public Mantis Bug Tracker issue tracker synced from MantisHub. Useful for AI agents that need grounding in MantisBT core issues.",
-      "crawler": "mantishub"
+      "crawler": "mantishub",
+      "entityCount": 24170,
+      "sizeInMB": 687
     },
     {
       "title": "Sam Altman Blog",
       "url": "https://sam-altman.vboctor.workers.dev",
       "description": "Posts from Sam Altman's personal blog, synced from its Atom feed. Useful grounding for agents reasoning about OpenAI history, startup advice, and AI policy.",
-      "crawler": "rss"
+      "crawler": "rss",
+      "entityCount": 30,
+      "sizeInMB": 8
     },
     {
       "title": "Turso / libSQL",
       "url": "https://turso-database-libsql.vboctor.workers.dev",
       "description": "Issues and pull requests from the tursodatabase/libsql repository, synced from GitHub. Useful grounding for agents working with libSQL, Turso, or SQLite-based edge databases.",
-      "crawler": "github"
+      "crawler": "github",
+      "entityCount": 2512,
+      "sizeInMB": 35
+    },
+    {
+      "title": "Xdebug Bug Tracker",
+      "url": "https://xdebug.vboctor.workers.dev",
+      "description": "A replica of the official Xdebug bug tracker synced from its public MantisBT instance. Useful for AI agents that need grounding in Xdebug issues and PHP debugging topics.",
+      "crawler": "mantishub",
+      "entityCount": 4120,
+      "sizeInMB": 115
     }
   ]
 }

--- a/packages/website/src/catalog.ts
+++ b/packages/website/src/catalog.ts
@@ -5,6 +5,8 @@ interface CatalogEntry {
   url: string;
   description: string;
   crawler: string;
+  entityCount?: number;
+  sizeInMB?: number;
 }
 
 const CRAWLER_COLORS: Record<string, string> = {
@@ -34,6 +36,18 @@ const collections: CatalogEntry[] = [
   a.title.localeCompare(b.title, "en", { sensitivity: "base" })
 );
 
+function formatEntityCount(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+function renderStats(c: CatalogEntry): string {
+  if (c.entityCount === undefined && c.sizeInMB === undefined) return "";
+  const parts: string[] = [];
+  if (c.entityCount !== undefined) parts.push(`${formatEntityCount(c.entityCount)} entities`);
+  if (c.sizeInMB !== undefined) parts.push(`${c.sizeInMB} MB`);
+  return `<div class="catalog-tile-stats">${parts.join(" &bull; ")}</div>`;
+}
+
 function renderTile(c: CatalogEntry): string {
   const color = CRAWLER_COLORS[c.crawler] ?? "#555b6e";
   return `<a class="catalog-tile" href="${escapeHtml(c.url)}" target="_blank" rel="noopener" data-title="${escapeHtml(c.title.toLowerCase())}" data-description="${escapeHtml(c.description.toLowerCase())}">
@@ -45,6 +59,7 @@ function renderTile(c: CatalogEntry): string {
       <svg class="catalog-tile-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
     </h3>
     <p class="catalog-tile-desc">${escapeHtml(c.description)}</p>
+    ${renderStats(c)}
   </a>`;
 }
 
@@ -259,6 +274,10 @@ export const catalogPage = `<!DOCTYPE html>
     .catalog-tile-desc {
       font-size: 14px; color: var(--text-secondary);
       line-height: 1.6; margin: 0; flex: 1;
+    }
+    .catalog-tile-stats {
+      font-size: 12px; color: var(--text-muted);
+      margin-top: 2px;
     }
     .catalog-empty {
       padding: 40px 20px; text-align: center;

--- a/packages/website/src/site.html
+++ b/packages/website/src/site.html
@@ -607,7 +607,7 @@
 <!-- Hero -->
 <section class="hero" id="why">
   <h1>Your second brain,<br/><span class="gradient-text">now with full context.</span></h1>
-  <p>Built for humans and AI.</p>
+  <p>Built for humans and their agents!</p>
   <!-- Quotes carousel -->
   <div class="hero-carousel" id="heroCarousel" aria-label="Feature highlights">
     <div class="carousel-click-zone carousel-click-left" id="carouselClickLeft"></div>

--- a/packages/worker/src/handlers/api.ts
+++ b/packages/worker/src/handlers/api.ts
@@ -60,12 +60,19 @@ api.get("/api/app-info", (c) => {
 api.get("/api/collections", async (c) => {
   const collections = await getCollections(c.env.BUCKET);
   const entityCount = await getEntityCount(c.env.DB);
-  const result = collections.map((col) => ({
-    name: col.name,
-    title: col.title || col.name,
-    enabled: true,
-    entityCount,
-  }));
+  // collections.yml only stores names — titles live in per-collection yml.
+  const configs = await Promise.all(
+    collections.map((col) => getCollectionConfig(c.env.BUCKET, col.name)),
+  );
+  const result = collections.map((col, i) => {
+    const cfg = configs[i];
+    return {
+      name: col.name,
+      title: cfg?.title || col.name,
+      enabled: true,
+      entityCount,
+    };
+  });
   return c.json(result);
 });
 
@@ -119,18 +126,28 @@ api.get("/api/collections/:name/tree", async (c) => {
     offset += PAGE_SIZE;
   }
 
+  const labelWithTitle = col?.crawler ? themeEngine.labelFilesWithTitle(col.crawler) : true;
   const titleByPath = new Map<string, string>();
   const mdPaths = allResults
     .map((row) => {
       const rel = row.folder ? `${row.folder}/${row.slug}.md` : `${row.slug}.md`;
-      if (row.title) titleByPath.set(rel, row.title);
+      if (labelWithTitle && row.title) titleByPath.set(rel, row.title);
       return rel;
     })
     .filter((p) => p.endsWith(".md"));
 
-  // Derive folder configs from the theme instead of R2-stored yml files
+  // Derive folder configs from the theme (static defaults) and merge per-collection
+  // overrides that publish wrote to _config/{name}-folders.json (source .folder.yml,
+  // collection hide patterns, etc.).
   const folderConfigs = new Map<string, { visible?: boolean; sort?: "ASC" | "DESC"; hide?: string[]; showCount?: boolean; expandFirstN?: number; expanded?: boolean; created_at_prefix?: boolean }>();
   const rootConfig: { hide?: string[]; sort?: "ASC" | "DESC"; expandFirstN?: number } = {};
+
+  let collectionFolderOverrides: Record<string, FolderConfig> = {};
+  try {
+    const obj = await c.env.BUCKET.get(`_config/${name}-folders.json`);
+    if (obj) collectionFolderOverrides = await obj.json<Record<string, FolderConfig>>();
+  } catch { /* no overrides */ }
+
   if (col?.crawler) {
     const themeFolderConfigs = themeEngine.getFolderConfigs(col.crawler);
     const themeRootConfig = themeEngine.getRootConfig(col.crawler);
@@ -152,6 +169,18 @@ api.get("/api/collections/:name/tree", async (c) => {
         folderConfigs.set(folderPath, themeFolderConfigs[folderName]);
       }
     }
+  }
+
+  // Overlay per-collection overrides on top of theme defaults (root and subdirs).
+  const rootOverride = collectionFolderOverrides[""];
+  if (rootOverride) {
+    if (rootOverride.sort) rootConfig.sort = rootOverride.sort;
+    if (rootOverride.hide) rootConfig.hide = rootOverride.hide;
+  }
+  for (const [path, cfg] of Object.entries(collectionFolderOverrides)) {
+    if (path === "") continue;
+    const existing = folderConfigs.get(path) ?? {};
+    folderConfigs.set(path, { ...existing, ...cfg });
   }
 
   // Store root config at "" key so sortTree can apply it at the root level
@@ -194,7 +223,20 @@ api.get("/api/collections/:name/default-file", async (c) => {
 
   if (all.length === 0) return c.json({ file: null });
 
-  const folderConfigs = col?.crawler ? themeEngine.getFolderConfigs(col.crawler) : {};
+  const folderConfigs: Record<string, FolderConfig> = col?.crawler ? { ...themeEngine.getFolderConfigs(col.crawler) } : {};
+  // Overlay per-collection overrides (same JSON the tree endpoint reads). The
+  // root override ("" key) lands in folderConfigs[""] so pickFirstTreeFile
+  // honors the DESC/ASC setting at the content root.
+  try {
+    const obj = await c.env.BUCKET.get(`_config/${name}-folders.json`);
+    if (obj) {
+      const overrides = await obj.json<Record<string, FolderConfig>>();
+      for (const [path, cfg] of Object.entries(overrides)) {
+        const key = path === "" ? "" : (path.includes("/") ? path.split("/").pop()! : path);
+        folderConfigs[key] = { ...(folderConfigs[key] ?? {}), ...cfg };
+      }
+    }
+  } catch { /* no overrides */ }
   const picked = pickFirstTreeFile(all, folderConfigs);
   if (!picked) return c.json({ file: null });
   const filePath = picked.folder ? `${picked.folder}/${picked.slug}.md` : `${picked.slug}.md`;

--- a/scripts/fix-missing-attachments.ts
+++ b/scripts/fix-missing-attachments.ts
@@ -1,0 +1,289 @@
+#!/usr/bin/env bun
+/**
+ * One-off repair script: download missing attachment files for MantisBT collections.
+ *
+ * Handles two cases:
+ *   A. Attachment has no storagePath (never downloaded): download and set storagePath.
+ *   B. Attachment has storagePath but file is missing from disk: re-download to same path.
+ *
+ * Uses the MantisBT REST API (with auth token if configured) for reliable downloads.
+ * Falls back to file_download.php for public trackers.
+ *
+ * After running, regenerate markdown with:
+ *   bun run fink -- generate <collection>
+ *
+ * Usage:
+ *   bun scripts/fix-missing-attachments.ts xdebug
+ *   bun scripts/fix-missing-attachments.ts mantisbt
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+
+const COLLECTION = process.argv[2];
+if (!COLLECTION) {
+  console.error("Usage: bun scripts/fix-missing-attachments.ts <collection>");
+  process.exit(1);
+}
+
+const FROZENINK_DIR = join(homedir(), ".frozenink");
+const COLLECTIONS_DIR = join(FROZENINK_DIR, "collections");
+const COLLECTION_DIR = join(COLLECTIONS_DIR, COLLECTION);
+const DB_PATH = join(COLLECTION_DIR, "db", "data.db");
+
+if (!existsSync(DB_PATH)) {
+  console.error(`DB not found: ${DB_PATH}`);
+  process.exit(1);
+}
+
+const configFile = join(COLLECTION_DIR, `${COLLECTION}.yml`);
+if (!existsSync(configFile)) {
+  console.error(`Config not found: ${configFile}`);
+  process.exit(1);
+}
+const configText = await Bun.file(configFile).text();
+const urlMatch = configText.match(/url:\s*(.+)/);
+if (!urlMatch) {
+  console.error("Could not find url in config");
+  process.exit(1);
+}
+const BASE_URL = urlMatch[1].trim().replace(/\/+$/, "");
+
+// Load auth token from credentials if configured.
+let AUTH_TOKEN = "";
+const credMatch = configText.match(/^credentials:\s*(\S+)/m);
+if (credMatch && credMatch[1] !== "{}") {
+  const credName = credMatch[1];
+  const globalCreds = join(FROZENINK_DIR, "credentials.yml");
+  if (existsSync(globalCreds)) {
+    const credsText = await Bun.file(globalCreds).text();
+    const tokenMatch = new RegExp(`${credName}:\\s*\\n\\s+token:\\s*(\\S+)`).exec(credsText);
+    if (tokenMatch) AUTH_TOKEN = tokenMatch[1];
+  }
+}
+
+console.log(`Collection: ${COLLECTION}  Base URL: ${BASE_URL}`);
+console.log(`Auth token: ${AUTH_TOKEN ? `${AUTH_TOKEN.slice(0, 4)}…(${AUTH_TOKEN.length} chars)` : "none"}\n`);
+
+const db = new Database(DB_PATH, { readwrite: true });
+
+const rows = db.query<{ external_id: string; data: string }, []>(
+  "SELECT external_id, data FROM entities WHERE json_extract(data, '$.source.id') IS NOT NULL"
+).all();
+
+console.log(`Found ${rows.length} entities to scan...\n`);
+
+let fixed = 0;
+let skipped = 0;
+let errors = 0;
+
+const authHeaders: Record<string, string> = {
+  "User-Agent": "Mozilla/5.0 (compatible; FrozenInk/1.0)",
+};
+if (AUTH_TOKEN) authHeaders["Authorization"] = AUTH_TOKEN;
+
+/** Download via REST API (returns base64-decoded binary). */
+async function downloadViaRestApi(issueId: number, fileId: number): Promise<Buffer | null> {
+  const url = `${BASE_URL}/api/rest/issues/${issueId}/files/${fileId}`;
+  try {
+    const res = await fetch(url, { headers: authHeaders });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { files?: Array<{ content?: string }> };
+    const b64 = data.files?.[0]?.content;
+    if (!b64) return null;
+    return Buffer.from(b64, "base64");
+  } catch {
+    return null;
+  }
+}
+
+/** Download via file_download.php (works on public trackers without auth). */
+async function downloadViaLegacy(fileId: number, type: "bug" | "bugnote"): Promise<Buffer | null> {
+  const url = `${BASE_URL}/file_download.php?file_id=${fileId}&type=${type}`;
+  try {
+    const res = await fetch(url, { headers: authHeaders, redirect: "follow" });
+    if (!res.ok) return null;
+    const ct = res.headers.get("content-type") ?? "";
+    // If the server returns HTML it's a login redirect or error page — skip.
+    if (ct.includes("text/html")) return null;
+    return Buffer.from(await res.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+function slugifyProjectName(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 60);
+}
+
+function assetFilename(id: number, filename: string): string {
+  return `${id}-${filename}`;
+}
+
+for (const row of rows) {
+  const entityData = JSON.parse(row.data) as {
+    source: {
+      id: number;
+      project?: { name?: string };
+      attachments?: Array<{ id?: number; filename: string; content_type?: string; size?: number; storagePath?: string }>;
+      notes?: Array<{ id: number; attachments?: Array<{ id: number; filename: string; content_type?: string; storagePath?: string }> }>;
+    };
+    assets?: Array<{ filename: string; mimeType: string; storagePath: string; hash?: string }>;
+  };
+
+  const source = entityData.source;
+  const issueId = source.id;
+
+  // Case A: no storagePath (never downloaded).
+  const missingIssueAtts = (source.attachments ?? []).filter((f) => !f.storagePath);
+  const missingNoteAtts = (source.notes ?? []).flatMap((note) =>
+    (note.attachments ?? []).filter((att) => !att.storagePath).map((att) => ({ ...att, noteId: note.id }))
+  );
+
+  // Case B: storagePath set but file missing from disk.
+  const staleIssueAtts = (source.attachments ?? []).filter(
+    (f) => f.storagePath && !existsSync(join(COLLECTION_DIR, f.storagePath))
+  );
+  const staleNoteAtts = (source.notes ?? []).flatMap((note) =>
+    (note.attachments ?? [])
+      .filter((att) => att.storagePath && !existsSync(join(COLLECTION_DIR, att.storagePath)))
+      .map((att) => ({ ...att, noteId: note.id }))
+  );
+
+  if (
+    missingIssueAtts.length === 0 &&
+    missingNoteAtts.length === 0 &&
+    staleIssueAtts.length === 0 &&
+    staleNoteAtts.length === 0
+  )
+    continue;
+
+  const total = missingIssueAtts.length + missingNoteAtts.length + staleIssueAtts.length + staleNoteAtts.length;
+  console.log(`Issue ${issueId}: ${total} attachment(s) to fix (${missingIssueAtts.length + missingNoteAtts.length} new, ${staleIssueAtts.length + staleNoteAtts.length} stale)`);
+
+  // Determine asset prefix for NEW (no-storagePath) attachments.
+  let assetPrefix: string | null = null;
+  // Try to infer from existing storagePaths (even stale ones give us the right directory).
+  for (const f of source.attachments ?? []) {
+    if (f.storagePath) { assetPrefix = dirname(f.storagePath); break; }
+  }
+  if (!assetPrefix) {
+    for (const note of source.notes ?? []) {
+      for (const att of note.attachments ?? []) {
+        if (att.storagePath) { assetPrefix = dirname(att.storagePath); break; }
+      }
+      if (assetPrefix) break;
+    }
+  }
+  if (!assetPrefix && source.project?.name) {
+    assetPrefix = `content/${slugifyProjectName(source.project.name)}/issues/assets`;
+  }
+
+  // Fetch from REST API if issue-level attachments are missing their IDs.
+  if (missingIssueAtts.some((f) => f.id === undefined)) {
+    try {
+      const res = await fetch(`${BASE_URL}/api/rest/issues/${issueId}`, { headers: authHeaders });
+      if (res.ok) {
+        const apiData = (await res.json()) as { issues: Array<{ attachments?: Array<{ id: number; filename: string }> }> };
+        const apiAtts = apiData.issues?.[0]?.attachments ?? [];
+        for (const f of missingIssueAtts) {
+          if (f.id === undefined) {
+            const match = apiAtts.find((a) => a.filename === f.filename);
+            if (match) f.id = match.id;
+          }
+        }
+      }
+    } catch { /* ignore */ }
+  }
+
+  let changed = false;
+
+  // Helper: download a file and save it.
+  async function saveAttachment(
+    fileId: number,
+    filename: string,
+    mimeType: string | undefined,
+    storagePath: string,
+    noteType: "bug" | "bugnote",
+  ): Promise<boolean> {
+    const diskPath = join(COLLECTION_DIR, storagePath);
+    mkdirSync(dirname(diskPath), { recursive: true });
+
+    // Try REST API first (works with auth), then legacy URL.
+    let content = await downloadViaRestApi(issueId, fileId);
+    if (!content) content = await downloadViaLegacy(fileId, noteType);
+    if (!content) {
+      console.warn(`    ✗ Could not download ${filename} (id=${fileId})`);
+      errors++;
+      return false;
+    }
+    writeFileSync(diskPath, content);
+    if (!entityData.assets) entityData.assets = [];
+    // Remove stale entry if present.
+    entityData.assets = entityData.assets.filter((a) => a.storagePath !== storagePath);
+    entityData.assets.push({ filename, mimeType: mimeType ?? "application/octet-stream", storagePath });
+    console.log(`    ✓ ${filename} (${content.length} bytes) → ${storagePath}`);
+    fixed++;
+    return true;
+  }
+
+  // Process new issue-level attachments (no storagePath).
+  for (const f of missingIssueAtts) {
+    if (!assetPrefix) { console.warn(`    No asset prefix for issue ${issueId}`); skipped++; continue; }
+    if (f.id === undefined) { console.warn(`    No ID for ${f.filename}`); skipped++; continue; }
+    const storedName = assetFilename(f.id, f.filename);
+    const storagePath = `${assetPrefix}/${storedName}`;
+    if (await saveAttachment(f.id, storedName, f.content_type, storagePath, "bug")) {
+      f.storagePath = storagePath;
+      changed = true;
+    }
+  }
+
+  // Process stale issue-level attachments (storagePath set but file missing).
+  for (const f of staleIssueAtts) {
+    const storagePath = f.storagePath!;
+    // Extract file ID from stored filename (format: {id}-{filename}).
+    const storedName = storagePath.split("/").pop()!;
+    const idMatch = storedName.match(/^(\d+)-/);
+    if (!idMatch) { console.warn(`    Cannot parse ID from ${storedName}`); skipped++; continue; }
+    const fileId = parseInt(idMatch[1], 10);
+    await saveAttachment(fileId, storedName, f.content_type, storagePath, "bug");
+    changed = true; // storagePath already set correctly, just restore the file
+  }
+
+  // Process new note attachments (no storagePath).
+  for (const att of missingNoteAtts) {
+    if (!assetPrefix) { console.warn(`    No asset prefix for note att`); skipped++; continue; }
+    const storedName = assetFilename(att.id, att.filename);
+    const storagePath = `${assetPrefix}/${storedName}`;
+    if (await saveAttachment(att.id, storedName, att.content_type, storagePath, "bugnote")) {
+      const noteAtt = source.notes?.find((n) => n.id === att.noteId)?.attachments?.find((a) => a.id === att.id);
+      if (noteAtt) { noteAtt.storagePath = storagePath; changed = true; }
+    }
+  }
+
+  // Process stale note attachments (storagePath set but file missing).
+  for (const att of staleNoteAtts) {
+    const storagePath = att.storagePath!;
+    const storedName = storagePath.split("/").pop()!;
+    const idMatch = storedName.match(/^(\d+)-/);
+    if (!idMatch) { console.warn(`    Cannot parse ID from ${storedName}`); skipped++; continue; }
+    const fileId = parseInt(idMatch[1], 10);
+    await saveAttachment(fileId, storedName, att.content_type, storagePath, "bugnote");
+    changed = true;
+  }
+
+  if (changed) {
+    db.run("UPDATE entities SET data = ? WHERE external_id = ?", [
+      JSON.stringify(entityData),
+      row.external_id,
+    ]);
+  }
+}
+
+db.close();
+
+console.log(`\nDone. Fixed: ${fixed}  Skipped: ${skipped}  Errors: ${errors}`);
+console.log(`\nRun: bun run fink -- generate ${COLLECTION}  to regenerate markdown with updated storagePaths.`);


### PR DESCRIPTION
## Summary

- Fixes the published Cloudflare Worker so Obsidian collections look like the local/desktop UI: embedded images resolve, `.folder.yml` sort/hide settings are honored, the collection title (not the slug) shows in the header, and the sidebar shows filenames instead of H1s.
- Extracts the vault-reading code out of `ObsidianTheme` so the worker bundle no longer depends on `node:fs` (was blocking deploys after the `.folder.yml` feature landed).
- Adds MD5 etag comparison to publish's R2 upload skip logic so content changes of identical byte length (typically Vite `index.html`) are never skipped.
- Silences `/api/preferences` 404 console noise on published sites.
- UI: groups disabled collections at the bottom of the management list under a separator.
- Website: adds `victor-blog` to the public catalog.

## Test plan
- [x] `bun run ci` (typecheck + all tests + UI build + worker build)
- [x] Republished `victor-blog`; verified header title, file-tree order (DESC), sidebar labels (filenames), and attachment serving on `victor-blog.vboctor.workers.dev`
- [x] Verified `/api/collections` returns `"Victor Boctor's Blog"`
- [x] Verified `/api/attachments/victor-blog/assets/...` returns `image/png`
- [x] Verified etag-based skip re-uploads `index.html` when asset hashes change but length doesn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)