### PR TITLE
Desktop: pass --publish never to electron-builder

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -8,10 +8,10 @@
     "rebuild-native": "electron-rebuild -m .",
     "compile": "bun build.mjs",
     "start": "bun build.mjs && electron .",
-    "dist": "bun build.mjs && electron-builder",
-    "dist:mac": "bun build.mjs && electron-builder --mac",
-    "dist:win": "bun build.mjs && electron-builder --win",
-    "dist:linux": "bun build.mjs && electron-builder --linux"
+    "dist": "bun build.mjs && electron-builder --publish never",
+    "dist:mac": "bun build.mjs && electron-builder --mac --publish never",
+    "dist:win": "bun build.mjs && electron-builder --win --publish never",
+    "dist:linux": "bun build.mjs && electron-builder --linux --publish never"
   },
   "dependencies": {
     "better-sqlite3": "^11.0.0",


### PR DESCRIPTION
## Summary

Fixes the v0.10.1 release failure: `dist:mac` crashed with "GitHub Personal Access Token is not set" because `electron-builder.yml` configures `publish: github` and the release workflow doesn't export `GH_TOKEN` to the desktop build step.

The workflow is designed to have `softprops/action-gh-release` upload artifacts, so passing `--publish never` tells electron-builder to emit artifacts and `latest-*.yml` update manifests locally without attempting an upload.

## Test plan
- [ ] Cut a patch release (e.g. retag v0.10.1 or v0.10.2) and confirm the Release workflow completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)