### PR TITLE
Desktop: add metadata required for Linux .deb builds

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -39,6 +39,9 @@ win:
 linux:
   icon: build/icon.png
   category: Development
+  maintainer: Victor Boctor <vboctor@gmail.com>
+  synopsis: Frozen Ink desktop app
+  description: A local-first reader for Frozen Ink collections.
   target:
     - target: AppImage
       arch:

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -4,6 +4,12 @@
   "productName": "Frozen Ink",
   "private": true,
   "main": "dist/main/index.mjs",
+  "homepage": "https://github.com/vboctor/frozen-ink",
+  "author": {
+    "name": "Victor Boctor",
+    "email": "vboctor@gmail.com"
+  },
+  "description": "Frozen Ink desktop app — a local-first reader for Frozen Ink collections.",
   "scripts": {
     "rebuild-native": "electron-rebuild -m .",
     "compile": "bun build.mjs",


### PR DESCRIPTION
## Summary

Fixes the v0.10.2 release failure on `build-desktop (ubuntu-latest)`:

```
⨯ Please specify project homepage, ...
Please specify author 'email' in the application package.json
It is required to set Linux .deb package maintainer.
```

electron-builder's fpm target (used for .deb) rejects the build without these fields. Added:

- `homepage`, `author` (with email), `description` to `packages/desktop/package.json`
- `linux.maintainer`, `linux.synopsis`, `linux.description` to `electron-builder.yml`

After merging, cut a new release (e.g. `scripts/release.sh 0.10.3`) — tags are immutable so v0.10.2 can't be reused.

## Test plan
- [ ] Cut v0.10.3 and confirm all three `build-desktop` matrix jobs complete and the `publish` job runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)