### PR TITLE
Desktop: override linux artifactName to avoid scoped-name path

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -42,6 +42,10 @@ linux:
   maintainer: Victor Boctor <vboctor@gmail.com>
   synopsis: Frozen Ink desktop app
   description: A local-first reader for Frozen Ink collections.
+  # Default artifactName embeds the scoped npm package name ("@frozenink/desktop"),
+  # and fpm interprets the "/" as a directory — which makes the .deb build fail
+  # with "Parent directory does not exist". Use a plain slug instead.
+  artifactName: "frozenink-desktop-${version}-${arch}.${ext}"
   target:
     - target: AppImage
       arch:


### PR DESCRIPTION
## Summary

Fixes the v0.10.3 release failure on `build-desktop (ubuntu-latest)`:

\`\`\`
Parent directory does not exist:
  /home/runner/.../release/@frozenink - cannot write to
  /home/runner/.../release/@frozenink/desktop_0.10.3_amd64.deb
\`\`\`

electron-builder's default \`artifactName\` uses the npm package name, which is the scoped \`@frozenink/desktop\`. fpm interprets the \`/\` as a directory separator and fails the \`.deb\` build.

Overriding \`linux.artifactName\` to \`frozenink-desktop-\${version}-\${arch}.\${ext}\` keeps the artifact in \`release/\` directly. AppImage picks up the new pattern too — both still match the workflow's \`*.deb\` / \`*.AppImage\` upload globs.

After merge, cut v0.10.4.

## Test plan
- [ ] Cut v0.10.4 and confirm the linux desktop artifact builds and uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)