### PR TITLE
CI: drop retired macos-13 runner, cross-compile darwin-x64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,11 @@ jobs:
           - os: ubuntu-latest
             platform: linux
             upload_npm: true
+          # macos-14 is arm64. Bun cross-compiles darwin-x64 from here so we
+          # emit both darwin binaries on a single runner — macos-13 hosted
+          # runners are retired (GH changelog 2025-09-19).
           - os: macos-14
-            platform: darwin-arm64
-          - os: macos-13
-            platform: darwin-x64
+            platform: darwin
           - os: windows-latest
             platform: windows
 
@@ -49,7 +50,7 @@ jobs:
           path: packages/cli/dist/fink-darwin-arm64
 
       - name: Upload darwin-x64 binary
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
         uses: actions/upload-artifact@v4
         with:
           name: fink-darwin-x64


### PR DESCRIPTION
## Summary

GitHub is retiring the macos-13 hosted runner image ([changelog](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)).

Bun supports cross-compiling to darwin-x64 from an arm64 host, and `packages/cli/build.mjs` already emits every target it can produce. So we just run the darwin CLI job once on `macos-14` and upload both `fink-darwin-arm64` and `fink-darwin-x64` artifacts from it.

The desktop matrix never used macos-13 — the DMG is `arch: universal` built on macos-14.

## Test plan
- [ ] Cut the next release and confirm `build-cli (macos-14)` produces both darwin binaries and the `publish` job includes both in the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)