### PR TITLE
CI: fix npm-payload path in release publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,8 +183,11 @@ jobs:
         # No NPM_TOKEN needed. npm auto-detects the OIDC context from GitHub Actions.
         # Prerequisite: configure trusted publishing on npmjs.com for @vboctor/fink
         # pointing at this repo + this workflow file.
+        # Note: actions/upload-artifact@v4 strips the common ancestor of the
+        # uploaded paths, so the downloaded artifact contains the files
+        # directly under artifacts/npm-payload/ (not under packages/cli/dist/).
         run: |
-          cd artifacts/npm-payload/packages/cli/dist
+          cd artifacts/npm-payload
           npm publish --access public --provenance
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

The v0.10.5 release got all the way through the build matrix — CLI and desktop artifacts all produced — but failed the `publish` job:

\`\`\`
cd: artifacts/npm-payload/packages/cli/dist: No such file or directory
\`\`\`

`actions/upload-artifact@v4` strips the common ancestor of the uploaded paths. The npm-payload uploaded 4 files all under `packages/cli/dist/`, so the download lands them directly under `artifacts/npm-payload/` — not in a nested path.

This failure was latent: previous releases never got past `build-desktop` so the `publish` job had never actually run.

## Test plan
- [ ] Cut v0.10.6 and confirm the `publish` job runs npm publish + creates the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)