### PR TITLE
CI: drop --provenance from npm publish (repo is private)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,9 +186,11 @@ jobs:
         # Note: actions/upload-artifact@v4 strips the common ancestor of the
         # uploaded paths, so the downloaded artifact contains the files
         # directly under artifacts/npm-payload/ (not under packages/cli/dist/).
+        # --provenance is not passed: npm rejects it when the source repo is
+        # private (requires public visibility for sigstore verification).
         run: |
           cd artifacts/npm-payload
-          npm publish --access public --provenance
+          npm publish --access public
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

v0.10.6 published the tarball up to the point of signing, then npm rejected it:

\`\`\`
422 Unprocessable Entity - Error verifying sigstore provenance bundle:
Unsupported GitHub Actions source repository visibility: "private".
Only public source repositories are supported when publishing with provenance.
\`\`\`

Removing `--provenance` lets OIDC trusted publishing succeed. Re-add it if/when `vboctor/frozen-ink` becomes public.

## Test plan
- [ ] Cut v0.10.7 and confirm `npm publish` succeeds and the GitHub Release is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)