### PR TITLE
CLI: fix dist package.json repository URL, re-enable provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,9 +186,11 @@ jobs:
         # Note: actions/upload-artifact@v4 strips the common ancestor of the
         # uploaded paths, so the downloaded artifact contains the files
         # directly under artifacts/npm-payload/ (not under packages/cli/dist/).
+        # --provenance is not passed: npm rejects it when the source repo is
+        # private (requires public visibility for sigstore verification).
         run: |
           cd artifacts/npm-payload
-          npm publish --access public --provenance
+          npm publish --access public
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,11 +186,9 @@ jobs:
         # Note: actions/upload-artifact@v4 strips the common ancestor of the
         # uploaded paths, so the downloaded artifact contains the files
         # directly under artifacts/npm-payload/ (not under packages/cli/dist/).
-        # --provenance is not passed: npm rejects it when the source repo is
-        # private (requires public visibility for sigstore verification).
         run: |
           cd artifacts/npm-payload
-          npm publish --access public
+          npm publish --access public --provenance
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/packages/cli/build.mjs
+++ b/packages/cli/build.mjs
@@ -117,11 +117,11 @@ function generateDistPackageJson() {
     author: "Victor Boctor",
     repository: {
       type: "git",
-      url: "https://github.com/vboctor/fink",
+      url: "https://github.com/vboctor/frozen-ink",
     },
-    homepage: "https://github.com/vboctor/fink#readme",
+    homepage: "https://github.com/vboctor/frozen-ink#readme",
     bugs: {
-      url: "https://github.com/vboctor/fink/issues",
+      url: "https://github.com/vboctor/frozen-ink/issues",
     },
     keywords: [
       "cli",


### PR DESCRIPTION
## Summary

Two fixes bundled since they're coupled:

1. **`packages/cli/build.mjs`** — generated dist `package.json` pointed at `github.com/vboctor/fink`, but the actual repo is `vboctor/frozen-ink`. npm provenance checks rejected the publish with:

   > \`repository.url\` is "git+https://github.com/vboctor/fink.git", expected to match "https://github.com/vboctor/frozen-ink" from provenance

2. **`.github/workflows/release.yml`** — re-enable `--provenance` on `npm publish` now that the repo is public (PR #84 dropped it temporarily while the repo was private).

## Test plan
- [ ] Cut v0.10.7 and confirm `npm publish` succeeds with provenance and the GitHub Release is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)