### PR TITLE
MantisHub: fix left panel text overlapping right sidebar

### DIFF
--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -2154,6 +2154,7 @@ body {
 .mt-main-col {
   flex: 1;
   min-width: 0;
+  overflow: hidden;
 }
 
 .mt-sidebar-col {
@@ -2206,6 +2207,17 @@ body {
 .mt-description {
   color: var(--text);
   word-break: break-word;
+}
+
+.mt-code-block {
+  background: var(--code-bg);
+  border-radius: var(--radius);
+  padding: 16px;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.45;
+  margin: 8px 0;
 }
 
 /* Attachments */


### PR DESCRIPTION
## Summary

- Add `overflow: hidden` to `.mt-main-col` to prevent content from bleeding past the column boundary into `.mt-sidebar-col`
- Add `.mt-code-block` CSS with `overflow-x: auto` so wide code blocks scroll horizontally instead of expanding beyond the column

Fixes #86.

## Test plan

- [ ] Open a MantisHub issue with a long description or code blocks and verify text stays within the left column
- [ ] Verify code blocks scroll horizontally when content is wide
- [ ] Verify the sidebar metadata column is not obscured

🤖 Generated with [Claude Code](https://claude.com/claude-code)