### PR TITLE
Fix app crash and progress visibility during post-sync publish (#87)

### DIFF
--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -770,11 +770,19 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
 
       if (getCollectionPublishState(name)) {
         console.log(`[sync:${name}] collection is published — republishing`);
-        syncProgress = { ...syncProgress, status: `republishing ${name}` };
+        syncProgress = { ...syncProgress, status: `republishing ${name}: starting` };
         try {
-          await triggerPublish({ collectionName: name });
+          await triggerPublish({ collectionName: name }, (step, detail) => {
+            // Mirror publish progress into syncProgress so the SyncProgress UI
+            // (which polls /api/sync/status, not /api/publish/status) shows
+            // step-by-step updates during the post-sync republish instead of
+            // appearing frozen on "republishing ${name}".
+            const label = detail || step;
+            syncProgress = { ...syncProgress, status: `republishing ${name}: ${label}` };
+          });
         } catch (err) {
           console.error(`[sync:${name}] republish failed: ${err}`);
+          syncProgress = { ...syncProgress, status: `republish failed: ${String(err)}` };
         }
       }
     }
@@ -802,7 +810,10 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
 
 // --- Publish logic ---
 
-async function triggerPublish(opts: Record<string, unknown>): Promise<void> {
+async function triggerPublish(
+  opts: Record<string, unknown>,
+  onExtraProgress?: (step: string, detail: string) => void,
+): Promise<void> {
   const startedAt = publishProgress.startedAt ?? Date.now();
   publishProgress = { active: true, step: "starting", detail: "Starting publish...", error: null, startedAt };
   try {
@@ -819,11 +830,13 @@ async function triggerPublish(opts: Record<string, unknown>): Promise<void> {
       (step, detail) => {
         publishProgress = { ...publishProgress, step, detail };
         console.log(`[publish:${collectionName}] ${step}: ${detail}`);
+        onExtraProgress?.(step, detail);
       },
     );
 
     publishProgress = { active: false, step: "done", detail: "Publish completed", error: null, startedAt };
   } catch (err) {
     publishProgress = { active: false, step: "failed", detail: "", error: String(err), startedAt };
+    throw err;
   }
 }

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -369,6 +369,9 @@ export function handleManagementRequest(req: Request): Response | null {
   const syncOneMatch = path.match(/^\/api\/sync\/([^/]+)$/);
   if (syncOneMatch && method === "POST") {
     const name = decodeURIComponent(syncOneMatch[1]);
+    // Mark active synchronously before any await so that status polls arriving
+    // during body-read don't see the stale idle state and prematurely complete.
+    syncProgress = { active: true, collectionName: name, status: "starting", created: 0, updated: 0, deleted: 0, error: null };
     return handleAsync(async () => {
       const body = await readBody(req);
       const full = !!body.full;
@@ -379,6 +382,9 @@ export function handleManagementRequest(req: Request): Response | null {
 
   // POST /api/sync (sync all)
   if (path === "/api/sync" && method === "POST") {
+    // Mark active synchronously before any await so that status polls arriving
+    // during body-read don't see the stale idle state and prematurely complete.
+    syncProgress = { active: true, collectionName: null, status: "starting", created: 0, updated: 0, deleted: 0, error: null };
     return handleAsync(async () => {
       const body = await readBody(req);
       const full = !!body.full;

--- a/packages/cli/src/commands/wrangler-api.ts
+++ b/packages/cli/src/commands/wrangler-api.ts
@@ -130,12 +130,10 @@ export function invalidateCredentials(): void {
 }
 
 export async function checkWranglerAuth(): Promise<void> {
-  try {
-    await getCredentials();
-  } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
-    process.exit(1);
-  }
+  // Throws on auth failure. Callers in CLI commands catch and exit; callers in
+  // the desktop management API catch and surface the error in publishProgress
+  // rather than crashing the process.
+  await getCredentials();
 }
 
 // --- Retry helper for transient Cloudflare/network errors ---

--- a/packages/core/src/compat/resources.ts
+++ b/packages/core/src/compat/resources.ts
@@ -81,7 +81,9 @@ const WRANGLER_INSTALL_URL = "https://developers.cloudflare.com/workers/wrangler
  * Search order:
  * 1. User-configured path (from frozenink.yml "wranglerPath")
  * 2. Monorepo dev: node_modules/.bin/wrangler
- * 3. System PATH: "wrangler" (via `which`)
+ * 3. Well-known absolute paths (macOS packaged app: Dock-launched apps have a
+ *    minimal PATH that omits Homebrew's /opt/homebrew/bin and nvm/volta dirs)
+ * 4. System PATH: "wrangler" (via `which` / `where`)
  *
  * Returns the path, or throws with install instructions.
  */
@@ -101,7 +103,29 @@ export async function resolveWrangler(moduleDir: string, configuredPath?: string
     if (existsSync(rootBin)) return rootBin;
   }
 
-  // 3. System PATH
+  // 3. Well-known absolute locations that packaged Electron apps miss because
+  //    Dock-launched processes inherit a minimal PATH.
+  const home = process.env.HOME ?? "";
+  const candidates: string[] = [];
+  if (process.platform === "darwin") {
+    candidates.push(
+      "/opt/homebrew/bin/wrangler",         // Homebrew on Apple Silicon
+      "/usr/local/bin/wrangler",            // Homebrew on Intel / classic npm global
+      join(home, ".volta/bin/wrangler"),    // Volta
+      join(home, ".bun/bin/wrangler"),      // Bun global
+    );
+  } else if (process.platform === "linux") {
+    candidates.push(
+      "/usr/local/bin/wrangler",
+      join(home, ".volta/bin/wrangler"),
+      join(home, ".bun/bin/wrangler"),
+    );
+  }
+  for (const p of candidates) {
+    if (p && existsSync(p)) return p;
+  }
+
+  // 4. System PATH
   try {
     const { stdout, exitCode } = await spawnProcess(["which", "wrangler"]);
     if (exitCode === 0 && stdout.trim()) return stdout.trim();

--- a/packages/ui/src/components/manage/SyncProgress.tsx
+++ b/packages/ui/src/components/manage/SyncProgress.tsx
@@ -15,6 +15,11 @@ interface SyncProgressProps {
 export default function SyncProgress({ onComplete }: SyncProgressProps) {
   const [progress, setProgress] = useState<SyncProgressType | null>(null);
   const intervalRef = useRef<number | null>(null);
+  // Guard against the race where the first poll returns active:false (initial
+  // idle state) before the server has marked the sync as started.  Only fire
+  // onComplete after we have seen at least one active:true response so we know
+  // a real sync run has begun and then finished.
+  const hasSeenActiveRef = useRef(false);
 
   useEffect(() => {
     const poll = () => {
@@ -22,7 +27,10 @@ export default function SyncProgress({ onComplete }: SyncProgressProps) {
         .then((r) => r.json())
         .then((data: SyncProgressType) => {
           setProgress(data);
-          if (!data.active) {
+          if (data.active) {
+            hasSeenActiveRef.current = true;
+          }
+          if (!data.active && hasSeenActiveRef.current) {
             if (intervalRef.current) clearInterval(intervalRef.current);
             onComplete({
               created: data.created,


### PR DESCRIPTION
## Summary

Resolves #87 — the macOS desktop app auto-closing after sync and before publishing — plus a related visibility bug discovered while testing the fix.

### Commit 1: Prevent app crash after sync when publishing to Cloudflare

- **Root cause**: `checkWranglerAuth` called `process.exit(1)` on credential failure, which is uncatchable and terminates the Electron process even though `triggerPublish` has a try/catch. Replaced with a plain throw; CLI callers still exit (their own catch blocks do that), desktop callers now surface the error in `publishProgress.error`.
- **Secondary issue**: Dock-launched macOS apps inherit a minimal PATH missing `/opt/homebrew/bin`, so `which wrangler` fails even when wrangler is Homebrew-installed. Expanded `resolveWrangler` to probe well-known absolute paths (Homebrew, Volta, Bun global) before `which`.
- **Race condition**: Both `POST /api/sync` handlers now set `syncProgress.active = true` synchronously before any await, and `SyncProgress` now requires at least one `active:true` observation before firing `onComplete` — prevents a fast first poll from auto-dismissing the UI mid-sync.

### Commit 2: Surface publish progress during post-sync republish

After fixing the crash, publish still *appeared* stuck: the sync-triggered republish routed progress into `publishProgress`, but the `SyncProgress` UI only polls `/api/sync/status`. Every publish step (d1 setup, r2 uploads, worker deploy, d1 inserts) was invisible, freezing the UI on `republishing ${name}` for the full publish duration.

- `triggerPublish` now accepts an optional `onExtraProgress` callback and re-throws on error
- Sync loop passes that callback to mirror each publish step into `syncProgress.status`

This also gives diagnostic visibility if publish does genuinely hang — the user can now see *which* step stalled.

## Test plan

- [x] `bun run ci` passes locally (markdown lint, typecheck, core/crawlers/mcp/ui tests, UI build, worker build)
- [ ] Verify in packaged macOS app: sync a published collection, confirm the UI shows step-by-step `republishing ${name}: ${detail}` updates and the app does not crash
- [ ] Verify error handling: revoke wrangler auth, trigger publish from UI, confirm the error surfaces as a red banner instead of crashing the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)