### PR TITLE
fix: guard toLowerCase against undefined review state and priority name

### DIFF
--- a/packages/crawlers/src/github/theme.ts
+++ b/packages/crawlers/src/github/theme.ts
@@ -930,7 +930,7 @@ export class GitHubTheme implements Theme {
         // Skip reviews with no body and no review comments (nothing to show)
         if (!r.body && reviewComments.length === 0) continue;
 
-        parts.push(`<div class="gh-review-box gh-review-${r.state.toLowerCase()}">`);
+        parts.push(`<div class="gh-review-box gh-review-${(r.state ?? "").toLowerCase()}">`);
         parts.push(`<div class="gh-comment-header">`);
         parts.push(`${avatarImg(r.user, 32, resolve)} ${userLink(r.user, true, resolve)} <span class="gh-review-state">${stateLabel}</span> <span class="gh-comment-date">on ${formatDate(r.submittedAt)}</span>`);
         parts.push(`</div>`);

--- a/packages/crawlers/src/mantishub/theme.ts
+++ b/packages/crawlers/src/mantishub/theme.ts
@@ -367,7 +367,7 @@ function priorityIndicator(name: string): string {
     urgent: "#e74c3c",
     immediate: "#c0392b",
   };
-  const color = colors[name.toLowerCase()] ?? "#999";
+  const color = colors[(name ?? "").toLowerCase()] ?? "#999";
   return `<span class="mt-priority-dash" style="color:${color}">&mdash;</span>`;
 }
 


### PR DESCRIPTION
## Summary

- Guard `r.state.toLowerCase()` in GitHub theme with `(r.state ?? "").toLowerCase()` — prevents crash when a PR review's `state` field is missing from stored JSON
- Guard `name.toLowerCase()` in MantisHub `priorityIndicator` with `(name ?? "").toLowerCase()` — prevents crash when a priority object has no `name` field

Closes #91

## Test plan

- [ ] Verify existing GitHub theme tests still pass
- [ ] Verify existing MantisHub theme tests still pass
- [ ] Confirm a GitHub collection with a PR review missing state renders without crash
- [ ] Confirm a MantisHub collection with a non-standard priority renders without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)