### PR TITLE
Show collection name beside title in manage UI

### DIFF
--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -2978,6 +2978,16 @@ body {
   margin: 0;
   color: var(--text);
 }
+.manage-panel-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.manage-panel-collection-name {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+}
 .manage-panel-subtitle {
   color: var(--text-secondary);
   margin: 0 0 16px;
@@ -3167,10 +3177,21 @@ select.form-input { cursor: pointer; }
 .collection-card-type svg {
   flex-shrink: 0;
 }
+.collection-card-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 6px;
+}
 .collection-card-name {
-  margin: 0 0 6px;
+  margin: 0;
   font-size: 15px;
   font-weight: 500;
+}
+.collection-card-id {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-muted);
 }
 .collection-card-stats {
   display: flex;

--- a/packages/ui/src/components/manage/CollectionDetail.tsx
+++ b/packages/ui/src/components/manage/CollectionDetail.tsx
@@ -344,6 +344,7 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
 
   // Filter MCP tools to only those relevant for this collection
   const hasCloud = !!collection.publish;
+  const showCollectionName = !!collection.title && collection.title !== collection.name;
 
   return (
     <div className="manage-panel">
@@ -353,7 +354,10 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
           <button className="btn btn-sm" onClick={onBack} title="Back to collections">
             &larr; Back
           </button>
-          <h2>{collection.title || collection.name}</h2>
+          <div className="manage-panel-title-row">
+            <h2>{collection.title || collection.name}</h2>
+            {showCollectionName && <span className="manage-panel-collection-name">{collection.name}</span>}
+          </div>
           <span className="collection-card-type">
             <CrawlerIcon type={collection.crawlerType} />
             {CRAWLER_LABELS[collection.crawlerType] ?? collection.crawlerType}

--- a/packages/ui/src/components/manage/CollectionList.tsx
+++ b/packages/ui/src/components/manage/CollectionList.tsx
@@ -147,6 +147,7 @@ export default function CollectionList({ onSelect, onAdd, onSyncComplete, onColl
 
         const renderCard = (col: Collection) => {
           const status = statuses[col.name];
+          const showCollectionName = !!col.title && col.title !== col.name;
           return (
             <div
               key={col.name}
@@ -163,7 +164,10 @@ export default function CollectionList({ onSelect, onAdd, onSyncComplete, onColl
                   {!col.enabled && <span className="status-badge status-failed">Disabled</span>}
                 </div>
               </div>
-              <h3 className="collection-card-name">{col.title || col.name}</h3>
+              <div className="collection-card-title-row">
+                <h3 className="collection-card-name">{col.title || col.name}</h3>
+                {showCollectionName && <span className="collection-card-id">{col.name}</span>}
+              </div>
               {col.description && (
                 <p className="collection-card-desc">{col.description}</p>
               )}


### PR DESCRIPTION
## Summary
- show the collection name as subtle secondary text beside the title in the Manage Collections list
- show the collection name as subtle secondary text beside the title in the Collection Detail header
- keep title emphasis unchanged and avoid duplicate display when title equals name

## Validation
- bun run typecheck

Closes #93
