### PR TITLE
feat: track active sync jobs in parallel (#97)

### DIFF
--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -44,6 +44,11 @@ import { pullCollection } from "./pull";
 
 // --- In-memory sync/publish/export progress tracking ---
 
+/**
+ * Legacy shape retained for the /api/sync/status endpoint. Derived from the
+ * per-collection jobs map so existing consumers keep working while the new
+ * /api/sync/jobs endpoint exposes the full list for parallel tracking.
+ */
 export interface SyncProgress {
   active: boolean;
   collectionName: string | null;
@@ -52,6 +57,19 @@ export interface SyncProgress {
   updated: number;
   deleted: number;
   error: string | null;
+}
+
+export interface SyncJob {
+  collectionName: string;
+  active: boolean;
+  status: string;
+  created: number;
+  updated: number;
+  deleted: number;
+  error: string | null;
+  startedAt: number;
+  completedAt: number | null;
+  full: boolean;
 }
 
 export interface PublishProgress {
@@ -71,15 +89,64 @@ export interface ExportProgress {
   error: string | null;
 }
 
-let syncProgress: SyncProgress = {
-  active: false,
-  collectionName: null,
-  status: "idle",
-  created: 0,
-  updated: 0,
-  deleted: 0,
-  error: null,
-};
+const syncJobs = new Map<string, SyncJob>();
+/** Keep finished jobs around briefly so the UI can render their final state. */
+const JOB_RETENTION_MS = 60_000;
+
+function pruneJobs(): void {
+  const now = Date.now();
+  for (const [name, job] of syncJobs) {
+    if (!job.active && job.completedAt && now - job.completedAt > JOB_RETENTION_MS) {
+      syncJobs.delete(name);
+    }
+  }
+}
+
+function listSyncJobs(): SyncJob[] {
+  pruneJobs();
+  return [...syncJobs.values()].sort((a, b) => a.startedAt - b.startedAt);
+}
+
+/** Derive the legacy singleton shape from the jobs map. */
+function derivedSyncProgress(): SyncProgress {
+  const jobs = listSyncJobs();
+  const active = jobs.filter((j) => j.active);
+  if (active.length > 0) {
+    // Aggregate counts across all active jobs so "Sync All" sees totals.
+    const totals = active.reduce(
+      (acc, j) => ({
+        created: acc.created + j.created,
+        updated: acc.updated + j.updated,
+        deleted: acc.deleted + j.deleted,
+      }),
+      { created: 0, updated: 0, deleted: 0 },
+    );
+    const primary = active[active.length - 1];
+    return {
+      active: true,
+      collectionName: active.length === 1 ? primary.collectionName : null,
+      status: active.length === 1 ? primary.status : `syncing ${active.length} collections`,
+      created: totals.created,
+      updated: totals.updated,
+      deleted: totals.deleted,
+      error: null,
+    };
+  }
+  // No active jobs — surface the most recently completed as the "last result".
+  if (jobs.length === 0) {
+    return { active: false, collectionName: null, status: "idle", created: 0, updated: 0, deleted: 0, error: null };
+  }
+  const last = jobs.reduce((a, b) => ((b.completedAt ?? 0) > (a.completedAt ?? 0) ? b : a));
+  return {
+    active: false,
+    collectionName: last.collectionName,
+    status: last.error ? "failed" : "completed",
+    created: last.created,
+    updated: last.updated,
+    deleted: last.deleted,
+    error: last.error,
+  };
+}
 
 let publishProgress: PublishProgress = {
   active: false,
@@ -365,39 +432,41 @@ export function handleManagementRequest(req: Request): Response | null {
 
   // --- Sync ---
 
-  // POST /api/sync/:name (sync single collection)
+  // POST /api/sync/:name (sync single collection — fire-and-forget)
   const syncOneMatch = path.match(/^\/api\/sync\/([^/]+)$/);
   if (syncOneMatch && method === "POST") {
     const name = decodeURIComponent(syncOneMatch[1]);
-    // Mark active synchronously before any await so that status polls arriving
-    // during body-read don't see the stale idle state and prematurely complete.
-    syncProgress = { active: true, collectionName: name, status: "starting", created: 0, updated: 0, deleted: 0, error: null };
+    // Seed an "active" job synchronously so status polls between the HTTP
+    // response and the actual sync start don't see an idle state.
+    ensureSyncJob(name, false);
     return handleAsync(async () => {
       const body = await readBody(req);
       const full = !!body.full;
-      await triggerSync([name], full);
+      void startSyncJob(name, full);
       return jsonResponse({ ok: true });
     });
   }
 
-  // POST /api/sync (sync all)
+  // POST /api/sync (sync all enabled collections — in parallel)
   if (path === "/api/sync" && method === "POST") {
-    // Mark active synchronously before any await so that status polls arriving
-    // during body-read don't see the stale idle state and prematurely complete.
-    syncProgress = { active: true, collectionName: null, status: "starting", created: 0, updated: 0, deleted: 0, error: null };
+    const enabled = listCollections().filter((c) => c.enabled);
+    for (const c of enabled) ensureSyncJob(c.name, false);
     return handleAsync(async () => {
       const body = await readBody(req);
       const full = !!body.full;
-      const collections = listCollections().filter((c) => c.enabled);
-      const names = collections.map((c) => c.name);
-      await triggerSync(names, full);
-      return jsonResponse({ ok: true });
+      for (const c of enabled) void startSyncJob(c.name, full);
+      return jsonResponse({ ok: true, started: enabled.map((c) => c.name) });
     });
   }
 
-  // GET /api/sync/status
+  // GET /api/sync/status — legacy aggregate view (derived from the jobs map)
   if (path === "/api/sync/status" && method === "GET") {
-    return jsonResponse(syncProgress);
+    return jsonResponse(derivedSyncProgress());
+  }
+
+  // GET /api/sync/jobs — list all active + recently completed sync jobs
+  if (path === "/api/sync/jobs" && method === "GET") {
+    return jsonResponse(listSyncJobs());
   }
 
   // GET /api/collections/:name/sync-runs (returns last sync state wrapped in an array for backward compat)
@@ -650,66 +719,83 @@ function handleAsync(fn: () => Promise<Response>): Response {
 
 // --- Sync logic ---
 
-async function triggerSync(collectionNames: string[], full: boolean): Promise<void> {
-  const home = getFrozenInkHome();
-  const registry = createDefaultRegistry();
-  const themeEngine = createThemeEngine();
-  const prepareThemeEngine = createGenerateThemeEngine();
-
-  syncProgress = {
+/**
+ * Ensure a job slot exists for `name`, seeded in an active/starting state.
+ * Returns null if a sync is already running for this collection (caller
+ * should not start another).
+ */
+function ensureSyncJob(name: string, full: boolean): SyncJob | null {
+  const existing = syncJobs.get(name);
+  if (existing && existing.active) return null;
+  const job: SyncJob = {
+    collectionName: name,
     active: true,
-    collectionName: null,
     status: "starting",
     created: 0,
     updated: 0,
     deleted: 0,
     error: null,
+    startedAt: Date.now(),
+    completedAt: null,
+    full,
   };
+  syncJobs.set(name, job);
+  return job;
+}
 
-  let totalCreated = 0;
-  let totalUpdated = 0;
-  let totalDeleted = 0;
+/**
+ * Serialize post-sync republishes so concurrent sync completions don't
+ * clobber each other's Cloudflare deploys (and the shared publishProgress).
+ */
+let publishChain: Promise<unknown> = Promise.resolve();
+function queuePublish(fn: () => Promise<void>): Promise<void> {
+  const next = publishChain.then(fn, fn);
+  publishChain = next.catch(() => {});
+  return next;
+}
+
+/**
+ * Run a sync for a single collection as a background task. Safe to call
+ * multiple times in parallel with different collection names.
+ */
+async function startSyncJob(name: string, full: boolean): Promise<void> {
+  const job = ensureSyncJob(name, full);
+  if (!job) return; // already running
+  job.full = full;
+
+  const home = getFrozenInkHome();
+  const registry = createDefaultRegistry();
+  const themeEngine = createThemeEngine();
+  const prepareThemeEngine = createGenerateThemeEngine();
 
   try {
-    for (const name of collectionNames) {
-      const col = getCollection(name);
-      if (!col) continue;
+    const col = getCollection(name);
+    if (!col) throw new Error(`Collection "${name}" not found`);
 
-      // Remote/cloned collections use pullCollection — no prepare or crawler needed
-      if (col.crawler === "remote") {
-        syncProgress = { ...syncProgress, collectionName: name, status: `syncing ${name}` };
-        console.log(`[sync:${name}] starting (remote/cloned)`);
-        try {
-          const result = await pullCollection(name, {
-            onProgress: (msg) => {
-              syncProgress = { ...syncProgress, status: msg };
-              console.log(`[sync:${name}] ${msg}`);
-            },
-          });
-          totalCreated += result.created;
-          totalUpdated += result.updated;
-          totalDeleted += result.deleted;
-          syncProgress = { ...syncProgress, created: totalCreated, updated: totalUpdated, deleted: totalDeleted };
-        } catch (err) {
-          console.error(`  Sync failed for "${name}": ${err}`);
-        }
-        continue;
-      }
-
+    // Remote/cloned collections use pullCollection — no prepare or crawler needed
+    if (col.crawler === "remote") {
+      job.status = `syncing ${name}`;
+      console.log(`[sync:${name}] starting (remote/cloned)`);
+      const result = await pullCollection(name, {
+        onProgress: (msg) => {
+          job.status = msg;
+          console.log(`[sync:${name}] ${msg}`);
+        },
+      });
+      job.created = result.created;
+      job.updated = result.updated;
+      job.deleted = result.deleted;
+    } else {
       // Run prepare before incremental sync: schema migrations, folder ymls, stale markdown check
       if (!full) {
-        syncProgress = { ...syncProgress, collectionName: name, status: `preparing ${name}` };
+        job.status = `preparing ${name}`;
         await prepareCollection(col, home, prepareThemeEngine, (msg) => console.log(`[prepare:${name}]`, msg));
       }
 
-      syncProgress = {
-        ...syncProgress,
-        collectionName: name,
-        status: `syncing ${name}`,
-      };
+      job.status = `syncing ${name}`;
 
       const factory = registry.get(col.crawler);
-      if (!factory) continue;
+      if (!factory) throw new Error(`No crawler registered for "${col.crawler}"`);
 
       const crawler = factory();
       try {
@@ -726,7 +812,6 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
         mkdirSync(join(collectionDir, "content"), { recursive: true });
         const storage = new LocalStorageBackend(collectionDir);
 
-        // Full re-sync should match CLI behavior: clear content + DB to start clean.
         if (full) {
           const contentDir = join(collectionDir, "content");
           const dbDir = join(collectionDir, "db");
@@ -734,7 +819,7 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
           if (existsSync(dbDir)) rmSync(dbDir, { recursive: true, force: true });
           mkdirSync(join(collectionDir, "content"), { recursive: true });
           updateCollectionSyncState(getCollectionDbPath(name), { cursor: null });
-          syncProgress = { ...syncProgress, status: `${name}: cleared local data for full re-sync` };
+          job.status = `${name}: cleared local data for full re-sync`;
         }
 
         const engine = new SyncEngine({
@@ -746,65 +831,49 @@ async function triggerSync(collectionNames: string[], full: boolean): Promise<vo
           markdownBasePath: "content",
           assetConfig: col.assets as { extensions?: string[]; maxSize?: number } | undefined,
           onEntityProcessed: (info) => {
-            if (info.created) totalCreated++;
-            if (info.updated) totalUpdated++;
-            syncProgress = {
-              ...syncProgress,
-              created: totalCreated,
-              updated: totalUpdated,
-            };
+            if (info.created) job.created++;
+            if (info.updated) job.updated++;
           },
           onProgress: (msg) => {
-            syncProgress = { ...syncProgress, status: `${name}: ${msg}` };
+            job.status = `${name}: ${msg}`;
             console.log(`[sync:${name}] ${msg}`);
           },
         });
 
         const result = await engine.run({ syncType: full ? "full" : "incremental" });
-        totalDeleted += result.deleted;
-        syncProgress = { ...syncProgress, deleted: totalDeleted };
+        job.deleted = result.deleted;
         console.log(`[sync:${name}] done: +${result.created} ~${result.updated} -${result.deleted}`);
       } finally {
         await crawler.dispose();
       }
+    }
 
-      if (getCollectionPublishState(name)) {
-        console.log(`[sync:${name}] collection is published — republishing`);
-        syncProgress = { ...syncProgress, status: `republishing ${name}: starting` };
+    // Post-sync republish (serialized across collections via queuePublish)
+    if (getCollectionPublishState(name)) {
+      console.log(`[sync:${name}] collection is published — queueing republish`);
+      job.status = `waiting to republish ${name}`;
+      await queuePublish(async () => {
+        job.status = `republishing ${name}: starting`;
         try {
           await triggerPublish({ collectionName: name }, (step, detail) => {
-            // Mirror publish progress into syncProgress so the SyncProgress UI
-            // (which polls /api/sync/status, not /api/publish/status) shows
-            // step-by-step updates during the post-sync republish instead of
-            // appearing frozen on "republishing ${name}".
             const label = detail || step;
-            syncProgress = { ...syncProgress, status: `republishing ${name}: ${label}` };
+            job.status = `republishing ${name}: ${label}`;
           });
         } catch (err) {
           console.error(`[sync:${name}] republish failed: ${err}`);
-          syncProgress = { ...syncProgress, status: `republish failed: ${String(err)}` };
+          job.status = `republish failed: ${String(err)}`;
         }
-      }
+      });
     }
 
-    syncProgress = {
-      active: false,
-      collectionName: null,
-      status: "completed",
-      created: totalCreated,
-      updated: totalUpdated,
-      deleted: totalDeleted,
-      error: null,
-    };
-    console.log(`[sync] completed: +${totalCreated} ~${totalUpdated} -${totalDeleted} across ${collectionNames.length} collection(s)`);
+    job.status = "completed";
   } catch (err) {
-    syncProgress = {
-      ...syncProgress,
-      active: false,
-      status: "failed",
-      error: String(err),
-    };
-    console.error(`[sync] failed: ${err}`);
+    job.error = String(err);
+    job.status = "failed";
+    console.error(`[sync:${name}] failed: ${err}`);
+  } finally {
+    job.active = false;
+    job.completedAt = Date.now();
   }
 }
 

--- a/packages/cli/src/tui/components/App.tsx
+++ b/packages/cli/src/tui/components/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Box, Text, useApp, useInput } from "ink";
 import {
   ensureInitialized,
@@ -8,6 +8,7 @@ import { CollectionList } from "./CollectionList.js";
 import { SyncView } from "./SyncView.js";
 import { SettingsView } from "./SettingsView.js";
 import { SearchView } from "./SearchView.js";
+import { listJobs, subscribe, type TuiSyncJob } from "../sync-jobs.js";
 
 export type Screen =
   | "home"
@@ -30,6 +31,44 @@ const ALL_MENU_ITEMS: MenuItem[] = [
   { key: "f", label: "Search", description: "Full-text search across all synced content", screen: "search", requiresCollections: true },
   { key: "g", label: "Settings", description: "Configure sync interval, concurrency, and logging", screen: "settings" },
 ];
+
+function SyncJobsFooter(): React.ReactElement | null {
+  const [jobs, setJobs] = useState<TuiSyncJob[]>(() => listJobs());
+  useEffect(() => subscribe(() => setJobs(listJobs())), []);
+  useEffect(() => {
+    const id = setInterval(() => setJobs(listJobs()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  if (jobs.length === 0) return null;
+  const active = jobs.filter((j) => j.active);
+  if (active.length === 0) {
+    // Surface the most recently finished job as a one-liner until it's pruned.
+    const last = jobs[jobs.length - 1];
+    const color = last.error ? "red" : "green";
+    return (
+      <Box paddingX={1}>
+        <Text color={color}>
+          ● {last.collectionName}: {last.error ? `failed — ${last.error}` : `done (+${last.created} ~${last.updated} -${last.deleted})`}
+        </Text>
+      </Box>
+    );
+  }
+  return (
+    <Box paddingX={1} flexDirection="column">
+      <Text color="cyan">● {active.length} sync{active.length === 1 ? "" : "s"} running</Text>
+      {active.map((job) => (
+        <Box key={job.collectionName} marginLeft={2} gap={1}>
+          <Text color="cyan">•</Text>
+          <Text bold>{job.collectionName}</Text>
+          <Text dimColor>
+            +{job.created} ~{job.updated} -{job.deleted}
+          </Text>
+          <Text dimColor>— {job.status}</Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}
 
 export function App(): React.ReactElement {
   const { exit } = useApp();
@@ -102,6 +141,7 @@ export function App(): React.ReactElement {
         <Box paddingX={1} marginTop={1}>
           <Text dimColor>↑↓ navigate  Enter select  q quit</Text>
         </Box>
+        <SyncJobsFooter />
       </Box>
     );
   }
@@ -124,6 +164,7 @@ export function App(): React.ReactElement {
       <Box paddingX={1}>
         <Text dimColor>ESC back to menu</Text>
       </Box>
+      <SyncJobsFooter />
     </Box>
   );
 }

--- a/packages/cli/src/tui/components/SyncView.tsx
+++ b/packages/cli/src/tui/components/SyncView.tsx
@@ -1,31 +1,25 @@
 import React, { useState, useCallback, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
-import { existsSync, rmSync } from "fs";
-import { join } from "path";
+import { existsSync } from "fs";
 import {
   ensureInitialized,
   listCollections,
   getCollectionDb,
   getCollectionDbPath,
   getCollectionSyncState,
-  getFrozenInkHome,
   entities,
-  SyncEngine,
-  ThemeEngine,
-  LocalStorageBackend,
 } from "@frozenink/core";
-import {
-  createDefaultRegistry,
-  gitHubTheme,
-  obsidianTheme,
-  gitTheme,
-  mantisHubTheme,
-  rssTheme,
-} from "@frozenink/crawlers";
 import { sql } from "drizzle-orm";
+import {
+  listJobs,
+  startSync,
+  subscribe,
+  isActive,
+  type TuiSyncJob,
+} from "../sync-jobs.js";
 
 type SyncMode = "skip" | "incremental" | "full";
-type ViewMode = "select" | "syncing" | "done";
+type ViewMode = "select" | "syncing";
 
 const W_CHECK = 6;
 const W_NAME = 20;
@@ -79,25 +73,23 @@ function getEntityCount(name: string): string {
   }
 }
 
+/** Subscribe to the shared store and re-render when jobs change. */
+function useJobs(): TuiSyncJob[] {
+  const [snapshot, setSnapshot] = useState<TuiSyncJob[]>(() => listJobs());
+  useEffect(() => subscribe(() => setSnapshot(listJobs())), []);
+  // Tick every second so the elapsed time updates in the UI.
+  useEffect(() => {
+    const id = setInterval(() => setSnapshot(listJobs()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return snapshot;
+}
+
 export function SyncView(): React.ReactElement {
   const [cursor, setCursor] = useState(0);
   const [viewMode, setViewMode] = useState<ViewMode>("select");
-  const [progress, setProgress] = useState<string[]>([]);
   const [syncModes, setSyncModes] = useState<Map<string, SyncMode>>(new Map());
-  const [totalStats, setTotalStats] = useState<{ created: number; updated: number; deleted: number; total: number } | null>(null);
-  const [fetchedCount, setFetchedCount] = useState(0);
-  const [syncingCollection, setSyncingCollection] = useState(false);
-  const [elapsedMs, setElapsedMs] = useState(0);
-  const [syncStartTime, setSyncStartTime] = useState<number | null>(null);
-
-  // Tick elapsed time every second while syncing
-  useEffect(() => {
-    if (syncStartTime === null) return;
-    const interval = setInterval(() => {
-      setElapsedMs(Date.now() - syncStartTime);
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [syncStartTime]);
+  const jobs = useJobs();
 
   ensureInitialized();
   const collections = listCollections().filter((c: { enabled: boolean }) => c.enabled);
@@ -128,115 +120,20 @@ export function SyncView(): React.ReactElement {
     });
   }, []);
 
-  const startSync = useCallback(async () => {
+  const startAll = useCallback(() => {
     const toSync = collections.filter((c: { name: string }) => {
       const m = syncModes.get(c.name);
       return m === "incremental" || m === "full";
     });
-
     if (toSync.length === 0) return;
-
+    for (const c of toSync) {
+      if (isActive(c.name)) continue;
+      startSync(c.name, syncModes.get(c.name) === "full" ? "full" : "incremental");
+    }
     setViewMode("syncing");
-    setProgress([]);
-    setTotalStats(null);
-    setFetchedCount(0);
-    const syncStart = Date.now();
-    setSyncStartTime(syncStart);
-
-    const home = getFrozenInkHome();
-    const registry = createDefaultRegistry();
-    const themeEngine = new ThemeEngine();
-    themeEngine.register(gitHubTheme);
-    themeEngine.register(obsidianTheme);
-    themeEngine.register(gitTheme);
-    themeEngine.register(mantisHubTheme);
-    themeEngine.register(rssTheme);
-
-    let totalCreated = 0;
-    let totalUpdated = 0;
-    let totalDeleted = 0;
-    let totalEntities = 0;
-
-    for (const col of toSync) {
-      const isFullSync = syncModes.get(col.name) === "full";
-      const label = isFullSync ? "full sync" : "sync";
-      setProgress((p) => [...p, `${label}: "${col.name}" (${col.crawler})...`]);
-      setFetchedCount(0);
-      setSyncingCollection(true);
-
-      const factory = registry.get(col.crawler);
-      if (!factory) {
-        setProgress((p) => [...p, `  No crawler for ${col.crawler}, skipping`]);
-        setSyncingCollection(false);
-        continue;
-      }
-
-      const crawler = factory();
-      await crawler.initialize(
-        col.config as Record<string, unknown>,
-        col.credentials as Record<string, unknown>,
-      );
-
-      const dbPath = getCollectionDbPath(col.name);
-      const collectionDir = join(home, "collections", col.name);
-
-      if (isFullSync) {
-        const contentDir = join(collectionDir, "content");
-        const dbDir = join(collectionDir, "db");
-        if (existsSync(contentDir)) rmSync(contentDir, { recursive: true, force: true });
-        if (existsSync(dbDir)) rmSync(dbDir, { recursive: true, force: true });
-        setProgress((p) => [...p, "  Cleared data for full re-sync"]);
-      }
-      const storage = new LocalStorageBackend(collectionDir);
-
-      const engine = new SyncEngine({
-        crawler,
-        dbPath,
-        collectionName: col.name,
-        themeEngine,
-        storage,
-        markdownBasePath: "content",
-        assetConfig: col.assets as { extensions?: string[]; maxSize?: number } | undefined,
-        onBatchFetched: ({ externalIds }: { externalIds: string[] }) => {
-          if (externalIds.length > 0) {
-            setFetchedCount((c) => c + externalIds.length);
-          }
-        },
-        onProgress: (msg: string) => {
-          setProgress((p) => [...p, `  ${msg}`]);
-        },
-      });
-
-      try {
-        const stats = await engine.run();
-        setSyncingCollection(false);
-        const colDb = getCollectionDb(dbPath);
-        const [{ total }] = colDb.select({ total: sql<number>`count(*)` }).from(entities).all();
-        totalCreated += stats.created;
-        totalUpdated += stats.updated;
-        totalDeleted += stats.deleted;
-        totalEntities += total;
-        const colElapsed = formatElapsed(Date.now() - syncStart);
-        setProgress((p) => [...p, `  +${stats.created} ~${stats.updated} -${stats.deleted} (${total} total) in ${colElapsed}`]);
-      } catch (err) {
-        setSyncingCollection(false);
-        const msg = err instanceof Error ? err.message : String(err);
-        setProgress((p) => [...p, `  Error: ${msg}`]);
-      }
-
-      await crawler.dispose();
-    }
-
-    const totalElapsed = Date.now() - syncStart;
-    setElapsedMs(totalElapsed);
-    setSyncStartTime(null); // stop the timer
-
-    // Only show combined totals when multiple collections were synced
-    if (toSync.length > 1) {
-      setTotalStats({ created: totalCreated, updated: totalUpdated, deleted: totalDeleted, total: totalEntities });
-    }
-    setViewMode("done");
-  }, [collections, syncModes]);
+    // Reset selections so a second round starts from a clean slate.
+    setAllMode("skip");
+  }, [collections, syncModes, setAllMode]);
 
   useInput((input, key) => {
     if (viewMode === "select") {
@@ -257,16 +154,11 @@ export function SyncView(): React.ReactElement {
       if (input === "S") setAllMode("incremental");
       if (input === "F") setAllMode("full");
       if (input === "N") setAllMode("skip");
-      if (key.return) startSync();
-    }
-    if (viewMode === "done") {
-      if (key.return || key.escape) {
-        setViewMode("select");
-        setProgress([]);
-        setTotalStats(null);
-        // Reset all to skip
-        setAllMode("skip");
-      }
+      if (key.return) startAll();
+      if (input === "v" && jobs.length > 0) setViewMode("syncing");
+    } else if (viewMode === "syncing") {
+      // [b]ack to selection — jobs keep running in the background.
+      if (input === "b" || key.escape) setViewMode("select");
     }
   });
 
@@ -278,34 +170,60 @@ export function SyncView(): React.ReactElement {
     );
   }
 
-  if (viewMode === "syncing" || viewMode === "done") {
+  if (viewMode === "syncing") {
+    const activeCount = jobs.filter((j) => j.active).length;
     return (
       <Box flexDirection="column" paddingY={1}>
-        <Text bold>{viewMode === "syncing" ? "Syncing..." : "Sync Complete"}</Text>
+        <Text bold>
+          Sync Jobs {activeCount > 0 ? `(${activeCount} running)` : "(all complete)"}
+        </Text>
         <Box flexDirection="column" marginLeft={1} marginTop={1}>
-          {progress.map((line, i) => (
-            <Text key={i} dimColor={viewMode === "done"}>{line}</Text>
-          ))}
-          {syncingCollection && fetchedCount > 0 && (
-            <Text dimColor>  Fetched {fetchedCount} entities... ({formatElapsed(elapsedMs)})</Text>
-          )}
+          {jobs.length === 0 && <Text dimColor>No jobs.</Text>}
+          {jobs.map((job) => {
+            const elapsed = job.active
+              ? Date.now() - job.startedAt
+              : (job.completedAt ?? Date.now()) - job.startedAt;
+            const state = job.active ? "running" : job.error ? "failed" : "done";
+            const stateColor = state === "running" ? "cyan" : state === "failed" ? "red" : "green";
+            return (
+              <Box key={job.collectionName} flexDirection="column" marginBottom={1}>
+                <Box gap={1}>
+                  <Text color={stateColor} bold>●</Text>
+                  <Text bold>{job.collectionName}</Text>
+                  <Text dimColor>({job.crawler}, {job.mode})</Text>
+                  <Text dimColor>{formatElapsed(elapsed)}</Text>
+                </Box>
+                <Box marginLeft={2} gap={2}>
+                  <Text color="green">+{job.created}</Text>
+                  <Text color="yellow">~{job.updated}</Text>
+                  <Text color="red">-{job.deleted}</Text>
+                  {job.fetched > 0 && job.active && (
+                    <Text dimColor>fetched {job.fetched}</Text>
+                  )}
+                </Box>
+                {job.status && (
+                  <Box marginLeft={2}>
+                    <Text dimColor>{job.status}</Text>
+                  </Box>
+                )}
+                {job.error && (
+                  <Box marginLeft={2}>
+                    <Text color="red">{job.error}</Text>
+                  </Box>
+                )}
+              </Box>
+            );
+          })}
         </Box>
-        {totalStats && (
-          <Box marginTop={1} gap={2}>
-            <Text color="green">+{totalStats.created}</Text>
-            <Text color="yellow">~{totalStats.updated}</Text>
-            <Text color="red">-{totalStats.deleted}</Text>
-            <Text dimColor>({totalStats.total} total)</Text>
-          </Box>
-        )}
-        {viewMode === "done" && (
-          <Box marginTop={1}><Text dimColor>Press Enter to continue</Text></Box>
-        )}
+        <Box marginTop={1}>
+          <Text dimColor>[b/ESC] back to selection — jobs keep running</Text>
+        </Box>
       </Box>
     );
   }
 
   const selectedCount = [...syncModes.values()].filter((m) => m !== "skip").length;
+  const activeJobsCount = jobs.filter((j) => j.active).length;
 
   return (
     <Box flexDirection="column" paddingY={1}>
@@ -328,8 +246,9 @@ export function SyncView(): React.ReactElement {
         {collections.map((col: { name: string; title?: string; crawler: string; enabled: boolean }, i: number) => {
           const mode = syncModes.get(col.name) || "skip";
           const selected = i === cursor;
-          const checkbox = mode === "skip" ? "[ ] " : mode === "incremental" ? "[s] " : "[f] ";
-          const checkColor = mode === "skip" ? "gray" : mode === "incremental" ? "green" : "yellow";
+          const running = isActive(col.name);
+          const checkbox = running ? "[~] " : mode === "skip" ? "[ ] " : mode === "incremental" ? "[s] " : "[f] ";
+          const checkColor = running ? "cyan" : mode === "skip" ? "gray" : mode === "incremental" ? "green" : "yellow";
           return (
             <Box key={col.name}>
               <Text color={selected ? "cyan" : undefined}>{selected ? "❯ " : "  "}</Text>
@@ -351,6 +270,11 @@ export function SyncView(): React.ReactElement {
         <Text dimColor>[n] Skip</Text>
         <Text dimColor>[S/F/N] All</Text>
         <Text dimColor>[Enter] Start{selectedCount > 0 ? ` (${selectedCount})` : ""}</Text>
+        {jobs.length > 0 && (
+          <Text color={activeJobsCount > 0 ? "cyan" : "green"}>
+            [v] View jobs ({activeJobsCount > 0 ? `${activeJobsCount} running` : `${jobs.length} recent`})
+          </Text>
+        )}
       </Box>
     </Box>
   );

--- a/packages/cli/src/tui/sync-jobs.ts
+++ b/packages/cli/src/tui/sync-jobs.ts
@@ -1,0 +1,257 @@
+/**
+ * Shared store for TUI sync jobs.
+ *
+ * Holds active and recently completed sync jobs at module scope so that
+ * navigating between TUI screens doesn't cancel them — the work runs in
+ * background promises here, not tied to any React component lifecycle.
+ */
+import { existsSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import {
+  getCollection,
+  getCollectionDbPath,
+  getFrozenInkHome,
+  SyncEngine,
+  ThemeEngine,
+  LocalStorageBackend,
+} from "@frozenink/core";
+import {
+  createDefaultRegistry,
+  gitHubTheme,
+  obsidianTheme,
+  gitTheme,
+  mantisHubTheme,
+  rssTheme,
+} from "@frozenink/crawlers";
+import { pullCollection } from "../commands/pull.js";
+
+export type SyncMode = "incremental" | "full";
+
+export interface TuiSyncJob {
+  collectionName: string;
+  crawler: string;
+  mode: SyncMode;
+  active: boolean;
+  status: string;
+  created: number;
+  updated: number;
+  deleted: number;
+  fetched: number;
+  error: string | null;
+  log: string[];
+  startedAt: number;
+  completedAt: number | null;
+}
+
+const jobs = new Map<string, TuiSyncJob>();
+const JOB_RETENTION_MS = 60_000;
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+export function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+function prune() {
+  const now = Date.now();
+  for (const [name, job] of jobs) {
+    if (!job.active && job.completedAt && now - job.completedAt > JOB_RETENTION_MS) {
+      jobs.delete(name);
+    }
+  }
+}
+
+export function listJobs(): TuiSyncJob[] {
+  prune();
+  return [...jobs.values()].sort((a, b) => a.startedAt - b.startedAt);
+}
+
+export function activeJobCount(): number {
+  prune();
+  let n = 0;
+  for (const j of jobs.values()) if (j.active) n++;
+  return n;
+}
+
+export function getJob(name: string): TuiSyncJob | undefined {
+  return jobs.get(name);
+}
+
+export function isActive(name: string): boolean {
+  const j = jobs.get(name);
+  return !!j && j.active;
+}
+
+export function clearCompletedJobs() {
+  for (const [name, job] of jobs) {
+    if (!job.active) jobs.delete(name);
+  }
+  notify();
+}
+
+function createThemeEngine(): ThemeEngine {
+  const engine = new ThemeEngine();
+  engine.register(gitHubTheme);
+  engine.register(obsidianTheme);
+  engine.register(gitTheme);
+  engine.register(mantisHubTheme);
+  engine.register(rssTheme);
+  return engine;
+}
+
+function pushLog(job: TuiSyncJob, line: string) {
+  job.log.push(line);
+  if (job.log.length > 50) job.log.splice(0, job.log.length - 50);
+}
+
+/**
+ * Start a sync for `name` in the background. If a sync is already running
+ * for that collection, this is a no-op and returns the existing job.
+ */
+export function startSync(name: string, mode: SyncMode): TuiSyncJob {
+  const existing = jobs.get(name);
+  if (existing && existing.active) return existing;
+
+  const col = getCollection(name);
+  if (!col) {
+    const failed: TuiSyncJob = {
+      collectionName: name,
+      crawler: "?",
+      mode,
+      active: false,
+      status: "failed",
+      created: 0,
+      updated: 0,
+      deleted: 0,
+      fetched: 0,
+      error: `Collection "${name}" not found`,
+      log: [],
+      startedAt: Date.now(),
+      completedAt: Date.now(),
+    };
+    jobs.set(name, failed);
+    notify();
+    return failed;
+  }
+
+  const job: TuiSyncJob = {
+    collectionName: name,
+    crawler: col.crawler,
+    mode,
+    active: true,
+    status: "starting",
+    created: 0,
+    updated: 0,
+    deleted: 0,
+    fetched: 0,
+    error: null,
+    log: [],
+    startedAt: Date.now(),
+    completedAt: null,
+  };
+  jobs.set(name, job);
+  notify();
+
+  void runJob(job);
+  return job;
+}
+
+async function runJob(job: TuiSyncJob): Promise<void> {
+  const { collectionName: name, mode } = job;
+  try {
+    const col = getCollection(name);
+    if (!col) throw new Error(`Collection "${name}" not found`);
+
+    if (col.crawler === "remote") {
+      job.status = "syncing (remote)";
+      notify();
+      const result = await pullCollection(name, {
+        onProgress: (msg) => {
+          job.status = msg;
+          pushLog(job, msg);
+          notify();
+        },
+      });
+      job.created = result.created;
+      job.updated = result.updated;
+      job.deleted = result.deleted;
+    } else {
+      const home = getFrozenInkHome();
+      const registry = createDefaultRegistry();
+      const themeEngine = createThemeEngine();
+      const factory = registry.get(col.crawler);
+      if (!factory) throw new Error(`No crawler registered for "${col.crawler}"`);
+
+      const crawler = factory();
+      try {
+        await crawler.initialize(
+          col.config as Record<string, unknown>,
+          col.credentials as Record<string, unknown>,
+        );
+
+        const dbPath = getCollectionDbPath(name);
+        const collectionDir = join(home, "collections", name);
+        mkdirSync(join(collectionDir, "content"), { recursive: true });
+
+        if (mode === "full") {
+          const contentDir = join(collectionDir, "content");
+          const dbDir = join(collectionDir, "db");
+          if (existsSync(contentDir)) rmSync(contentDir, { recursive: true, force: true });
+          if (existsSync(dbDir)) rmSync(dbDir, { recursive: true, force: true });
+          mkdirSync(join(collectionDir, "content"), { recursive: true });
+          job.status = "cleared for full re-sync";
+          pushLog(job, "cleared for full re-sync");
+          notify();
+        }
+
+        const storage = new LocalStorageBackend(collectionDir);
+        const engine = new SyncEngine({
+          crawler,
+          dbPath,
+          collectionName: name,
+          themeEngine,
+          storage,
+          markdownBasePath: "content",
+          assetConfig: col.assets as { extensions?: string[]; maxSize?: number } | undefined,
+          onBatchFetched: ({ externalIds }) => {
+            if (externalIds.length > 0) {
+              job.fetched += externalIds.length;
+              notify();
+            }
+          },
+          onEntityProcessed: (info) => {
+            if (info.created) job.created++;
+            if (info.updated) job.updated++;
+            notify();
+          },
+          onProgress: (msg: string) => {
+            job.status = msg;
+            pushLog(job, msg);
+            notify();
+          },
+        });
+
+        const result = await engine.run({ syncType: mode });
+        job.deleted = result.deleted;
+      } finally {
+        await crawler.dispose();
+      }
+    }
+
+    job.status = "completed";
+  } catch (err) {
+    job.error = err instanceof Error ? err.message : String(err);
+    job.status = "failed";
+    pushLog(job, `error: ${job.error}`);
+  } finally {
+    job.active = false;
+    job.completedAt = Date.now();
+    notify();
+  }
+}

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -3291,6 +3291,73 @@ select.form-input { cursor: pointer; }
 }
 .sync-collection-info strong { font-size: 13px; }
 
+/* Active Syncs (sidebar tracker for parallel sync jobs in Manage mode) */
+.active-syncs {
+  padding: 8px 12px 12px;
+  border-top: 1px solid var(--border);
+  margin-top: 8px;
+}
+.active-syncs-header {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+.active-syncs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.active-sync-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+  font-size: 12px;
+}
+.active-sync-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+.active-sync-name {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+.active-sync-counters {
+  display: flex;
+  gap: 8px;
+  font-size: 11px;
+  align-items: center;
+}
+.active-sync-elapsed {
+  margin-left: auto;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+.active-sync-status {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.active-sync-error {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--callout-danger-border);
+  word-break: break-word;
+}
+
 /* Sync Progress */
 .sync-progress {
   background: var(--bg-secondary);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -17,6 +17,7 @@ import ManageNav, { type ManageSection } from "./components/manage/ManageNav";
 import CollectionList from "./components/manage/CollectionList";
 import CollectionForm from "./components/manage/CollectionForm";
 import CollectionDetail from "./components/manage/CollectionDetail";
+import ActiveSyncs from "./components/manage/ActiveSyncs";
 import type { Collection, TreeNode, AppInfo, UIMode } from "./types";
 
 function loadTheme(): ThemeId {
@@ -922,13 +923,16 @@ export default function App() {
         </>
       )}
       {uiMode === "manage" && canManage && (
-        <ManageNav active={manageSection} onSelect={(section) => {
-          setManageSection(section);
-          // Close any open forms when navigating between manage pages
-          setEditingCollection(null);
-          setAddingCollection(false);
-          setViewingCollection(null);
-        }} />
+        <>
+          <ManageNav active={manageSection} onSelect={(section) => {
+            setManageSection(section);
+            // Close any open forms when navigating between manage pages
+            setEditingCollection(null);
+            setAddingCollection(false);
+            setViewingCollection(null);
+          }} />
+          <ActiveSyncs onJobComplete={triggerRefresh} />
+        </>
       )}
     </>
   );

--- a/packages/ui/src/components/BrowseSyncButton.tsx
+++ b/packages/ui/src/components/BrowseSyncButton.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import type { SyncProgress as SyncProgressType } from "../types";
+import type { SyncJob } from "../types";
 
 interface BrowseSyncButtonProps {
   collectionName: string;
@@ -9,8 +9,9 @@ interface BrowseSyncButtonProps {
 export default function BrowseSyncButton({ collectionName, onSyncComplete }: BrowseSyncButtonProps) {
   const [open, setOpen] = useState(false);
   const [syncing, setSyncing] = useState(false);
-  const [progress, setProgress] = useState<SyncProgressType | null>(null);
+  const [progress, setProgress] = useState<SyncJob | null>(null);
   const intervalRef = useRef<number | null>(null);
+  const hasSeenActiveRef = useRef(false);
 
   useEffect(() => {
     return () => {
@@ -22,6 +23,7 @@ export default function BrowseSyncButton({ collectionName, onSyncComplete }: Bro
     setOpen(true);
     setSyncing(true);
     setProgress(null);
+    hasSeenActiveRef.current = false;
 
     fetch(`/api/sync/${encodeURIComponent(collectionName)}`, {
       method: "POST",
@@ -30,11 +32,14 @@ export default function BrowseSyncButton({ collectionName, onSyncComplete }: Bro
     }).catch(console.error);
 
     const poll = () => {
-      fetch("/api/sync/status")
+      fetch("/api/sync/jobs")
         .then((r) => r.json())
-        .then((data: SyncProgressType) => {
-          setProgress(data);
-          if (!data.active) {
+        .then((jobs: SyncJob[]) => {
+          const job = jobs.find((j) => j.collectionName === collectionName);
+          if (!job) return;
+          setProgress(job);
+          if (job.active) hasSeenActiveRef.current = true;
+          if (!job.active && hasSeenActiveRef.current) {
             if (intervalRef.current) clearInterval(intervalRef.current);
             setSyncing(false);
             onSyncComplete?.();
@@ -87,6 +92,7 @@ export default function BrowseSyncButton({ collectionName, onSyncComplete }: Bro
                     <span className={`status-badge status-${progress.active ? "running" : progress.error ? "failed" : "completed"}`}>
                       {progress.active ? "Syncing" : progress.error ? "Failed" : "Done"}
                     </span>
+                    <span className="sync-progress-collection">{progress.collectionName}</span>
                   </div>
                   <div className="sync-progress-counters">
                     <span className="counter counter-created">{progress.created} created</span>

--- a/packages/ui/src/components/manage/ActiveSyncs.tsx
+++ b/packages/ui/src/components/manage/ActiveSyncs.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from "react";
+import type { SyncJob } from "../../types";
+
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}m ${sec}s`;
+}
+
+interface ActiveSyncsProps {
+  /** Called when a job transitions from active to completed so the parent can refresh stats. */
+  onJobComplete?: (job: SyncJob) => void;
+}
+
+export default function ActiveSyncs({ onJobComplete }: ActiveSyncsProps) {
+  const [jobs, setJobs] = useState<SyncJob[]>([]);
+  const [now, setNow] = useState(Date.now());
+  const seenActiveRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const tick = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(tick);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const res = await fetch("/api/sync/jobs");
+        if (!res.ok) return;
+        const data: SyncJob[] = await res.json();
+        if (cancelled) return;
+        // Detect completions: any job that was previously active and is no longer
+        const seen = seenActiveRef.current;
+        for (const job of data) {
+          if (job.active) {
+            seen.add(job.collectionName);
+          } else if (seen.has(job.collectionName)) {
+            seen.delete(job.collectionName);
+            onJobComplete?.(job);
+          }
+        }
+        setJobs(data);
+      } catch {}
+    };
+
+    poll();
+    const id = window.setInterval(poll, 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [onJobComplete]);
+
+  if (jobs.length === 0) return null;
+
+  return (
+    <div className="active-syncs">
+      <div className="active-syncs-header">Active Syncs</div>
+      <div className="active-syncs-list">
+        {jobs.map((job) => {
+          const elapsed = job.active
+            ? now - job.startedAt
+            : (job.completedAt ?? now) - job.startedAt;
+          const state = job.active ? "running" : job.error ? "failed" : "completed";
+          return (
+            <div key={job.collectionName} className="active-sync-card">
+              <div className="active-sync-row">
+                <span className="active-sync-name" title={job.collectionName}>
+                  {job.collectionName}
+                </span>
+                <span className={`status-badge status-${state}`}>
+                  {job.active ? "Syncing" : job.error ? "Failed" : "Done"}
+                </span>
+              </div>
+              <div className="active-sync-counters">
+                <span className="counter counter-created">+{job.created}</span>
+                <span className="counter counter-updated">~{job.updated}</span>
+                <span className="counter counter-deleted">−{job.deleted}</span>
+                <span className="active-sync-elapsed">{formatElapsed(elapsed)}</span>
+              </div>
+              {job.status && job.status !== "idle" && (
+                <div className="active-sync-status" title={job.status}>
+                  {job.status}
+                </div>
+              )}
+              {job.error && <div className="active-sync-error">{job.error}</div>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/manage/CollectionDetail.tsx
+++ b/packages/ui/src/components/manage/CollectionDetail.tsx
@@ -418,7 +418,7 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
             </>
           )}
         </div>
-        {syncing && <SyncProgress onComplete={handleSyncComplete} />}
+        {syncing && <SyncProgress collectionName={name} onComplete={handleSyncComplete} />}
         {!syncing && lastSyncResult && (
           <div className="sync-result" style={{ marginTop: 8 }}>
             {lastSyncResult.error ? (

--- a/packages/ui/src/components/manage/SyncProgress.tsx
+++ b/packages/ui/src/components/manage/SyncProgress.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import type { SyncProgress as SyncProgressType } from "../../types";
+import type { SyncJob } from "../../types";
 
 export interface SyncResult {
   created: number;
@@ -9,34 +9,96 @@ export interface SyncResult {
 }
 
 interface SyncProgressProps {
+  /** When provided, only track this collection's job. When omitted, aggregate across all jobs. */
+  collectionName?: string;
   onComplete: (result: SyncResult) => void;
 }
 
-export default function SyncProgress({ onComplete }: SyncProgressProps) {
-  const [progress, setProgress] = useState<SyncProgressType | null>(null);
+interface AggregateView {
+  active: boolean;
+  collectionName: string | null;
+  status: string;
+  created: number;
+  updated: number;
+  deleted: number;
+  error: string | null;
+}
+
+function aggregate(jobs: SyncJob[]): AggregateView {
+  if (jobs.length === 0) {
+    return { active: false, collectionName: null, status: "idle", created: 0, updated: 0, deleted: 0, error: null };
+  }
+  const active = jobs.filter((j) => j.active);
+  const totals = jobs.reduce(
+    (acc, j) => ({
+      created: acc.created + j.created,
+      updated: acc.updated + j.updated,
+      deleted: acc.deleted + j.deleted,
+    }),
+    { created: 0, updated: 0, deleted: 0 },
+  );
+  if (active.length > 0) {
+    return {
+      active: true,
+      collectionName: active.length === 1 ? active[0].collectionName : null,
+      status: active.length === 1 ? active[0].status : `syncing ${active.length} collections`,
+      created: totals.created,
+      updated: totals.updated,
+      deleted: totals.deleted,
+      error: null,
+    };
+  }
+  const firstError = jobs.find((j) => j.error)?.error ?? null;
+  return {
+    active: false,
+    collectionName: null,
+    status: firstError ? "failed" : "completed",
+    created: totals.created,
+    updated: totals.updated,
+    deleted: totals.deleted,
+    error: firstError,
+  };
+}
+
+function singleJobView(job: SyncJob): AggregateView {
+  return {
+    active: job.active,
+    collectionName: job.collectionName,
+    status: job.status,
+    created: job.created,
+    updated: job.updated,
+    deleted: job.deleted,
+    error: job.error,
+  };
+}
+
+export default function SyncProgress({ collectionName, onComplete }: SyncProgressProps) {
+  const [view, setView] = useState<AggregateView | null>(null);
   const intervalRef = useRef<number | null>(null);
-  // Guard against the race where the first poll returns active:false (initial
-  // idle state) before the server has marked the sync as started.  Only fire
-  // onComplete after we have seen at least one active:true response so we know
-  // a real sync run has begun and then finished.
+  // Guard against the race where the first poll returns no active jobs
+  // (idle initial state) before the server has registered the new job.
   const hasSeenActiveRef = useRef(false);
 
   useEffect(() => {
     const poll = () => {
-      fetch("/api/sync/status")
+      fetch("/api/sync/jobs")
         .then((r) => r.json())
-        .then((data: SyncProgressType) => {
-          setProgress(data);
-          if (data.active) {
-            hasSeenActiveRef.current = true;
-          }
-          if (!data.active && hasSeenActiveRef.current) {
+        .then((jobs: SyncJob[]) => {
+          const scoped = collectionName
+            ? jobs.filter((j) => j.collectionName === collectionName)
+            : jobs;
+          const next = collectionName && scoped.length > 0
+            ? singleJobView(scoped[0])
+            : aggregate(scoped);
+          setView(next);
+          if (next.active) hasSeenActiveRef.current = true;
+          if (!next.active && hasSeenActiveRef.current) {
             if (intervalRef.current) clearInterval(intervalRef.current);
             onComplete({
-              created: data.created,
-              updated: data.updated,
-              deleted: data.deleted,
-              error: data.error,
+              created: next.created,
+              updated: next.updated,
+              deleted: next.deleted,
+              error: next.error,
             });
           }
         })
@@ -49,30 +111,30 @@ export default function SyncProgress({ onComplete }: SyncProgressProps) {
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [onComplete]);
+  }, [collectionName, onComplete]);
 
-  if (!progress) return null;
+  if (!view) return null;
 
   return (
     <div className="sync-progress">
       <div className="sync-progress-header">
-        <span className={`status-badge status-${progress.active ? "running" : progress.error ? "failed" : "completed"}`}>
-          {progress.active ? "Syncing" : progress.error ? "Failed" : "Done"}
+        <span className={`status-badge status-${view.active ? "running" : view.error ? "failed" : "completed"}`}>
+          {view.active ? "Syncing" : view.error ? "Failed" : "Done"}
         </span>
-        {progress.collectionName && (
-          <span className="sync-progress-collection">{progress.collectionName}</span>
+        {view.collectionName && (
+          <span className="sync-progress-collection">{view.collectionName}</span>
         )}
       </div>
       <div className="sync-progress-counters">
-        <span className="counter counter-created">{progress.created} created</span>
-        <span className="counter counter-updated">{progress.updated} updated</span>
-        <span className="counter counter-deleted">{progress.deleted} deleted</span>
+        <span className="counter counter-created">{view.created} created</span>
+        <span className="counter counter-updated">{view.updated} updated</span>
+        <span className="counter counter-deleted">{view.deleted} deleted</span>
       </div>
-      {progress.status && progress.status !== "idle" && (
-        <div className="sync-progress-status">{progress.status}</div>
+      {view.status && view.status !== "idle" && (
+        <div className="sync-progress-status">{view.status}</div>
       )}
-      {progress.error && (
-        <div className="form-error">{progress.error}</div>
+      {view.error && (
+        <div className="form-error">{view.error}</div>
       )}
     </div>
   );

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -103,6 +103,19 @@ export interface SyncProgress {
   error: string | null;
 }
 
+export interface SyncJob {
+  collectionName: string;
+  active: boolean;
+  status: string;
+  created: number;
+  updated: number;
+  deleted: number;
+  error: string | null;
+  startedAt: number;
+  completedAt: number | null;
+  full: boolean;
+}
+
 export interface ExportRequest {
   collections: string[];
   outputDir: string;


### PR DESCRIPTION
## Summary

Closes #97. Replaces the global singleton sync progress with a per-collection job map so multiple syncs can run in parallel, and surfaces them in dedicated trackers in both Desktop and TUI.

### Backend (`management-api.ts`)
- New `SyncJob` shape held in `Map<string, SyncJob>` (60s retention for completed jobs)
- `POST /api/sync/:name` and `POST /api/sync` are now fire-and-forget; "Sync All" launches one job per enabled collection in parallel
- New `GET /api/sync/jobs` lists active + recently completed jobs; legacy `GET /api/sync/status` still works as a derived aggregate
- Post-sync republishes are serialized through a publish queue so concurrent completions don't clobber the shared `publishProgress` / Cloudflare deploys

### Desktop UI
- New `ActiveSyncs` panel mounted in the sidebar when Manage mode is active — one card per job with status, +created/~updated/−deleted counters, elapsed time, and errors
- `SyncProgress` and `BrowseSyncButton` now poll `/api/sync/jobs` filtered by collection name so concurrent syncs no longer mask each other
- New `SyncJob` type + sidebar CSS

### TUI
- New `packages/cli/src/tui/sync-jobs.ts` shared store holding jobs at module scope so background work survives screen navigation
- `SyncView` dispatches to the store (parallel), flips to a live job-list subview, and `[b]`/ESC returns to selection without cancelling work
- `SyncJobsFooter` rendered on every TUI screen so running/last-completed jobs are always visible

## Test plan
- [x] `bun run ci` (markdown lint, typecheck, core/crawlers/mcp tests, UI vitest, UI build, worker build) passes
- [ ] Manual: trigger two collection syncs back-to-back in Desktop Manage mode and confirm both progress cards appear in the sidebar and persist while navigating between Manage screens
- [ ] Manual: in `fink tui`, start parallel syncs from the Sync screen, navigate to Home/Collections, and confirm the footer continues to update
- [ ] Manual: a single-collection sync from CollectionDetail still shows inline progress and refreshes stats on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)