### PR TITLE
fix: add entity context for mantishub sync errors

### DIFF
--- a/packages/core/src/crawler/__tests__/sync-engine.test.ts
+++ b/packages/core/src/crawler/__tests__/sync-engine.test.ts
@@ -152,6 +152,48 @@ describe("SyncEngine", () => {
     expect(row.contentHash!.length).toBe(64);
   });
 
+  it("adds entity context to per-entity processing errors", async () => {
+    themeEngine = new ThemeEngine();
+    themeEngine.register({
+      crawlerType: "mock",
+      render(): string {
+        throw new Error("render failed");
+      },
+      getFilePath(ctx: ThemeRenderContext): string {
+        return `${ctx.entity.entityType}/${ctx.entity.externalId}.md`;
+      },
+    });
+
+    const crawler = createMockCrawler([
+      {
+        entities: [
+          {
+            externalId: "item-404",
+            entityType: "issue",
+            title: "Broken",
+            data: { body: "bad" },
+          },
+        ],
+        nextCursor: null,
+        hasMore: false,
+        deletedExternalIds: [],
+      },
+    ]);
+
+    const engine = new SyncEngine({
+      crawler,
+      dbPath: join(TEST_DIR, "entity-context.db"),
+      collectionName: "test",
+      themeEngine,
+      storage,
+      markdownBasePath: "md",
+    });
+
+    await expect(engine.run()).rejects.toThrow(
+      "Failed to process entity type=issue id=item-404: render failed",
+    );
+  });
+
   it("skips re-render when content hash is unchanged", async () => {
     const entityData = {
       externalId: "skip-1",

--- a/packages/core/src/crawler/sync-engine.ts
+++ b/packages/core/src/crawler/sync-engine.ts
@@ -29,6 +29,21 @@ function isToolPath(filePath: string): boolean {
   return filePath.split("/").some((segment) => segment.startsWith("."));
 }
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function withEntityContext(err: unknown, entity: Pick<CrawlerEntityData, "entityType" | "externalId">): Error {
+  const context = `entity type=${entity.entityType} id=${entity.externalId}`;
+  const message = errorMessage(err);
+  if (message.includes(context)) {
+    return err instanceof Error ? err : new Error(message);
+  }
+  const wrapped = new Error(`Failed to process ${context}: ${message}`);
+  (wrapped as Error & { cause?: unknown }).cause = err;
+  return wrapped;
+}
+
 
 /**
  * Extract internal link targets from rendered markdown.
@@ -241,9 +256,20 @@ export class SyncEngine {
         });
 
         // Process entities (links are deferred until all entities exist)
-        const deferredLinks: Array<{ entityId: number; markdown: string; markdownPath?: string }> = [];
+        const deferredLinks: Array<{
+          entityId: number;
+          entityType: string;
+          externalId: string;
+          markdown: string;
+          markdownPath?: string;
+        }> = [];
         for (const entityData of result.entities) {
-          const counts = await this.upsertEntity(entityData, crawlerType, deferredLinks);
+          let counts: { created: number; updated: number };
+          try {
+            counts = await this.upsertEntity(entityData, crawlerType, deferredLinks);
+          } catch (err) {
+            throw withEntityContext(err, entityData);
+          }
           created += counts.created;
           updated += counts.updated;
           this.onEntityProcessed?.({
@@ -255,9 +281,13 @@ export class SyncEngine {
         }
 
         // Sync links now that all entities in the batch exist
-        for (const { entityId, markdown, markdownPath } of deferredLinks) {
-          this.syncLinks(entityId, markdown, markdownPath);
-          this.recomputeHash(entityId);
+        for (const { entityId, entityType, externalId, markdown, markdownPath } of deferredLinks) {
+          try {
+            this.syncLinks(entityId, markdown, markdownPath);
+            this.recomputeHash(entityId);
+          } catch (err) {
+            throw withEntityContext(err, { entityType, externalId });
+          }
         }
 
         // Handle deletions
@@ -356,7 +386,13 @@ export class SyncEngine {
   private async upsertEntity(
     entityData: CrawlerEntityData,
     crawlerType: string,
-    deferredLinks?: Array<{ entityId: number; markdown: string; markdownPath?: string }>,
+    deferredLinks?: Array<{
+      entityId: number;
+      entityType: string;
+      externalId: string;
+      markdown: string;
+      markdownPath?: string;
+    }>,
   ): Promise<{ created: number; updated: number }> {
     // Build initial EntityData with source from the crawler
     const initialData: EntityData = {
@@ -474,7 +510,13 @@ export class SyncEngine {
 
       // Defer link syncing until all entities in the batch exist
       if (deferredLinks) {
-        deferredLinks.push({ entityId: existing.id, markdown, markdownPath: filePath });
+        deferredLinks.push({
+          entityId: existing.id,
+          entityType: entityData.entityType,
+          externalId: entityData.externalId,
+          markdown,
+          markdownPath: filePath,
+        });
       } else {
         this.syncLinks(existing.id, markdown, filePath);
         this.recomputeHash(existing.id);
@@ -535,7 +577,13 @@ export class SyncEngine {
 
     // Defer link syncing until all entities in the batch exist
     if (deferredLinks) {
-      deferredLinks.push({ entityId: inserted.id, markdown, markdownPath: filePath });
+      deferredLinks.push({
+        entityId: inserted.id,
+        entityType: entityData.entityType,
+        externalId: entityData.externalId,
+        markdown,
+        markdownPath: filePath,
+      });
     } else {
       this.syncLinks(inserted.id, markdown, filePath);
       this.recomputeHash(inserted.id);
@@ -780,64 +828,68 @@ export class SyncEngine {
   private async reRenderAllEntities(crawlerType: string): Promise<void> {
     const allEntities = this.db.select().from(entities).all();
     for (const row of allEntities) {
-      const rowData = (row.data as EntityData) ?? { source: {} };
-      // Re-derive title from stored data via the theme (no API call needed).
-      const derivedTitle = this.themeEngine.getTitle({
-        entity: {
+      try {
+        const rowData = (row.data as EntityData) ?? { source: {} };
+        // Re-derive title from stored data via the theme (no API call needed).
+        const derivedTitle = this.themeEngine.getTitle({
+          entity: {
+            externalId: row.externalId,
+            entityType: row.entityType,
+            title: row.title,
+            data: rowData.source,
+            url: rowData.url ?? undefined,
+          },
+          collectionName: this.collectionName,
+          crawlerType,
+        });
+        const title = derivedTitle ?? row.title;
+
+        const entityData: CrawlerEntityData = {
           externalId: row.externalId,
           entityType: row.entityType,
-          title: row.title,
+          title,
           data: rowData.source,
           url: rowData.url ?? undefined,
-        },
-        collectionName: this.collectionName,
-        crawlerType,
-      });
-      const title = derivedTitle ?? row.title;
+        };
+        const markdown = this.renderMarkdown(entityData, crawlerType);
+        const filePath = this.getMarkdownPath(entityData, crawlerType);
+        const storagePath = this.toStoragePath(filePath);
+        await this.storage.write(storagePath, markdown);
 
-      const entityData: CrawlerEntityData = {
-        externalId: row.externalId,
-        entityType: row.entityType,
-        title,
-        data: rowData.source,
-        url: rowData.url ?? undefined,
-      };
-      const markdown = this.renderMarkdown(entityData, crawlerType);
-      const filePath = this.getMarkdownPath(entityData, crawlerType);
-      const storagePath = this.toStoragePath(filePath);
-      await this.storage.write(storagePath, markdown);
+        const lastSlashR = filePath.lastIndexOf("/");
+        const reFolder = lastSlashR >= 0 ? filePath.slice(0, lastSlashR) : "";
+        const reSlug = filePath.slice(lastSlashR + 1).replace(/\.md$/, "");
 
-      const lastSlashR = filePath.lastIndexOf("/");
-      const reFolder = lastSlashR >= 0 ? filePath.slice(0, lastSlashR) : "";
-      const reSlug = filePath.slice(lastSlashR + 1).replace(/\.md$/, "");
+        // Delete old file if path changed
+        const oldPath = row.folder != null && row.slug != null
+          ? (row.folder ? `${row.folder}/${row.slug}.md` : `${row.slug}.md`)
+          : null;
+        if (oldPath && oldPath !== filePath) {
+          try { await this.storage.delete(this.toStoragePath(oldPath)); } catch { /* ignore */ }
+        }
 
-      // Delete old file if path changed
-      const oldPath = row.folder != null && row.slug != null
-        ? (row.folder ? `${row.folder}/${row.slug}.md` : `${row.slug}.md`)
-        : null;
-      if (oldPath && oldPath !== filePath) {
-        try { await this.storage.delete(this.toStoragePath(oldPath)); } catch { /* ignore */ }
+        this.db
+          .update(entities)
+          .set({ title, folder: reFolder, slug: reSlug })
+          .where(eq(entities.id, row.id))
+          .run();
+
+        // Re-sync wikilinks
+        this.syncLinks(row.id, markdown, filePath);
+        this.recomputeHash(row.id);
+
+        // Update search index
+        this.searchIndexer.updateIndex({
+          id: row.id,
+          externalId: row.externalId,
+          entityType: row.entityType,
+          title,
+          content: markdown,
+          tags: [],
+        });
+      } catch (err) {
+        throw withEntityContext(err, { entityType: row.entityType, externalId: row.externalId });
       }
-
-      this.db
-        .update(entities)
-        .set({ title, folder: reFolder, slug: reSlug })
-        .where(eq(entities.id, row.id))
-        .run();
-
-      // Re-sync wikilinks
-      this.syncLinks(row.id, markdown, filePath);
-      this.recomputeHash(row.id);
-
-      // Update search index
-      this.searchIndexer.updateIndex({
-        id: row.id,
-        externalId: row.externalId,
-        entityType: row.entityType,
-        title,
-        content: markdown,
-        tags: [],
-      });
     }
   }
 

--- a/packages/crawlers/src/mantishub/__tests__/crawler.test.ts
+++ b/packages/crawlers/src/mantishub/__tests__/crawler.test.ts
@@ -157,6 +157,18 @@ describe("MantisHubCrawler", () => {
     expect(result.entities[0].externalId).toBe("issue:9");
   });
 
+  it("rejects issues missing the required summary field with entity context", async () => {
+    crawler.setFetch(routingFetch(async () => {
+      return jsonResponse({
+        issues: [sampleIssue({ id: 7, summary: "" })],
+      });
+    }));
+
+    await expect(crawler.sync(null)).rejects.toThrow(
+      'Invalid issue entity id=7: missing required field "summary"',
+    );
+  });
+
   it("ignores legacy page-only cursor and restarts from page 1", async () => {
     let requestedUrl = "";
     crawler.setFetch(async (input: string | URL | Request) => {

--- a/packages/crawlers/src/mantishub/crawler.ts
+++ b/packages/crawlers/src/mantishub/crawler.ts
@@ -81,6 +81,11 @@ function slugify(text: string): string {
     .slice(0, 60);
 }
 
+function requiredString(value: unknown, entityType: string, id: string | number, field: string): string {
+  if (typeof value === "string" && value.trim()) return value;
+  throw new Error(`Invalid ${entityType} entity id=${id}: missing required field "${field}"`);
+}
+
 /** Detect MantisHub instances by URL pattern. */
 function isMantisHub(baseUrl: string): boolean {
   return baseUrl.includes(".mantishub.");
@@ -712,17 +717,18 @@ export class MantisHubCrawler implements Crawler {
   }
 
   private buildUserEntity(user: MantisHubUser): CrawlerEntityData {
+    const username = requiredString(user.name, "user", user.id, "name");
     const avatarUrl = user.avatar?.attr?.src ?? null;
-    const displayName = user.real_name ? `${user.real_name} (@${user.name})` : user.name;
+    const displayName = user.real_name ? `${user.real_name} (@${username})` : username;
     return {
-      externalId: `user:${user.name}`,
+      externalId: `user:${username}`,
       entityType: "user",
       title: displayName,
-      url: `${this.baseUrl}/user_summary_page.php?username=${encodeURIComponent(user.name)}`,
+      url: `${this.baseUrl}/user_summary_page.php?username=${encodeURIComponent(username)}`,
       tags: ["user"],
       data: {
         id: user.id,
-        name: user.name,
+        name: username,
         realName: user.real_name ?? null,
         email: user.email ?? null,
         avatarUrl,
@@ -731,15 +737,16 @@ export class MantisHubCrawler implements Crawler {
   }
 
   private buildProjectEntity(project: { id: number; name: string; categories: string[] }): CrawlerEntityData {
+    const name = requiredString(project.name, "project", project.id, "name");
     return {
       externalId: `project:${project.id}`,
       entityType: "project",
-      title: project.name,
+      title: name,
       url: `${this.baseUrl}/set_project.php?project_id=${project.id}`,
       tags: ["project"],
       data: {
         id: project.id,
-        name: project.name,
+        name,
         categories: project.categories,
       },
     };
@@ -963,6 +970,7 @@ export class MantisHubCrawler implements Crawler {
     page: MantisHubPage,
     files: MantisHubPageFile[],
   ): Promise<CrawlerEntityData> {
+    const pageName = requiredString(page.name, "page", page.id, "name");
     const hasher = createCryptoHasher("sha256");
     hasher.update(JSON.stringify({ page, files }));
     const contentHash = hasher.digest("hex");
@@ -1006,18 +1014,17 @@ export class MantisHubCrawler implements Crawler {
     }
 
     const projectId = page.project?.id;
-    const pageName = page.name;
     const pageUrl = `${this.baseUrl}/plugin.php?page=Pages/view&project_id=${projectId}&name=${encodeURIComponent(pageName)}`;
 
     return {
       externalId: `page:${projectId}:${pageName}`,
       entityType: "page",
-      title: page.title || page.name,
+      title: page.title || pageName,
       contentHash,
       url: pageUrl,
       data: {
         id: page.id,
-        name: page.name,
+        name: pageName,
         title: page.title,
         content: page.content ?? "",
         project: page.project,
@@ -1130,6 +1137,7 @@ export class MantisHubCrawler implements Crawler {
   }
 
   private async buildIssueEntity(issue: MantisHubIssue): Promise<CrawlerEntityData> {
+    const summary = requiredString(issue.summary, "issue", issue.id, "summary");
     const hasher = createCryptoHasher("sha256");
     hasher.update(JSON.stringify(issue));
     const contentHash = hasher.digest("hex");
@@ -1255,12 +1263,12 @@ export class MantisHubCrawler implements Crawler {
     return {
       externalId: `issue:${issue.id}`,
       entityType: "issue",
-      title: `${padId(issue.id)}: ${issue.summary}`,
+      title: `${padId(issue.id)}: ${summary}`,
       contentHash,
       url: `${this.baseUrl}/view.php?id=${issue.id}`,
       data: {
         id: issue.id,
-        summary: issue.summary,
+        summary,
         description: issue.description ?? "",
         stepsToReproduce: issue.steps_to_reproduce ?? "",
         additionalInformation: issue.additional_information ?? "",

--- a/packages/crawlers/src/mantishub/theme.ts
+++ b/packages/crawlers/src/mantishub/theme.ts
@@ -9,6 +9,12 @@ function slugify(text: string): string {
     .slice(0, 60);
 }
 
+function requiredDataString(context: ThemeRenderContext, field: string): string {
+  const value = context.entity.data[field];
+  if (typeof value === "string" && value.trim()) return value;
+  throw new Error(`Missing required field "${field}"`);
+}
+
 function padId(id: number): string {
   return String(id).padStart(5, "0");
 }
@@ -544,26 +550,26 @@ export class MantisHubTheme implements Theme {
     const d = context.entity.data;
 
     if (context.entity.entityType === "user") {
-      const name = d.name as string;
+      const name = requiredDataString(context, "name");
       return `users/${slugify(name)}.md`;
     }
 
     if (context.entity.entityType === "project") {
-      const name = d.name as string;
-      const slug = slugify(name) || "unnamed";
+      const name = requiredDataString(context, "name");
+      const slug = slugify(name);
       // Project entity lives inside its own project folder so every project's
       // issues/pages/metadata nest together under one subtree.
       return `${slug}/${slug}.md`;
     }
 
     if (context.entity.entityType === "page") {
-      const name = d.name as string;
+      const name = requiredDataString(context, "name");
       const projectName = (d.project as { name: string })?.name;
       return `${pageFilePath(name, projectName)}.md`;
     }
 
     const id = d.id as number;
-    const summary = d.summary as string;
+    const summary = requiredDataString(context, "summary");
     const projectName = (d.project as { name: string })?.name;
     return `${issueFilePath(id, summary, projectName)}.md`;
   }
@@ -579,18 +585,18 @@ export class MantisHubTheme implements Theme {
     const d = context.entity.data;
     switch (context.entity.entityType) {
       case "issue":
-        return d.id != null && d.summary != null
-          ? `${padId(d.id as number)}: ${d.summary as string}`
+        return d.id != null
+          ? `${padId(d.id as number)}: ${requiredDataString(context, "summary")}`
           : undefined;
       case "page":
-        return ((d.title || d.name) as string) || undefined;
+        return ((d.title as string | undefined)?.trim() || requiredDataString(context, "name"));
       case "user": {
         const realName = d.realName as string | null;
-        const name = d.name as string;
+        const name = requiredDataString(context, "name");
         return realName ? `${realName} (@${name})` : name;
       }
       case "project":
-        return (d.name as string) || undefined;
+        return requiredDataString(context, "name");
       default:
         return undefined;
     }


### PR DESCRIPTION
## Summary
- add sync-engine error wrapping so per-entity failures include the entity type and external id
- reject MantisHub issue/page/user/project entities when required source fields are blank instead of silently deriving empty names
- add focused tests for the new sync error context and required summary validation

## Testing
- bun run ci
