### PR TITLE
Resumable sync with per-entity error journal

### DIFF
--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -23,6 +23,7 @@ import {
   ThemeEngine,
   LocalStorageBackend,
   entities,
+  syncErrors,
   resolveCredentials,
   listNamedCredentials,
   getNamedCredentials,
@@ -57,6 +58,10 @@ export interface SyncProgress {
   updated: number;
   deleted: number;
   error: string | null;
+  /** Per-entity recoverable failures from the sync_errors journal. */
+  errorCount?: number;
+  /** Reason a sync ended unsuccessfully (rate_limit / fatal). */
+  failureReason?: string | null;
 }
 
 export interface SyncJob {
@@ -70,6 +75,10 @@ export interface SyncJob {
   startedAt: number;
   completedAt: number | null;
   full: boolean;
+  /** Per-entity recoverable failures from the sync_errors journal. */
+  errorCount?: number;
+  /** Reason a sync ended unsuccessfully (rate_limit / fatal). */
+  failureReason?: string | null;
 }
 
 export interface PublishProgress {
@@ -118,8 +127,9 @@ function derivedSyncProgress(): SyncProgress {
         created: acc.created + j.created,
         updated: acc.updated + j.updated,
         deleted: acc.deleted + j.deleted,
+        errorCount: acc.errorCount + (j.errorCount ?? 0),
       }),
-      { created: 0, updated: 0, deleted: 0 },
+      { created: 0, updated: 0, deleted: 0, errorCount: 0 },
     );
     const primary = active[active.length - 1];
     return {
@@ -130,6 +140,8 @@ function derivedSyncProgress(): SyncProgress {
       updated: totals.updated,
       deleted: totals.deleted,
       error: null,
+      errorCount: totals.errorCount,
+      failureReason: active.length === 1 ? primary.failureReason ?? null : null,
     };
   }
   // No active jobs — surface the most recently completed as the "last result".
@@ -145,6 +157,8 @@ function derivedSyncProgress(): SyncProgress {
     updated: last.updated,
     deleted: last.deleted,
     error: last.error,
+    errorCount: last.errorCount ?? 0,
+    failureReason: last.failureReason ?? null,
   };
 }
 
@@ -426,6 +440,8 @@ export function handleManagementRequest(req: Request): Response | null {
         entitiesUpdated: sync.lastUpdated ?? 0,
         entitiesDeleted: sync.lastDeleted ?? 0,
         errors: sync.lastErrors ?? null,
+        errorCount: sync.errorCount ?? 0,
+        failureReason: sync.failureReason ?? null,
       } : null,
     });
   }
@@ -467,6 +483,35 @@ export function handleManagementRequest(req: Request): Response | null {
   // GET /api/sync/jobs — list all active + recently completed sync jobs
   if (path === "/api/sync/jobs" && method === "GET") {
     return jsonResponse(listSyncJobs());
+  }
+
+  // GET /api/collections/:name/sync-errors — list per-entity failures from the journal
+  const syncErrorsMatch = path.match(/^\/api\/collections\/([^/]+)\/sync-errors$/);
+  if (syncErrorsMatch && method === "GET") {
+    const name = decodeURIComponent(syncErrorsMatch[1]);
+    const col = getCollection(name);
+    if (!col) return jsonResponse([]);
+    const dbPath = getCollectionDbPath(name);
+    if (!existsSync(dbPath)) return jsonResponse([]);
+    const colDb = getCollectionDb(dbPath);
+    const rows = colDb.select().from(syncErrors).all() as Array<{
+      externalId: string;
+      entityType: string;
+      error: string;
+      attempts: number;
+      firstSeenAt: string;
+      lastSeenAt: string;
+    }>;
+    return jsonResponse(
+      rows.map((r) => ({
+        externalId: r.externalId,
+        entityType: r.entityType,
+        error: r.error,
+        attempts: r.attempts,
+        firstSeenAt: r.firstSeenAt,
+        lastSeenAt: r.lastSeenAt,
+      })),
+    );
   }
 
   // GET /api/collections/:name/sync-runs (returns last sync state wrapped in an array for backward compat)
@@ -738,6 +783,8 @@ function ensureSyncJob(name: string, full: boolean): SyncJob | null {
     startedAt: Date.now(),
     completedAt: null,
     full,
+    errorCount: 0,
+    failureReason: null,
   };
   syncJobs.set(name, job);
   return job;
@@ -842,7 +889,12 @@ async function startSyncJob(name: string, full: boolean): Promise<void> {
 
         const result = await engine.run({ syncType: full ? "full" : "incremental" });
         job.deleted = result.deleted;
-        console.log(`[sync:${name}] done: +${result.created} ~${result.updated} -${result.deleted}`);
+        // Surface the per-entity error journal so the UI can show "N failed"
+        // without having to query the collection DB.
+        const finalState = getCollectionSyncState(getCollectionDbPath(name));
+        job.errorCount = finalState.errorCount ?? 0;
+        job.failureReason = finalState.failureReason ?? null;
+        console.log(`[sync:${name}] done: +${result.created} ~${result.updated} -${result.deleted} (errors=${job.errorCount})`);
       } finally {
         await crawler.dispose();
       }

--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -806,8 +806,12 @@ function queuePublish(fn: () => Promise<void>): Promise<void> {
  * multiple times in parallel with different collection names.
  */
 async function startSyncJob(name: string, full: boolean): Promise<void> {
-  const job = ensureSyncJob(name, full);
-  if (!job) return; // already running
+  // The HTTP handler seeded the job entry synchronously (status: "starting")
+  // so status polls don't see an idle window. Pick that entry up here rather
+  // than calling ensureSyncJob again — the second call would see active=true
+  // and return null, which would silently skip the actual sync.
+  const job = syncJobs.get(name);
+  if (!job || job.status !== "starting") return; // gone, or already running
   job.full = full;
 
   const home = getFrozenInkHome();
@@ -821,7 +825,7 @@ async function startSyncJob(name: string, full: boolean): Promise<void> {
 
     // Remote/cloned collections use pullCollection — no prepare or crawler needed
     if (col.crawler === "remote") {
-      job.status = `syncing ${name}`;
+      job.status = "syncing";
       console.log(`[sync:${name}] starting (remote/cloned)`);
       const result = await pullCollection(name, {
         onProgress: (msg) => {
@@ -835,11 +839,11 @@ async function startSyncJob(name: string, full: boolean): Promise<void> {
     } else {
       // Run prepare before incremental sync: schema migrations, folder ymls, stale markdown check
       if (!full) {
-        job.status = `preparing ${name}`;
+        job.status = "preparing";
         await prepareCollection(col, home, prepareThemeEngine, (msg) => console.log(`[prepare:${name}]`, msg));
       }
 
-      job.status = `syncing ${name}`;
+      job.status = "syncing";
 
       const factory = registry.get(col.crawler);
       if (!factory) throw new Error(`No crawler registered for "${col.crawler}"`);
@@ -866,7 +870,7 @@ async function startSyncJob(name: string, full: boolean): Promise<void> {
           if (existsSync(dbDir)) rmSync(dbDir, { recursive: true, force: true });
           mkdirSync(join(collectionDir, "content"), { recursive: true });
           updateCollectionSyncState(getCollectionDbPath(name), { cursor: null });
-          job.status = `${name}: cleared local data for full re-sync`;
+          job.status = "cleared local data for full re-sync";
         }
 
         const engine = new SyncEngine({
@@ -882,7 +886,10 @@ async function startSyncJob(name: string, full: boolean): Promise<void> {
             if (info.updated) job.updated++;
           },
           onProgress: (msg) => {
-            job.status = `${name}: ${msg}`;
+            // UI already shows the collection name in the progress card —
+            // don't double up with a "name:" prefix in the status text.
+            // The console log keeps the prefix for log correlation.
+            job.status = msg;
             console.log(`[sync:${name}] ${msg}`);
           },
         });
@@ -903,13 +910,13 @@ async function startSyncJob(name: string, full: boolean): Promise<void> {
     // Post-sync republish (serialized across collections via queuePublish)
     if (getCollectionPublishState(name)) {
       console.log(`[sync:${name}] collection is published — queueing republish`);
-      job.status = `waiting to republish ${name}`;
+      job.status = "waiting to republish";
       await queuePublish(async () => {
-        job.status = `republishing ${name}: starting`;
+        job.status = "republishing: starting";
         try {
           await triggerPublish({ collectionName: name }, (step, detail) => {
             const label = detail || step;
-            job.status = `republishing ${name}: ${label}`;
+            job.status = `republishing: ${label}`;
           });
         } catch (err) {
           console.error(`[sync:${name}] republish failed: ${err}`);

--- a/packages/core/src/crawler/index.ts
+++ b/packages/core/src/crawler/index.ts
@@ -5,6 +5,7 @@ export type {
   SyncResult,
   CrawlerEntityData,
   AssetFilter,
+  FailedEntity,
 } from "./interface";
 export { CrawlerRegistry, type CrawlerFactory } from "./registry";
 export { SyncEngine, type SyncEngineOptions, extractWikilinks } from "./sync-engine";

--- a/packages/core/src/crawler/interface.ts
+++ b/packages/core/src/crawler/interface.ts
@@ -29,11 +29,24 @@ export interface CrawlerEntityData {
   }[];
 }
 
+export interface FailedEntity {
+  externalId: string;
+  entityType: string;
+  error: string;
+}
+
 export interface SyncResult {
   entities: CrawlerEntityData[];
   nextCursor: SyncCursor | null;
   hasMore: boolean;
   deletedExternalIds: string[];
+  /**
+   * Per-entity fetch/parse failures that the crawler chose to skip rather than
+   * abort the batch. The SyncEngine records these in the sync_errors journal,
+   * applies the circuit breaker, and feeds them back via setRetryExternalIds()
+   * on the next sync.
+   */
+  failedEntities?: FailedEntity[];
 }
 
 export interface CrawlerMetadata {
@@ -76,4 +89,10 @@ export interface Crawler {
    * profiles whose bios rarely change).
    */
   setExistingExternalIds?(ids: Set<string>): void;
+  /**
+   * Optional: hand the crawler a set of externalIds that previously failed
+   * and should be retried on this run. Crawlers should attempt these before
+   * normal pagination so a fresh set of failures doesn't starve the backlog.
+   */
+  setRetryExternalIds?(ids: Set<string>): void;
 }

--- a/packages/core/src/crawler/sync-engine.ts
+++ b/packages/core/src/crawler/sync-engine.ts
@@ -1,7 +1,7 @@
 import { eq, and } from "drizzle-orm";
 import { createCryptoHasher } from "../compat/crypto";
 import { getCollectionDb } from "../db/client";
-import { entities } from "../db/collection-schema";
+import { entities, syncErrors } from "../db/collection-schema";
 import type { EntityData } from "../db/collection-schema";
 import { MetadataStore } from "../db/metadata";
 import { getCollection, updateCollection } from "../config/context";
@@ -93,6 +93,14 @@ const DEFAULT_ASSET_EXTENSIONS: string[] = [];
 
 /** Default max asset size: 10 MB in KB. */
 const DEFAULT_ASSET_MAX_SIZE_KB = 10240;
+
+/**
+ * Per-entity retry cap. Once an entity has failed this many times across
+ * runs, the SyncEngine stops handing it back to the crawler as a retry
+ * candidate. The journal row is kept (so the count stays visible in the UI)
+ * but it no longer slows down every subsequent incremental sync.
+ */
+const MAX_ENTITY_ATTEMPTS = 3;
 
 export interface AssetConfig {
   /** Allowed file extensions (with dot). */
@@ -196,6 +204,24 @@ export class SyncEngine {
       this.crawler.setExistingExternalIds(new Set(rows.map((r: { externalId: string }) => r.externalId)));
     }
 
+    // Hand the crawler the set of externalIds that previously failed so it
+    // can re-attempt them at the start of this run. Entries that have already
+    // failed MAX_ENTITY_ATTEMPTS times are skipped — their journal row stays
+    // (so the count is still visible to the user) but they no longer add
+    // work to every incremental sync. On success the row is cleared below.
+    if (this.crawler.setRetryExternalIds) {
+      const failedRows = this.db
+        .select({ externalId: syncErrors.externalId, attempts: syncErrors.attempts })
+        .from(syncErrors)
+        .all() as Array<{ externalId: string; attempts: number }>;
+      const retryable = failedRows
+        .filter((r) => (r.attempts ?? 0) < MAX_ENTITY_ATTEMPTS)
+        .map((r) => r.externalId);
+      if (retryable.length > 0) {
+        this.crawler.setRetryExternalIds(new Set(retryable));
+      }
+    }
+
     const metadata = new MetadataStore(this.dbPath);
 
     // Mirror user-facing config fields from YAML into the DB so consumers
@@ -255,6 +281,16 @@ export class SyncEngine {
           entityTypes: result.entities.map((e) => e.entityType),
         });
 
+        // Record per-entity failures into the journal (sync_errors). The
+        // sync continues regardless — the journal preserves visibility and
+        // lets the user resume retries later. Per-entity attempts are capped
+        // at MAX_ENTITY_ATTEMPTS so the same broken records don't slow down
+        // every incremental sync forever.
+        const failed = result.failedEntities ?? [];
+        for (const f of failed) {
+          this.recordSyncError(f.externalId, f.entityType, f.error);
+        }
+
         // Process entities (links are deferred until all entities exist)
         const deferredLinks: Array<{
           entityId: number;
@@ -272,6 +308,8 @@ export class SyncEngine {
           }
           created += counts.created;
           updated += counts.updated;
+          // Successful sync: clear any prior journal entry for this entity.
+          this.clearSyncError(entityData.externalId);
           this.onEntityProcessed?.({
             collectionName: this.collectionName,
             externalId: entityData.externalId,
@@ -296,16 +334,16 @@ export class SyncEngine {
           if (didDelete) deleted++;
         }
 
-        // Update cursor
+        // Update cursor and persist after every successful batch so resume
+        // works even if the next call crashes the process. Cost is a single
+        // metadata write per page — negligible vs. fetching the page.
         if (result.nextCursor) {
           cursor = result.nextCursor;
         }
+        metadata.setSyncState({ cursor: cursor ?? null });
 
         hasMore = result.hasMore;
       }
-
-      // Persist cursor to DB; version goes to YAML (user-facing) and is mirrored in DB.
-      metadata.setSyncState({ cursor: cursor ?? null });
 
       if (pausedByRateLimit) {
         // Don't bump version, reconcile (would delete unsynced entities as
@@ -318,10 +356,16 @@ export class SyncEngine {
           lastCreated: created,
           lastUpdated: updated,
           lastDeleted: deleted,
-          lastErrors: ["Paused due to GitHub rate limit; will resume on next sync"],
+          lastErrors: ["Paused due to rate limit; will resume on next sync"],
+          errorCount: this.countSyncErrors(),
+          failureReason: "rate_limit",
         });
         return { created, updated, deleted };
       }
+
+      // Sync completed normally. The cursor was already persisted on the last
+      // batch above and now carries the incremental watermark (e.g. updatedSince
+      // for MantisHub) that the next incremental run will use. Don't clear it.
 
       metadata.setCollectionVersion(currentVersion);
       updateCollection(this.collectionName, { version: currentVersion });
@@ -345,6 +389,8 @@ export class SyncEngine {
         lastUpdated: updated,
         lastDeleted: deleted,
         lastErrors: errors.length > 0 ? errors : null,
+        errorCount: this.countSyncErrors(),
+        failureReason: null,
       });
 
       return { created, updated, deleted };
@@ -357,11 +403,50 @@ export class SyncEngine {
         lastUpdated: updated,
         lastDeleted: deleted,
         lastErrors: errors,
+        errorCount: this.countSyncErrors(),
+        failureReason: "fatal",
       });
       throw err;
     } finally {
       metadata.close();
     }
+  }
+
+  /**
+   * Record a recoverable per-entity sync failure. Increments the attempt
+   * counter on existing rows; inserts a new row otherwise. The journal is
+   * read on the next sync to feed retry IDs back to the crawler.
+   */
+  private recordSyncError(externalId: string, entityType: string, error: string): void {
+    const [existing] = this.db
+      .select({ attempts: syncErrors.attempts })
+      .from(syncErrors)
+      .where(eq(syncErrors.externalId, externalId))
+      .all();
+    const now = new Date().toISOString().replace("T", " ").replace("Z", "");
+    if (existing) {
+      this.db
+        .update(syncErrors)
+        .set({ error, attempts: (existing.attempts ?? 0) + 1, lastSeenAt: now })
+        .where(eq(syncErrors.externalId, externalId))
+        .run();
+    } else {
+      this.db
+        .insert(syncErrors)
+        .values({ externalId, entityType, error, attempts: 1, firstSeenAt: now, lastSeenAt: now })
+        .run();
+    }
+  }
+
+  /** Remove a journal entry — called when the entity successfully syncs. */
+  private clearSyncError(externalId: string): void {
+    this.db.delete(syncErrors).where(eq(syncErrors.externalId, externalId)).run();
+  }
+
+  /** Total number of unresolved sync failures in the journal. */
+  private countSyncErrors(): number {
+    const rows = this.db.select({ id: syncErrors.externalId }).from(syncErrors).all();
+    return rows.length;
   }
 
   private async updateEntityData(entityId: number, updates: Partial<EntityData>): Promise<void> {

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -52,6 +52,19 @@ export function getCollectionDb(dbPath: string) {
   sqlite.exec("CREATE INDEX IF NOT EXISTS idx_entities_type     ON entities(entity_type);");
   sqlite.exec("CREATE INDEX IF NOT EXISTS idx_entities_updated  ON entities(updated_at);")
 
+  // Per-entity sync failure journal. Created lazily on first DB open so existing
+  // collections gain it without an explicit migration step.
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS sync_errors (
+      external_id    TEXT PRIMARY KEY,
+      entity_type    TEXT NOT NULL,
+      error          TEXT NOT NULL,
+      attempts       INTEGER NOT NULL DEFAULT 1,
+      first_seen_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      last_seen_at   TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+
   // One-time backfill: populate folder/slug from data.markdown_path for existing rows
   const needsBackfill = sqlite.prepare(
     "SELECT id, json_extract(data, '$.markdown_path') as mp FROM entities WHERE folder IS NULL AND json_extract(data, '$.markdown_path') IS NOT NULL LIMIT 500",

--- a/packages/core/src/db/collection-schema.ts
+++ b/packages/core/src/db/collection-schema.ts
@@ -48,3 +48,21 @@ export const entities = sqliteTable("entities", {
     .notNull()
     .default(sql`(datetime('now'))`),
 });
+
+/**
+ * Per-entity sync failure journal. Populated by the SyncEngine when a crawler
+ * reports a recoverable failure for a specific entity. Rows are removed when
+ * the entity is successfully synced. Cleared on full re-sync.
+ */
+export const syncErrors = sqliteTable("sync_errors", {
+  externalId: text("external_id").primaryKey(),
+  entityType: text("entity_type").notNull(),
+  error: text("error").notNull(),
+  attempts: integer("attempts").notNull().default(1),
+  firstSeenAt: text("first_seen_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  lastSeenAt: text("last_seen_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});

--- a/packages/core/src/db/metadata.ts
+++ b/packages/core/src/db/metadata.ts
@@ -13,6 +13,13 @@ export interface SyncStateSnapshot {
   lastUpdated?: number;
   lastDeleted?: number;
   lastErrors?: unknown[];
+  /** Number of per-entity recoverable errors recorded in sync_errors. */
+  errorCount?: number;
+  /**
+   * Reason the last sync ended, when not "completed". One of:
+   * "rate_limit" | "fatal".
+   */
+  failureReason?: string;
 }
 
 /**
@@ -27,6 +34,8 @@ export interface SyncStateUpdate {
   lastUpdated?: number;
   lastDeleted?: number;
   lastErrors?: unknown[] | null;
+  errorCount?: number;
+  failureReason?: string | null;
 }
 
 /** Metadata key namespace. All keys are implicitly scoped to the collection. */
@@ -38,6 +47,8 @@ const K = {
   syncLastUpdated: "sync.last_updated",
   syncLastDeleted: "sync.last_deleted",
   syncLastErrors: "sync.last_errors",
+  syncErrorCount: "sync.error_count",
+  syncFailureReason: "sync.failure_reason",
   title: "title",
   description: "description",
   version: "version",
@@ -122,6 +133,12 @@ export class MetadataStore {
       try { snapshot.lastErrors = JSON.parse(lastErrors); } catch { /* ignore */ }
     }
 
+    const errorCount = this.getOptional(K.syncErrorCount);
+    if (errorCount !== null) snapshot.errorCount = Number(errorCount);
+
+    const failureReason = this.getOptional(K.syncFailureReason);
+    if (failureReason !== null) snapshot.failureReason = failureReason;
+
     return snapshot;
   }
 
@@ -141,6 +158,11 @@ export class MetadataStore {
       } else {
         this.set(K.syncLastErrors, JSON.stringify(updates.lastErrors));
       }
+    }
+    if (updates.errorCount !== undefined) this.set(K.syncErrorCount, String(updates.errorCount));
+    if ("failureReason" in updates) {
+      if (updates.failureReason == null) this.delete(K.syncFailureReason);
+      else this.set(K.syncFailureReason, updates.failureReason);
     }
   }
 

--- a/packages/crawlers/src/mantishub/__tests__/crawler.test.ts
+++ b/packages/crawlers/src/mantishub/__tests__/crawler.test.ts
@@ -158,11 +158,16 @@ describe("MantisHubCrawler", () => {
   });
 
   it("journals issues missing the required summary field with entity context", async () => {
-    crawler.setFetch(routingFetch(async () => {
-      return jsonResponse({
-        issues: [sampleIssue({ id: 7, summary: "" })],
-      });
-    }));
+    // The list endpoint uses select=id,updated_at, so the malformed-summary
+    // scenario surfaces during the per-issue detail fetch — intercept that
+    // directly rather than mocking the list payload.
+    crawler.setFetch(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.match(SINGLE_ISSUE_RE)) {
+        return jsonResponse({ issues: [sampleIssue({ id: 7, summary: "" })] });
+      }
+      return jsonResponse({ issues: [{ id: 7, updated_at: "2024-01-02T00:00:00Z" }] });
+    });
 
     // Per-entity validation errors are reported via failedEntities so the
     // sync can continue and the SyncEngine can journal them for retry,
@@ -251,8 +256,8 @@ describe("MantisHubCrawler", () => {
 
   it("advances to page 2 with in-run cursor state", async () => {
     const listUrls: string[] = [];
-    // Full sync uses page_size=100 — return a full page to trigger pagination.
-    const repeatedPage = Array.from({ length: 100 }, (_, i) =>
+    // List call uses page_size=25 — return a full page to trigger pagination.
+    const repeatedPage = Array.from({ length: 25 }, (_, i) =>
       sampleIssue({
         id: i + 1,
         updated_at: "2024-03-01T00:00:00Z",

--- a/packages/crawlers/src/mantishub/__tests__/crawler.test.ts
+++ b/packages/crawlers/src/mantishub/__tests__/crawler.test.ts
@@ -157,16 +157,25 @@ describe("MantisHubCrawler", () => {
     expect(result.entities[0].externalId).toBe("issue:9");
   });
 
-  it("rejects issues missing the required summary field with entity context", async () => {
+  it("journals issues missing the required summary field with entity context", async () => {
     crawler.setFetch(routingFetch(async () => {
       return jsonResponse({
         issues: [sampleIssue({ id: 7, summary: "" })],
       });
     }));
 
-    await expect(crawler.sync(null)).rejects.toThrow(
-      'Invalid issue entity id=7: missing required field "summary"',
-    );
+    // Per-entity validation errors are reported via failedEntities so the
+    // sync can continue and the SyncEngine can journal them for retry,
+    // rather than aborting the whole batch on one malformed issue.
+    const result = await crawler.sync(null);
+    expect(result.entities.filter((e) => e.entityType === "issue")).toHaveLength(0);
+    expect(result.failedEntities).toEqual([
+      {
+        externalId: "issue:7",
+        entityType: "issue",
+        error: 'Invalid issue entity id=7: missing required field "summary"',
+      },
+    ]);
   });
 
   it("ignores legacy page-only cursor and restarts from page 1", async () => {
@@ -242,7 +251,8 @@ describe("MantisHubCrawler", () => {
 
   it("advances to page 2 with in-run cursor state", async () => {
     const listUrls: string[] = [];
-    const repeatedPage = Array.from({ length: 25 }, (_, i) =>
+    // Full sync uses page_size=100 — return a full page to trigger pagination.
+    const repeatedPage = Array.from({ length: 100 }, (_, i) =>
       sampleIssue({
         id: i + 1,
         updated_at: "2024-03-01T00:00:00Z",

--- a/packages/crawlers/src/mantishub/crawler.ts
+++ b/packages/crawlers/src/mantishub/crawler.ts
@@ -5,6 +5,7 @@ import type {
   SyncCursor,
   SyncResult,
   AssetFilter,
+  FailedEntity,
 } from "@frozenink/core";
 import { createCryptoHasher } from "@frozenink/core";
 import type {
@@ -33,6 +34,14 @@ interface MantisHubSyncCursor extends SyncCursor {
   repeatedPageCount?: number;
   /** Current sync phase. Undefined / missing means "issues". */
   phase?: "issues" | "pages" | "users";
+  /**
+   * Frozen "as-of" timestamp for the in-progress full sync. Pinned at the
+   * start of an initial sync so DESC pagination is stable across resumes —
+   * new activity after this time doesn't shift pages mid-flight. Cleared
+   * when the issues phase finishes; subsequent incremental syncs use
+   * `updatedSince` as the watermark instead.
+   */
+  snapshotCeiling?: string;
   /** User data accumulated across issue pages (serialized in cursor). */
   _users?: Record<number, { id: number; name: string; email?: string }>;
   /** Project data accumulated across issue pages (serialized in cursor). */
@@ -43,9 +52,24 @@ interface MantisHubSyncCursor extends SyncCursor {
   _pagesBrowsePage?: number;
   /** Issue IDs to fetch during incremental sync (populated by lightweight scan). */
   _incrementalIds?: number[];
+  /**
+   * Issue IDs from the previous run's failure journal that should be retried
+   * before resuming normal pagination. Drained as fetches succeed/fail.
+   */
+  _retryIds?: number[];
 }
 
-const PAGE_SIZE = 25;
+/**
+ * Full-sync list pages are large (100): cheap list calls, fewer round trips
+ * across a 10k-issue initial sync. Each listed issue still gets its own
+ * detail fetch sequentially, so the per-batch wall time stays modest.
+ *
+ * Incremental fetch pages are smaller (25): the scan already produced a
+ * targeted ID list, so smaller batches mean more frequent cursor
+ * checkpoints and progress updates without increasing total work.
+ */
+const FULL_SYNC_PAGE_SIZE = 100;
+const INCREMENTAL_PAGE_SIZE = 25;
 const SCAN_PAGE_SIZE = 100;
 const PAGE_DELAY_MS = 100;
 const SCAN_PAGE_DELAY_MS = 20;
@@ -142,6 +166,18 @@ export class MantisHubCrawler implements Crawler {
     this.progressCallback = callback;
   }
 
+  private retryExternalIds: Set<string> | null = null;
+  private retriesInitialized = false;
+
+  setRetryExternalIds(ids: Set<string>): void {
+    this.retryExternalIds = ids;
+    this.retriesInitialized = false;
+  }
+
+  private issueExternalId(id: number): string {
+    return `issue:${id}`;
+  }
+
   private reportProgress(msg: string): void {
     this.progressCallback?.(msg);
   }
@@ -229,6 +265,38 @@ export class MantisHubCrawler implements Crawler {
   async sync(cursor: SyncCursor | null): Promise<SyncResult> {
     const c = (cursor as MantisHubSyncCursor) ?? {};
 
+    // Initial-sync snapshot ceiling: when this is the very first sync (no
+    // prior cursor at all), pin the dataset to a single point in time. The
+    // issue list endpoint is paginated DESC by updated_at — without a
+    // ceiling, new updates that arrive mid-sync shift every later page by
+    // one slot, so the saved cursor on resume points at the wrong content.
+    // The ceiling makes pagination idempotent for the duration of the
+    // initial sync. Subsequent incremental syncs don't need it (they use
+    // `updatedSince` instead) and won't set it.
+    if (cursor === null && !c.updatedSince) {
+      c.snapshotCeiling = new Date().toISOString().replace("T", " ").replace(/\..+$/, "");
+    }
+
+    // Drain pending retries from the journal before normal pagination, so
+    // a flood of new activity doesn't starve previously-failed entities.
+    // Done on the first sync() call of the run regardless of whether this is
+    // an initial or incremental run.
+    if (!this.retriesInitialized) {
+      this.retriesInitialized = true;
+      if (this.retryExternalIds && this.retryExternalIds.size > 0) {
+        const retryIds = Array.from(this.retryExternalIds)
+          .map((id) => id.startsWith("issue:") ? id.slice("issue:".length) : id)
+          .map((id) => Number(id))
+          .filter((n) => Number.isFinite(n));
+        if (retryIds.length > 0) {
+          c._retryIds = retryIds;
+        }
+      }
+    }
+    if (c._retryIds && c._retryIds.length > 0) {
+      return this.fetchRetryBatch(c);
+    }
+
     // Restore accumulated user/project data from cursor (survives across pages).
     if (cursor === null) {
       this.collectedUsers.clear();
@@ -285,14 +353,32 @@ export class MantisHubCrawler implements Crawler {
     }
 
     this.reportProgress(`Full sync: fetching issues page ${page} (${fetched} synced so far)`);
-    let url = `${this.baseUrl}/api/rest/issues?page_size=${PAGE_SIZE}&page=${page}`;
+    let url = `${this.baseUrl}/api/rest/issues?page_size=${FULL_SYNC_PAGE_SIZE}&page=${page}`;
     if (this.projectId) {
       url += `&project_id=${this.projectId}`;
+    }
+    // Pin the dataset to the snapshot ceiling so concurrent updates after
+    // sync started don't shift later pages. MantisBT supports `filter_updated_before`.
+    if (c.snapshotCeiling) {
+      url += `&filter_updated_before=${encodeURIComponent(c.snapshotCeiling)}`;
     }
 
     const response = await this.apiFetch(url);
     const data = (await response.json()) as { issues: MantisHubIssue[] };
-    const issues = data.issues ?? [];
+    let issues = data.issues ?? [];
+
+    // Belt-and-suspenders: if the server doesn't honor filter_updated_before,
+    // drop items above the ceiling client-side. With DESC ordering, items
+    // newer than the ceiling appear at the front of the page.
+    if (c.snapshotCeiling) {
+      const ceilingTs = parseTimestamp(c.snapshotCeiling);
+      if (ceilingTs !== null) {
+        issues = issues.filter((i) => {
+          const ts = parseTimestamp(i.updated_at);
+          return ts === null || ts <= ceilingTs;
+        });
+      }
+    }
 
     issues.sort(
       (a, b) =>
@@ -325,7 +411,7 @@ export class MantisHubCrawler implements Crawler {
       issuesToProcess = issuesToProcess.slice(0, remaining);
     }
 
-    const apiHasMore = issues.length === PAGE_SIZE;
+    const apiHasMore = issues.length === FULL_SYNC_PAGE_SIZE;
     const reachedMax = this.maxEntities ? (fetched + issuesToProcess.length) >= this.maxEntities : false;
     const issuesHaveMore = apiHasMore && !reachedMax;
     const finalUpdatedSince = maxTimestamp(c.updatedSince, newestSeenUpdatedAt);
@@ -345,16 +431,23 @@ export class MantisHubCrawler implements Crawler {
 
     // Fetch full issue data individually — the list endpoint omits attachments
     // and note attachments. Sequential to avoid overwhelming the server.
+    // Per-issue failures are reported to the engine via failedEntities rather
+    // than thrown, so one bad issue doesn't abort a 10k-issue sync. Auth/list
+    // failures still surface above; this only handles per-record errors.
     const entities: CrawlerEntityData[] = [];
+    const failedEntities: FailedEntity[] = [];
     for (const issue of issuesToProcess) {
-      let fullIssue: MantisHubIssue;
       try {
-        fullIssue = await this.fetchIssue(issue.id);
+        const fullIssue = await this.fetchIssue(issue.id);
+        entities.push(await this.buildIssueEntity(fullIssue));
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        throw new Error(`Failed to sync entity type=issue id=${issue.id}: ${message}`);
+        failedEntities.push({
+          externalId: this.issueExternalId(issue.id),
+          entityType: "issue",
+          error: message,
+        });
       }
-      entities.push(await this.buildIssueEntity(fullIssue));
     }
 
     const newFetched = fetched + issuesToProcess.length;
@@ -366,12 +459,14 @@ export class MantisHubCrawler implements Crawler {
     if (issuesHaveMore) {
       return {
         entities,
+        failedEntities,
         nextCursor: {
           page: page + 1,
           fetched: newFetched,
           newestSeenUpdatedAt,
           lastPageSignature: pageSignature,
           repeatedPageCount,
+          snapshotCeiling: c.snapshotCeiling,
           ...serializedCollected,
         },
         hasMore: true,
@@ -383,6 +478,7 @@ export class MantisHubCrawler implements Crawler {
     const transition = this.transitionFromIssues(finalUpdatedSince);
     return {
       entities,
+      failedEntities,
       ...transition,
     };
   }
@@ -466,26 +562,30 @@ export class MantisHubCrawler implements Crawler {
 
   /**
    * Fetch phase of incremental sync: fetch full issue data for IDs
-   * identified during the scan phase, in batches of PAGE_SIZE.
+   * identified during the scan phase, in batches of INCREMENTAL_PAGE_SIZE.
    */
   private async fetchIncrementalBatch(c: MantisHubSyncCursor): Promise<SyncResult> {
     const ids = c._incrementalIds ?? [];
-    const batch = ids.slice(0, PAGE_SIZE);
-    const remaining = ids.slice(PAGE_SIZE);
+    const batch = ids.slice(0, INCREMENTAL_PAGE_SIZE);
+    const remaining = ids.slice(INCREMENTAL_PAGE_SIZE);
 
     const entities: CrawlerEntityData[] = [];
+    const failedEntities: FailedEntity[] = [];
     for (let i = 0; i < batch.length; i++) {
       const id = batch[i];
       this.reportProgress(`Fetching issue #${id} (${i + 1}/${batch.length} in batch, ${remaining.length + batch.length - i - 1} remaining)`);
-      let fullIssue: MantisHubIssue;
       try {
-        fullIssue = await this.fetchIssue(id);
+        const fullIssue = await this.fetchIssue(id);
+        this.collectUsersAndProjects(fullIssue);
+        entities.push(await this.buildIssueEntity(fullIssue));
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        throw new Error(`Failed to sync entity type=issue id=${id}: ${message}`);
+        failedEntities.push({
+          externalId: this.issueExternalId(id),
+          entityType: "issue",
+          error: message,
+        });
       }
-      this.collectUsersAndProjects(fullIssue);
-      entities.push(await this.buildIssueEntity(fullIssue));
     }
 
     const serializedCollected = {
@@ -496,6 +596,7 @@ export class MantisHubCrawler implements Crawler {
     if (remaining.length > 0) {
       return {
         entities,
+        failedEntities,
         nextCursor: {
           updatedSince: c.updatedSince,
           newestSeenUpdatedAt: c.newestSeenUpdatedAt,
@@ -511,7 +612,55 @@ export class MantisHubCrawler implements Crawler {
     const finalUpdatedSince = maxTimestamp(c.updatedSince, c.newestSeenUpdatedAt);
     return {
       entities,
+      failedEntities,
       ...this.transitionFromIssues(finalUpdatedSince),
+    };
+  }
+
+  /**
+   * Drain the retry queue passed in via setRetryExternalIds(). Runs first
+   * (before normal pagination) so a continuous stream of new activity doesn't
+   * starve previously-failed entities. Per-issue failures are journaled
+   * again with an incremented attempt counter; successes are removed from
+   * the journal by the SyncEngine.
+   */
+  private async fetchRetryBatch(c: MantisHubSyncCursor): Promise<SyncResult> {
+    const ids = c._retryIds ?? [];
+    const batch = ids.slice(0, INCREMENTAL_PAGE_SIZE);
+    const remaining = ids.slice(INCREMENTAL_PAGE_SIZE);
+
+    const entities: CrawlerEntityData[] = [];
+    const failedEntities: FailedEntity[] = [];
+    for (let i = 0; i < batch.length; i++) {
+      const id = batch[i];
+      this.reportProgress(`Retrying previously-failed issue #${id} (${i + 1}/${batch.length}, ${remaining.length} more queued)`);
+      try {
+        const fullIssue = await this.fetchIssue(id);
+        this.collectUsersAndProjects(fullIssue);
+        entities.push(await this.buildIssueEntity(fullIssue));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        failedEntities.push({
+          externalId: this.issueExternalId(id),
+          entityType: "issue",
+          error: message,
+        });
+      }
+    }
+
+    // After the retry queue is drained, fall back to whatever the cursor
+    // would otherwise drive (initial-page pagination, incremental scan, etc.)
+    // by clearing _retryIds and passing through the rest of the cursor.
+    const nextCursor: MantisHubSyncCursor = {
+      ...c,
+      _retryIds: remaining.length > 0 ? remaining : undefined,
+    };
+    return {
+      entities,
+      failedEntities,
+      nextCursor,
+      hasMore: true,
+      deletedExternalIds: [],
     };
   }
 
@@ -524,13 +673,20 @@ export class MantisHubCrawler implements Crawler {
       if (users.length > 0) {
         this.reportProgress(`Fetching ${users.length} user profile(s)`);
       }
+      // MantisHub commonly denies access to other users' profiles (the
+      // signed-in account often only has visibility into its own user record).
+      // Once we've seen enough failures we stop trying to fetch user profiles
+      // entirely and emit shell entities (id + name + email collected from
+      // issues) for the rest. User fetch failures are NEVER added to the
+      // sync_errors journal — there's no value in retrying a profile the
+      // current credentials cannot see.
+      const MAX_USER_FETCH_FAILURES = 10;
       let i = 0;
-      let consecutiveForbidden = 0;
-      let allForbidden = false;
+      let userFailureCount = 0;
+      let abortUserFetch = false;
       for (const basic of users) {
         i++;
-        if (allForbidden) {
-          // Server denied access to all users — emit shell entities for remaining.
+        if (abortUserFetch) {
           entities.push(this.buildUserEntity({ id: basic.id, name: basic.name, email: basic.email }));
           continue;
         }
@@ -538,19 +694,14 @@ export class MantisHubCrawler implements Crawler {
         try {
           const profile = await this.fetchUser(basic.id);
           entities.push(this.buildUserEntity(profile));
-          consecutiveForbidden = 0;
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          if (message.includes("→ 403")) {
-            consecutiveForbidden++;
-            if (consecutiveForbidden >= 10) {
-              console.warn(`  Warning: 10 consecutive 403s fetching users — assuming all user profiles are forbidden. Creating shell entries for remaining ${users.length - i} user(s).`);
-              allForbidden = true;
-            }
-          } else {
-            consecutiveForbidden = 0;
-          }
+          userFailureCount++;
           console.warn(`  Warning: entity type=user id=${basic.id} name=${basic.name}: ${message}`);
+          if (userFailureCount >= MAX_USER_FETCH_FAILURES) {
+            console.warn(`  Warning: ${MAX_USER_FETCH_FAILURES} user fetch failures — stopping user sync. Creating shell entries for remaining ${users.length - i} user(s) from data collected during issue sync.`);
+            abortUserFetch = true;
+          }
           // Build a minimal user entity from data collected during issue sync.
           entities.push(this.buildUserEntity({
             id: basic.id,

--- a/packages/crawlers/src/mantishub/crawler.ts
+++ b/packages/crawlers/src/mantishub/crawler.ts
@@ -60,19 +60,49 @@ interface MantisHubSyncCursor extends SyncCursor {
 }
 
 /**
- * Full-sync list pages are large (100): cheap list calls, fewer round trips
- * across a 10k-issue initial sync. Each listed issue still gets its own
- * detail fetch sequentially, so the per-batch wall time stays modest.
- *
- * Incremental fetch pages are smaller (25): the scan already produced a
- * targeted ID list, so smaller batches mean more frequent cursor
- * checkpoints and progress updates without increasing total work.
+ * Page size for both full-sync list calls and the incremental fetch batches.
+ * Detail fetches dominate wall time (one HTTP call per issue), so smaller
+ * pages give more frequent cursor checkpoints and progress updates without
+ * meaningfully changing total work. The scan-only endpoint stays at 100
+ * because its payload is tiny (id + updated_at) and not RTT-bound per row.
  */
-const FULL_SYNC_PAGE_SIZE = 100;
-const INCREMENTAL_PAGE_SIZE = 25;
+const PAGE_SIZE = 25;
 const SCAN_PAGE_SIZE = 100;
 const PAGE_DELAY_MS = 100;
 const SCAN_PAGE_DELAY_MS = 20;
+
+/**
+ * Number of per-issue detail fetches in flight at once. The list endpoint
+ * is throttled by PAGE_DELAY_MS between pages, but the individual issue
+ * fetches inside a page are RTT-bound — going from serial to 5-way
+ * concurrent cuts a 25-issue batch from ~25 sequential RTTs to ~5 rounds
+ * without overloading the server.
+ */
+const ISSUE_FETCH_CONCURRENCY = 5;
+
+/**
+ * Map `items` to results in input order, running at most `concurrency`
+ * promises in flight at any time. Results from `fn` are placed at the
+ * same index as their input. Errors are caught by `fn`'s try/catch in
+ * the call sites — this helper does not handle rejections.
+ */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
 
 function parseTimestamp(value: string | undefined): number | null {
   if (!value) return null;
@@ -352,8 +382,12 @@ export class MantisHubCrawler implements Crawler {
       await new Promise((resolve) => setTimeout(resolve, PAGE_DELAY_MS));
     }
 
-    this.reportProgress(`Full sync: fetching issues page ${page} (${fetched} synced so far)`);
-    let url = `${this.baseUrl}/api/rest/issues?page_size=${FULL_SYNC_PAGE_SIZE}&page=${page}`;
+    this.reportProgress(`Fetching issues page ${page}`);
+    // Use select=id,updated_at — the list call only needs IDs to drive the
+    // detail fetches and updated_at for pagination/snapshot bookkeeping.
+    // Skipping the full payload here saves bandwidth on every page; the per
+    // -issue detail fetch returns the full record anyway.
+    let url = `${this.baseUrl}/api/rest/issues?select=id,updated_at&page_size=${PAGE_SIZE}&page=${page}`;
     if (this.projectId) {
       url += `&project_id=${this.projectId}`;
     }
@@ -364,7 +398,7 @@ export class MantisHubCrawler implements Crawler {
     }
 
     const response = await this.apiFetch(url);
-    const data = (await response.json()) as { issues: MantisHubIssue[] };
+    const data = (await response.json()) as { issues: Array<{ id: number; updated_at: string }> };
     let issues = data.issues ?? [];
 
     // Belt-and-suspenders: if the server doesn't honor filter_updated_before,
@@ -411,7 +445,7 @@ export class MantisHubCrawler implements Crawler {
       issuesToProcess = issuesToProcess.slice(0, remaining);
     }
 
-    const apiHasMore = issues.length === FULL_SYNC_PAGE_SIZE;
+    const apiHasMore = issues.length === PAGE_SIZE;
     const reachedMax = this.maxEntities ? (fetched + issuesToProcess.length) >= this.maxEntities : false;
     const issuesHaveMore = apiHasMore && !reachedMax;
     const finalUpdatedSince = maxTimestamp(c.updatedSince, newestSeenUpdatedAt);
@@ -423,31 +457,44 @@ export class MantisHubCrawler implements Crawler {
       };
     }
 
-    // Collect users + projects from ALL fetched issues (not just processed ones)
-    // so we capture every user/project even in incremental syncs.
-    for (const issue of issues) {
-      this.collectUsersAndProjects(issue);
-    }
+    // The list call uses select=id,updated_at, so the slim payload doesn't
+    // carry user/project/category/notes data. Collection happens in the
+    // detail-fetch loop below where the full issue payload is available.
 
-    // Fetch full issue data individually — the list endpoint omits attachments
-    // and note attachments. Sequential to avoid overwhelming the server.
-    // Per-issue failures are reported to the engine via failedEntities rather
-    // than thrown, so one bad issue doesn't abort a 10k-issue sync. Auth/list
-    // failures still surface above; this only handles per-record errors.
+    // Fetch full issue data individually. The list endpoint is tiny now
+    // (id+updated_at only); the per-issue calls return the full record
+    // including attachments and notes. Run up to ISSUE_FETCH_CONCURRENCY in
+    // parallel to hide RTT. Per-issue failures are reported via
+    // failedEntities so one bad issue doesn't abort the run; auth/list
+    // failures still surface above.
+    type IssueOutcome =
+      | { kind: "ok"; entity: CrawlerEntityData }
+      | { kind: "fail"; failure: FailedEntity };
+    const outcomes = await mapWithConcurrency<typeof issuesToProcess[number], IssueOutcome>(
+      issuesToProcess,
+      ISSUE_FETCH_CONCURRENCY,
+      async (issue) => {
+        try {
+          const fullIssue = await this.fetchIssue(issue.id);
+          this.collectUsersAndProjects(fullIssue);
+          return { kind: "ok", entity: await this.buildIssueEntity(fullIssue) };
+        } catch (err) {
+          return {
+            kind: "fail",
+            failure: {
+              externalId: this.issueExternalId(issue.id),
+              entityType: "issue",
+              error: err instanceof Error ? err.message : String(err),
+            },
+          };
+        }
+      },
+    );
     const entities: CrawlerEntityData[] = [];
     const failedEntities: FailedEntity[] = [];
-    for (const issue of issuesToProcess) {
-      try {
-        const fullIssue = await this.fetchIssue(issue.id);
-        entities.push(await this.buildIssueEntity(fullIssue));
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        failedEntities.push({
-          externalId: this.issueExternalId(issue.id),
-          entityType: "issue",
-          error: message,
-        });
-      }
+    for (const o of outcomes) {
+      if (o.kind === "ok") entities.push(o.entity);
+      else failedEntities.push(o.failure);
     }
 
     const newFetched = fetched + issuesToProcess.length;
@@ -501,7 +548,7 @@ export class MantisHubCrawler implements Crawler {
         await new Promise((resolve) => setTimeout(resolve, SCAN_PAGE_DELAY_MS));
       }
 
-      this.reportProgress(`Scanning issues: page ${page} (${ids.length} updated so far)`);
+      this.reportProgress(`Scanning issues: page ${page}`);
       let url = `${this.baseUrl}/api/rest/issues?select=id,updated_at&page_size=${SCAN_PAGE_SIZE}&page=${page}`;
       if (this.projectId) url += `&project_id=${this.projectId}`;
 
@@ -562,30 +609,35 @@ export class MantisHubCrawler implements Crawler {
 
   /**
    * Fetch phase of incremental sync: fetch full issue data for IDs
-   * identified during the scan phase, in batches of INCREMENTAL_PAGE_SIZE.
+   * identified during the scan phase, in batches of PAGE_SIZE.
    */
   private async fetchIncrementalBatch(c: MantisHubSyncCursor): Promise<SyncResult> {
     const ids = c._incrementalIds ?? [];
-    const batch = ids.slice(0, INCREMENTAL_PAGE_SIZE);
-    const remaining = ids.slice(INCREMENTAL_PAGE_SIZE);
+    const batch = ids.slice(0, PAGE_SIZE);
+    const remaining = ids.slice(PAGE_SIZE);
 
-    const entities: CrawlerEntityData[] = [];
-    const failedEntities: FailedEntity[] = [];
-    for (let i = 0; i < batch.length; i++) {
-      const id = batch[i];
-      this.reportProgress(`Fetching issue #${id} (${i + 1}/${batch.length} in batch, ${remaining.length + batch.length - i - 1} remaining)`);
+    this.reportProgress(`Fetching ${batch.length} issue(s), ${remaining.length} more queued`);
+    const outcomes = await mapWithConcurrency(batch, ISSUE_FETCH_CONCURRENCY, async (id) => {
       try {
         const fullIssue = await this.fetchIssue(id);
         this.collectUsersAndProjects(fullIssue);
-        entities.push(await this.buildIssueEntity(fullIssue));
+        return { kind: "ok" as const, entity: await this.buildIssueEntity(fullIssue) };
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        failedEntities.push({
-          externalId: this.issueExternalId(id),
-          entityType: "issue",
-          error: message,
-        });
+        return {
+          kind: "fail" as const,
+          failure: {
+            externalId: this.issueExternalId(id),
+            entityType: "issue",
+            error: err instanceof Error ? err.message : String(err),
+          },
+        };
       }
+    });
+    const entities: CrawlerEntityData[] = [];
+    const failedEntities: FailedEntity[] = [];
+    for (const o of outcomes) {
+      if (o.kind === "ok") entities.push(o.entity);
+      else failedEntities.push(o.failure);
     }
 
     const serializedCollected = {
@@ -626,26 +678,31 @@ export class MantisHubCrawler implements Crawler {
    */
   private async fetchRetryBatch(c: MantisHubSyncCursor): Promise<SyncResult> {
     const ids = c._retryIds ?? [];
-    const batch = ids.slice(0, INCREMENTAL_PAGE_SIZE);
-    const remaining = ids.slice(INCREMENTAL_PAGE_SIZE);
+    const batch = ids.slice(0, PAGE_SIZE);
+    const remaining = ids.slice(PAGE_SIZE);
 
-    const entities: CrawlerEntityData[] = [];
-    const failedEntities: FailedEntity[] = [];
-    for (let i = 0; i < batch.length; i++) {
-      const id = batch[i];
-      this.reportProgress(`Retrying previously-failed issue #${id} (${i + 1}/${batch.length}, ${remaining.length} more queued)`);
+    this.reportProgress(`Retrying ${batch.length} previously-failed issue(s), ${remaining.length} more queued`);
+    const retryOutcomes = await mapWithConcurrency(batch, ISSUE_FETCH_CONCURRENCY, async (id) => {
       try {
         const fullIssue = await this.fetchIssue(id);
         this.collectUsersAndProjects(fullIssue);
-        entities.push(await this.buildIssueEntity(fullIssue));
+        return { kind: "ok" as const, entity: await this.buildIssueEntity(fullIssue) };
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        failedEntities.push({
-          externalId: this.issueExternalId(id),
-          entityType: "issue",
-          error: message,
-        });
+        return {
+          kind: "fail" as const,
+          failure: {
+            externalId: this.issueExternalId(id),
+            entityType: "issue",
+            error: err instanceof Error ? err.message : String(err),
+          },
+        };
       }
+    });
+    const entities: CrawlerEntityData[] = [];
+    const failedEntities: FailedEntity[] = [];
+    for (const o of retryOutcomes) {
+      if (o.kind === "ok") entities.push(o.entity);
+      else failedEntities.push(o.failure);
     }
 
     // After the retry queue is drained, fall back to whatever the cursor

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -3388,7 +3388,8 @@ select.form-input { cursor: pointer; }
 }
 .counter-created { color: #1a7f37; }
 .counter-updated { color: #0969da; }
-.counter-deleted { color: #cf222e; }
+.counter-deleted { color: #6e7781; }
+.counter-failed  { color: #cf222e; }
 .sync-progress-status {
   font-size: 12px;
   color: var(--text-secondary);

--- a/packages/ui/src/components/manage/CollectionDetail.tsx
+++ b/packages/ui/src/components/manage/CollectionDetail.tsx
@@ -401,6 +401,11 @@ export default function CollectionDetail({ name, onBack, onEdit, onCollectionsCh
               )}
             </span>
           )}
+          {status?.lastSyncRun?.errorCount != null && status.lastSyncRun.errorCount > 0 && (
+            <span className="sync-error-count">
+              {status.lastSyncRun.errorCount} failed (will retry up to 3 attempts)
+            </span>
+          )}
         </div>
         <div className="collection-card-actions" style={{ marginTop: 8 }}>
           {collection?.crawlerType === "remote" ? (

--- a/packages/ui/src/components/manage/SyncProgress.tsx
+++ b/packages/ui/src/components/manage/SyncProgress.tsx
@@ -22,11 +22,13 @@ interface AggregateView {
   updated: number;
   deleted: number;
   error: string | null;
+  errorCount: number;
+  failureReason: string | null;
 }
 
 function aggregate(jobs: SyncJob[]): AggregateView {
   if (jobs.length === 0) {
-    return { active: false, collectionName: null, status: "idle", created: 0, updated: 0, deleted: 0, error: null };
+    return { active: false, collectionName: null, status: "idle", created: 0, updated: 0, deleted: 0, error: null, errorCount: 0, failureReason: null };
   }
   const active = jobs.filter((j) => j.active);
   const totals = jobs.reduce(
@@ -34,8 +36,9 @@ function aggregate(jobs: SyncJob[]): AggregateView {
       created: acc.created + j.created,
       updated: acc.updated + j.updated,
       deleted: acc.deleted + j.deleted,
+      errorCount: acc.errorCount + (j.errorCount ?? 0),
     }),
-    { created: 0, updated: 0, deleted: 0 },
+    { created: 0, updated: 0, deleted: 0, errorCount: 0 },
   );
   if (active.length > 0) {
     return {
@@ -46,9 +49,12 @@ function aggregate(jobs: SyncJob[]): AggregateView {
       updated: totals.updated,
       deleted: totals.deleted,
       error: null,
+      errorCount: totals.errorCount,
+      failureReason: active.length === 1 ? active[0].failureReason ?? null : null,
     };
   }
   const firstError = jobs.find((j) => j.error)?.error ?? null;
+  const firstFailureReason = jobs.find((j) => j.failureReason)?.failureReason ?? null;
   return {
     active: false,
     collectionName: null,
@@ -57,6 +63,8 @@ function aggregate(jobs: SyncJob[]): AggregateView {
     updated: totals.updated,
     deleted: totals.deleted,
     error: firstError,
+    errorCount: totals.errorCount,
+    failureReason: firstFailureReason,
   };
 }
 
@@ -69,6 +77,8 @@ function singleJobView(job: SyncJob): AggregateView {
     updated: job.updated,
     deleted: job.deleted,
     error: job.error,
+    errorCount: job.errorCount ?? 0,
+    failureReason: job.failureReason ?? null,
   };
 }
 
@@ -129,9 +139,17 @@ export default function SyncProgress({ collectionName, onComplete }: SyncProgres
         <span className="counter counter-created">{view.created} created</span>
         <span className="counter counter-updated">{view.updated} updated</span>
         <span className="counter counter-deleted">{view.deleted} deleted</span>
+        {view.errorCount > 0 && (
+          <span className="counter counter-failed">{view.errorCount} failed</span>
+        )}
       </div>
       {view.status && view.status !== "idle" && (
         <div className="sync-progress-status">{view.status}</div>
+      )}
+      {view.failureReason === "rate_limit" && (
+        <div className="form-warning">
+          Sync paused by upstream rate limit. Click Sync again to resume from where it stopped.
+        </div>
       )}
       {view.error && (
         <div className="form-error">{view.error}</div>

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -91,6 +91,8 @@ export interface SyncRun {
   errors: unknown;
   startedAt: string;
   completedAt: string | null;
+  errorCount?: number;
+  failureReason?: string | null;
 }
 
 export interface SyncProgress {
@@ -101,6 +103,8 @@ export interface SyncProgress {
   updated: number;
   deleted: number;
   error: string | null;
+  errorCount?: number;
+  failureReason?: string | null;
 }
 
 export interface SyncJob {
@@ -114,6 +118,8 @@ export interface SyncJob {
   startedAt: number;
   completedAt: number | null;
   full: boolean;
+  errorCount?: number;
+  failureReason?: string | null;
 }
 
 export interface ExportRequest {


### PR DESCRIPTION
## Summary
- New \`sync_errors\` journal table: per-entity fetch failures are recorded and skipped, not aborting the run; retried (up to 3 attempts) on the next sync.
- Cursor persisted after every batch — interrupted full syncs resume from the last batch instead of restarting.
- MantisHub initial sync uses a \`snapshotCeiling\` pinned at run start (\`filter_updated_before\`) so DESC pagination stays stable across resumes; list endpoint uses \`select=id,updated_at\`; \`PAGE_SIZE=25\` everywhere; per-issue detail fetches run 5-way concurrent.
- MantisHub users phase aborts after 10 fetch failures and emits shell entities for the remaining users from data already collected during the issues phase. User failures are never journaled.
- \`startSyncJob\` was double-calling \`ensureSyncJob\` and silently exiting because the guard saw the synchronously-seeded entry as already active — fixed by claiming the seeded entry by status.
- UI: error counter shown in progress card; \`counter-deleted\` is grey, new \`counter-failed\` is red. Status messages drop the collection-name and inline counter redundancy.

## Test plan
- [ ] \`bun run ci\` passes locally (markdown lint, typecheck, all test suites, UI build, worker build)
- [ ] Full sync of a large MantisHub project completes; cursor advances per batch and resume works after a kill
- [ ] Inject a 5xx for a single issue and confirm it lands in \`sync_errors\` (visible as "N failed" in the UI) without aborting
- [ ] Re-run sync and confirm the journaled entry retries; after 3 failed attempts, retries stop
- [ ] Users-phase abort triggers when most user fetches return 403; shell entities are emitted for the rest
- [ ] Click "Sync" — UI no longer hangs on "starting"; status moves through "syncing" → progress messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)