### PR TITLE
fix: render MantisHub page content as markdown in HTML mode

### DIFF
--- a/packages/crawlers/src/mantishub/__tests__/theme.test.ts
+++ b/packages/crawlers/src/mantishub/__tests__/theme.test.ts
@@ -112,6 +112,46 @@ describe("MantisHubTheme HTML issue-ref linkification", () => {
   });
 });
 
+describe("MantisHubTheme HTML page rendering", () => {
+  function makePageContext(content: string): ThemeRenderContext {
+    return {
+      entity: {
+        externalId: "page:1:getting-started",
+        entityType: "page",
+        title: "Getting Started",
+        data: {
+          id: 99,
+          name: "getting-started",
+          title: "Getting Started",
+          project: { id: 1, name: "TestProject" },
+          content,
+          files: [],
+        },
+      },
+      collectionName: "test",
+      crawlerType: "mantishub",
+      lookupEntityPath: lookup,
+    };
+  }
+
+  it("renders page content as markdown (headings)", () => {
+    const html = theme.renderHtml!(makePageContext("## Section\n\nParagraph text."));
+    expect(html).toContain("<h2");
+    expect(html).toContain("Section");
+  });
+
+  it("renders page content as markdown (bold)", () => {
+    const html = theme.renderHtml!(makePageContext("This is **important**."));
+    expect(html).toContain("<strong>important</strong>");
+  });
+
+  it("linkifies #N issue references in page content", () => {
+    const html = theme.renderHtml!(makePageContext("See #100 for details."));
+    expect(html).toContain('class="mt-issue-ref"');
+    expect(html).toContain("#wikilink/issues%2F00100-linked-issue");
+  });
+});
+
 describe("MantisHubTheme getFilePath", () => {
   it("places issues under <project-slug>/issues/", () => {
     const ctx = makeIssueContext();

--- a/packages/crawlers/src/mantishub/theme.ts
+++ b/packages/crawlers/src/mantishub/theme.ts
@@ -1016,7 +1016,7 @@ export class MantisHubTheme implements Theme {
     if (content) {
       parts.push(`<div class="mt-section">`);
       parts.push(`<div class="mt-section-body">`);
-      parts.push(`<div class="mt-description">${textToHtml(content, lookup, projectId)}</div>`);
+      parts.push(`<div class="mt-description">${markdownToHtml(content, lookup, projectId)}</div>`);
       parts.push(`</div>`);
       parts.push(`</div>`);
     }


### PR DESCRIPTION
## Summary

- MantisHub wiki pages store content as raw markdown, but `renderPageHtml` was calling `textToHtml` which only escapes/linkifies — it does not parse markdown syntax
- Switch to `markdownToHtml` so headings, bold, lists, code blocks, etc. are properly rendered
- Add 3 tests covering markdown rendering (headings, bold, issue-ref linkification) for page HTML output

Closes #101

## Test plan

- [x] `bun test packages/crawlers/src/mantishub/__tests__/theme.test.ts` — all 19 tests pass
- [x] New tests: page content with `## heading` renders `<h2>`, `**bold**` renders `<strong>`, `#100` linkifies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)