### PR TITLE
perf: batch collection status into list endpoint + cache disk size

### DIFF
--- a/packages/cli/src/commands/management-api.ts
+++ b/packages/cli/src/commands/management-api.ts
@@ -3,9 +3,10 @@
  * These routes handle collection CRUD, sync triggering, publish orchestration,
  * export, and configuration — all gated behind mode === "desktop".
  */
-import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, readdirSync, rmSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import yaml from "js-yaml";
+import { sql } from "drizzle-orm";
 import {
   getFrozenInkHome,
   getCollectionDb,
@@ -29,6 +30,8 @@ import {
   getNamedCredentials,
   getCollectionSyncState,
   updateCollectionSyncState,
+  getOrComputeDiskSize,
+  refreshDiskSizeCache,
 } from "@frozenink/core";
 import {
   createDefaultRegistry,
@@ -198,28 +201,52 @@ export function setPublishCollectionsOverride(fn: PublishCollectionsFn | null): 
 
 // --- Helpers ---
 
-/** Recursively sum file sizes in a directory. */
-function getDirectorySize(dirPath: string): number {
-  if (!existsSync(dirPath)) return 0;
-  let total = 0;
-  try {
-    for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
-      const fullPath = join(dirPath, entry.name);
-      if (entry.isDirectory()) {
-        total += getDirectorySize(fullPath);
-      } else {
-        try { total += statSync(fullPath).size; } catch {}
-      }
-    }
-  } catch {}
-  return total;
-}
-
-/** Get disk size in bytes for a collection (db + content). */
-function getCollectionDiskSize(name: string): number {
-  const home = getFrozenInkHome();
-  const colDir = join(home, "collections", name);
-  return getDirectorySize(colDir);
+/**
+ * Compute the per-collection status fields (entityCount, diskSizeBytes,
+ * lastSyncRun) shared between the list and detail endpoints.
+ */
+export function collectionStatus(name: string): {
+  entityCount: number;
+  diskSizeBytes: number;
+  lastSyncRun: {
+    status: string | undefined;
+    startedAt: string;
+    entitiesCreated: number;
+    entitiesUpdated: number;
+    entitiesDeleted: number;
+    errors: unknown;
+    errorCount: number;
+    failureReason: string | null;
+  } | null;
+} {
+  const dbPath = getCollectionDbPath(name);
+  let entityCount = 0;
+  if (existsSync(dbPath)) {
+    const colDb = getCollectionDb(dbPath);
+    const [{ c }] = colDb
+      .select({ c: sql<number>`count(*)` })
+      .from(entities)
+      .all();
+    entityCount = Number(c) || 0;
+  }
+  const diskSizeBytes = getOrComputeDiskSize(name);
+  const sync = getCollectionSyncState(dbPath);
+  return {
+    entityCount,
+    diskSizeBytes,
+    lastSyncRun: sync.lastAt
+      ? {
+          status: sync.lastStatus,
+          startedAt: sync.lastAt,
+          entitiesCreated: sync.lastCreated ?? 0,
+          entitiesUpdated: sync.lastUpdated ?? 0,
+          entitiesDeleted: sync.lastDeleted ?? 0,
+          errors: sync.lastErrors ?? null,
+          errorCount: sync.errorCount ?? 0,
+          failureReason: sync.failureReason ?? null,
+        }
+      : null,
+  };
 }
 
 // --- Mode detection ---
@@ -365,6 +392,7 @@ export function handleManagementRequest(req: Request): Response | null {
         const home = getFrozenInkHome();
         const themeEngine = createGenerateThemeEngine();
         await prepareCollection(updatedCol, home, themeEngine, (msg) => console.log(`[prepare:${name}]`, msg));
+        refreshDiskSizeCache(name).catch(() => {});
       }
       return jsonResponse({ ok: true });
     });
@@ -397,6 +425,7 @@ export function handleManagementRequest(req: Request): Response | null {
       const home = getFrozenInkHome();
       const themeEngine = createGenerateThemeEngine();
       await prepareCollection(col, home, themeEngine, (msg) => console.log(`[prepare:${name}]`, msg));
+      refreshDiskSizeCache(name).catch(() => {});
       return jsonResponse({ ok: true });
     });
   }
@@ -422,30 +451,7 @@ export function handleManagementRequest(req: Request): Response | null {
     const name = decodeURIComponent(statusMatch[1]);
     const col = getCollection(name);
     if (!col) return errorResponse("Collection not found", 404);
-
-    const dbPath = getCollectionDbPath(name);
-    let entityCount = 0;
-    if (existsSync(dbPath)) {
-      const colDb = getCollectionDb(dbPath);
-      entityCount = colDb.select().from(entities).all().length;
-    }
-
-    const diskSizeBytes = getCollectionDiskSize(name);
-    const sync = getCollectionSyncState(dbPath);
-    return jsonResponse({
-      entityCount,
-      diskSizeBytes,
-      lastSyncRun: sync.lastAt ? {
-        status: sync.lastStatus,
-        startedAt: sync.lastAt,
-        entitiesCreated: sync.lastCreated ?? 0,
-        entitiesUpdated: sync.lastUpdated ?? 0,
-        entitiesDeleted: sync.lastDeleted ?? 0,
-        errors: sync.lastErrors ?? null,
-        errorCount: sync.errorCount ?? 0,
-        failureReason: sync.failureReason ?? null,
-      } : null,
-    });
+    return jsonResponse(collectionStatus(name));
   }
 
   // --- Sync ---
@@ -955,6 +961,10 @@ async function startSyncJob(name: string, full: boolean): Promise<void> {
   } finally {
     job.active = false;
     job.completedAt = Date.now();
+    // Disk size will have changed (created/deleted entities, db growth) — refresh
+    // the YAML cache so the next list/status read gets a fresh value without
+    // walking the directory tree on the request thread.
+    refreshDiskSizeCache(name).catch(() => {});
   }
 }
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -31,7 +31,7 @@ import {
 } from "@frozenink/crawlers";
 import { startStdioServer } from "@frozenink/mcp";
 import { eq, desc, inArray, and } from "drizzle-orm";
-import { handleManagementRequest, setAppMode } from "./management-api";
+import { handleManagementRequest, setAppMode, collectionStatus } from "./management-api";
 import { prepareCollections } from "./prepare";
 
 const __moduleDir = getModuleDir(import.meta.url);
@@ -408,15 +408,21 @@ export function createApiServer(
         const rows = collectionFilter
           ? (() => { const col = getCollection(collectionFilter); return col ? [col] : []; })()
           : listCollections();
-        const result = rows.map((r) => ({
-          name: r.name,
-          title: r.title ?? r.name,
-          description: r.description,
-          crawlerType: r.crawler,
-          enabled: r.enabled,
-          syncInterval: r.syncInterval,
-          publish: r.publish,
-        }));
+        const result = rows.map((r) => {
+          const status = collectionStatus(r.name);
+          return {
+            name: r.name,
+            title: r.title ?? r.name,
+            description: r.description,
+            crawlerType: r.crawler,
+            enabled: r.enabled,
+            syncInterval: r.syncInterval,
+            publish: r.publish,
+            entityCount: status.entityCount,
+            diskSizeBytes: status.diskSizeBytes,
+            lastSyncRun: status.lastSyncRun,
+          };
+        });
         return jsonResponse(result);
       }
 

--- a/packages/core/src/config/context.ts
+++ b/packages/core/src/config/context.ts
@@ -41,6 +41,8 @@ const collectionEntrySchema = z.object({
   hide: z.array(z.string()).optional(),
   publish: publishStateSchema.optional(),
   lastPublishedAt: z.string().optional(),
+  /** Cached on-disk size of the collection directory, in kilobytes. Refreshed after content mutations. */
+  size: z.number().optional(),
 });
 
 const legacyDeploymentEntrySchema = z.object({

--- a/packages/core/src/config/disk-cache.ts
+++ b/packages/core/src/config/disk-cache.ts
@@ -1,0 +1,79 @@
+import { existsSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+import { getFrozenInkHome } from "./loader";
+import { getCollection, updateCollection } from "./context";
+
+function getDirectorySizeBytes(dirPath: string): number {
+  if (!existsSync(dirPath)) return 0;
+  let total = 0;
+  try {
+    for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+      const full = join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        total += getDirectorySizeBytes(full);
+      } else {
+        try { total += statSync(full).size; } catch {}
+      }
+    }
+  } catch {}
+  return total;
+}
+
+function collectionDir(name: string): string {
+  return join(getFrozenInkHome(), "collections", name);
+}
+
+function bytesToKb(bytes: number): number {
+  return Math.round(bytes / 1024);
+}
+
+/** Read the cached disk size (KB) from the collection's YAML; null if not cached. */
+export function readCachedDiskSizeKb(name: string): number | null {
+  const col = getCollection(name);
+  if (!col) return null;
+  return typeof col.size === "number" ? col.size : null;
+}
+
+/**
+ * Persist the cached size (KB) to the collection YAML. updateCollection does
+ * read-modify-write so we don't stomp concurrent edits to other fields.
+ */
+function writeCachedDiskSizeKb(name: string, sizeKb: number): void {
+  try {
+    updateCollection(name, { size: sizeKb });
+  } catch {
+    // Cache write is best-effort.
+  }
+}
+
+const refreshLocks = new Map<string, Promise<number>>();
+
+/**
+ * Recompute the directory size and persist it (in KB) to the YAML cache.
+ * Returns size in bytes. Serialized per-collection via an in-process mutex
+ * so concurrent refreshes don't race.
+ */
+export function refreshDiskSizeCache(name: string): Promise<number> {
+  const inflight = refreshLocks.get(name);
+  if (inflight) return inflight;
+  const promise = (async () => {
+    const bytes = getDirectorySizeBytes(collectionDir(name));
+    writeCachedDiskSizeKb(name, bytesToKb(bytes));
+    return bytes;
+  })();
+  refreshLocks.set(name, promise);
+  promise.finally(() => refreshLocks.delete(name)).catch(() => {});
+  return promise;
+}
+
+/**
+ * Return the cached size (in bytes) if present; otherwise compute it now,
+ * persist it as KB, and return bytes. Cold-path compute is paid once.
+ */
+export function getOrComputeDiskSize(name: string): number {
+  const cachedKb = readCachedDiskSizeKb(name);
+  if (cachedKb != null) return cachedKb * 1024;
+  const bytes = getDirectorySizeBytes(collectionDir(name));
+  writeCachedDiskSizeKb(name, bytesToKb(bytes));
+  return bytes;
+}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -33,3 +33,8 @@ export {
   type FrozenInkYaml,
   type SiteEntry,
 } from "./context";
+export {
+  readCachedDiskSizeKb,
+  refreshDiskSizeCache,
+  getOrComputeDiskSize,
+} from "./disk-cache";

--- a/packages/ui/src/components/manage/CollectionList.tsx
+++ b/packages/ui/src/components/manage/CollectionList.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import SyncProgress from "./SyncProgress";
-import { formatTimestamp, type Collection, type CollectionStatus } from "../../types";
+import { formatTimestamp, type Collection } from "../../types";
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -79,28 +79,13 @@ interface CollectionListProps {
 
 export default function CollectionList({ onSelect, onAdd, onSyncComplete, onCollectionsChanged }: CollectionListProps) {
   const [collections, setCollections] = useState<Collection[]>([]);
-  const [statuses, setStatuses] = useState<Record<string, CollectionStatus>>({});
   const [syncing, setSyncing] = useState(false);
 
   const load = () => {
     fetch("/api/collections")
       .then((r) => r.json())
-      .then((data: Collection[]) => {
-        setCollections(data);
-        for (const col of data) {
-          loadStatus(col.name);
-        }
-      })
+      .then((data: Collection[]) => setCollections(data))
       .catch(console.error);
-  };
-
-  const loadStatus = (name: string) => {
-    fetch(`/api/collections/${encodeURIComponent(name)}/status`)
-      .then((r) => r.json())
-      .then((status: CollectionStatus) => {
-        setStatuses((prev) => ({ ...prev, [name]: status }));
-      })
-      .catch(() => {});
   };
 
   useEffect(load, []);
@@ -116,9 +101,7 @@ export default function CollectionList({ onSelect, onAdd, onSyncComplete, onColl
 
   const handleSyncComplete = () => {
     setSyncing(false);
-    for (const col of collections) {
-      loadStatus(col.name);
-    }
+    load();
     onSyncComplete?.();
     onCollectionsChanged?.();
   };
@@ -146,7 +129,6 @@ export default function CollectionList({ onSelect, onAdd, onSyncComplete, onColl
         const disabled = collections.filter((c) => !c.enabled).sort(byName);
 
         const renderCard = (col: Collection) => {
-          const status = statuses[col.name];
           const showCollectionName = !!col.title && col.title !== col.name;
           return (
             <div
@@ -172,16 +154,16 @@ export default function CollectionList({ onSelect, onAdd, onSyncComplete, onColl
                 <p className="collection-card-desc">{col.description}</p>
               )}
               <div className="collection-card-stats">
-                <span>{status?.entityCount != null ? formatCount(status.entityCount) : "—"} entities</span>
-                {status?.diskSizeBytes != null && status.diskSizeBytes > 0 && (
-                  <span>{formatSize(status.diskSizeBytes)}</span>
+                <span>{col.entityCount != null ? formatCount(col.entityCount) : "—"} entities</span>
+                {col.diskSizeBytes != null && col.diskSizeBytes > 0 && (
+                  <span>{formatSize(col.diskSizeBytes)}</span>
                 )}
-                {status?.lastSyncRun && (
+                {col.lastSyncRun && (
                   <span>
-                    Last sync: {formatTimestamp(status.lastSyncRun.startedAt)}
+                    Last sync: {formatTimestamp(col.lastSyncRun.startedAt)}
                     {" "}
-                    <span className={`sync-type-badge sync-type-${status.lastSyncRun.syncType || "incremental"}`}>
-                      {status.lastSyncRun.syncType === "full" ? "full" : "incr"}
+                    <span className={`sync-type-badge sync-type-${col.lastSyncRun.syncType || "incremental"}`}>
+                      {col.lastSyncRun.syncType === "full" ? "full" : "incr"}
                     </span>
                   </span>
                 )}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -42,6 +42,11 @@ export interface Collection {
   createdAt: string;
   updatedAt: string;
   publish?: PublishState;
+  /** Inlined status fields — populated by GET /api/collections so the
+   * Manage Collections grid renders all cards in one round-trip. */
+  entityCount?: number;
+  diskSizeBytes?: number;
+  lastSyncRun?: SyncRun | null;
 }
 
 export interface TreeNode {


### PR DESCRIPTION
## Summary

- Inline `entityCount` / `diskSizeBytes` / `lastSyncRun` into `GET /api/collections` so the Manage Collections grid renders all cards in a single round-trip.
- Replace the row-materializing `.all().length` scan with a `count(*)` query.
- Cache the directory size as `size:` (KB) in each collection's YAML; refreshed after sync / prepare / PATCH; lazy compute on cold start (write via `updateCollection` so concurrent edits aren't stomped).
- Drop the per-card status fetch loop in `CollectionList.tsx` and read stats directly off the list payload.

Fixes #127

## Test plan

- [x] `bun run ci` (markdown lint, typecheck, all test suites, UI build, worker build)
- [ ] Open Manage Collections in the live preview: single `GET /api/collections` request, no per-card fan-out, no `—` flicker
- [ ] Trigger a sync and confirm the cached `size:` in the collection YAML is refreshed after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)