### PR TITLE
chore: add /shipit slash command

### DIFF
--- a/.claude/commands/shipit.md
+++ b/.claude/commands/shipit.md
@@ -1,0 +1,7 @@
+1. Run local CI tests to make sure everything is in good shape.
+2. Create github issues for new feature or major fixes on this PR. If they don't exist already.
+3. Apply appropriate commits and reference the corresponding github issues.
+4. Push branch and create a PR.
+5. Wait for PR CI tests to pass and fix any issues that may arise.
+6. Merge PR using the rebase strategy.
+7. Make sure the fixed issues get closed successfully.

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -13,5 +13,5 @@
     "MD060": false
   },
   "globs": ["**/*.md"],
-  "ignores": ["node_modules", "**/node_modules", ".context", "**/.context"]
+  "ignores": ["node_modules", "**/node_modules", ".context", "**/.context", ".claude", "**/.claude"]
 }


### PR DESCRIPTION
## Summary
- Add `.claude/commands/shipit.md` with the project's ship-it workflow as a reusable `/shipit` slash command.
- Exclude `.claude/` from markdownlint since command files are prompt content, not docs.

## Test plan
- [x] `bun run ci` passes locally